### PR TITLE
configure: add an option to build with tcmalloc library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -305,6 +305,19 @@ else
         BUILD_TSAN=no
 fi
 
+# Initialize CFLAGS before usage
+BUILD_TCMALLOC=no
+AC_ARG_ENABLE([tcmalloc],
+              AC_HELP_STRING([--enable-tcmalloc],
+                             [Enable linking with tcmalloc library.]))
+if test "x$enable_tcmalloc" = "xyes"; then
+    BUILD_TCMALLOC=yes
+    GF_CFLAGS="${GF_CFLAGS} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free"
+    AC_CHECK_LIB([tcmalloc], [malloc], [],
+                 [AC_MSG_ERROR([when --enable-tcmalloc is used, tcmalloc library needs to be present])])
+    GF_LDFLAGS="-ltcmalloc ${GF_LDFLAGS}"
+fi
+
 
 dnl When possible, prefer libtirpc over glibc rpc.
 dnl
@@ -1584,6 +1597,7 @@ echo "IPV6 default         : $with_ipv6_default"
 echo "Use TIRPC            : $with_libtirpc"
 echo "With Python          : ${PYTHON_VERSION}"
 echo "Cloudsync            : $BUILD_CLOUDSYNC"
+echo "Link with TCMALLOC   : $BUILD_TCMALLOC"
 echo
 
 if test "x$BUILD_ASAN" = "xyes"; then


### PR DESCRIPTION
With this patch, one can now use '--enable-tcmalloc' while running
configure, and they can see that their glusterfs is linked with
libtcmalloc.

[atumball@local build]$ ldd /usr/local/sbin/glusterfs | grep tcmalloc
	libtcmalloc.so.4 => /lib64/libtcmalloc.so.4 (0x00007feec0b87000)

Once we establish a standard performance number with and without this option,
we will see how to make it default.

Updates: #237
Change-Id: I3377f57bfe4e17f101a212e1914a6d3c1687d528
Signed-off-by: Amar Tumballi <amarts@redhat.com>
