### PR TITLE
errorcode: more information as part of return code

### DIFF
--- a/api/examples/glfsxmp.c
+++ b/api/examples/glfsxmp.c
@@ -48,40 +48,40 @@ test_xattr(glfs_t *fs)
 
     ret = glfs_getxattr(fs, filename, "user.testkey", buf, 512);
     fprintf(stderr, "getxattr(%s): %d (%s)\n", filename, ret, strerror(errno));
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return -1;
 
     ret = glfs_listxattr(fs, filename, buf, 512);
     fprintf(stderr, "listxattr(%s): %d (%s)\n", filename, ret, strerror(errno));
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return -1;
 
     ret = glfs_symlink(fs, "filename", linkfile);
     fprintf(stderr, "symlink(%s %s): %s\n", filename, linkfile,
             strerror(errno));
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return -1;
 
     ret = glfs_readlink(fs, linkfile, buf, 512);
     fprintf(stderr, "readlink(%s) : %d (%s)\n", filename, ret, strerror(errno));
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return -1;
 
     ret = glfs_lsetxattr(fs, filename, "user.testkey3", "testval", 8, 0);
     fprintf(stderr, "lsetxattr(%s) : %d (%s)\n", linkfile, ret,
             strerror(errno));
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return -1;
 
     ret = glfs_llistxattr(fs, linkfile, buf, 512);
     fprintf(stderr, "llistxattr(%s): %d (%s)\n", filename, ret,
             strerror(errno));
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return -1;
 
     ret = glfs_lgetxattr(fs, filename, "user.testkey3", buf, 512);
     fprintf(stderr, "lgetxattr(%s): %d (%s)\n", linkfile, ret, strerror(errno));
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return -1;
 
     for (ptr = buf; ptr < buf + ret; ptr++) {
@@ -105,7 +105,7 @@ test_xattr(glfs_t *fs)
     ret = glfs_flistxattr(fd, buf, 512);
     fprintf(stderr, "flistxattr(%s): %d (%s)\n", filename, ret,
             strerror(errno));
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return -1;
 
     for (ptr = buf; ptr < buf + ret; ptr++) {
@@ -963,7 +963,7 @@ void
 assimilatetime(struct timespec *ts, struct timespec ts_st,
                struct timespec ts_ed)
 {
-    if ((ts_ed.tv_nsec - ts_st.tv_nsec) < 0) {
+    if (IS_ERROR((ts_ed.tv_nsec - ts_st.tv_nsec))) {
         ts->tv_sec += ts_ed.tv_sec - ts_st.tv_sec - 1;
         ts->tv_nsec += 1000000000 + ts_ed.tv_nsec - ts_st.tv_nsec;
     } else {
@@ -1396,7 +1396,7 @@ test_handleops(int argc, char *argv[])
     peek_stat(&sb);
 
     ret = glfs_h_extract_handle(leaf, leaf_handle, GFAPI_HANDLE_LENGTH);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         fprintf(stderr,
                 "glfs_h_extract_handle: error extracting handle of %s: %s\n",
                 full_leaf_name, strerror(errno));
@@ -1634,19 +1634,19 @@ test_write_apis(glfs_t *fs)
         fprintf(stderr, "open(%s): (%p) %s\n", filename, fd, strerror(errno));
 
     ret = glfs_writev(fd, &iov, 1, flags);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         fprintf(stderr, "writev(%s): %d (%s)\n", filename, ret,
                 strerror(errno));
     }
 
     ret = glfs_pwrite(fd, buf, 10, 4, flags, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         fprintf(stderr, "pwrite(%s): %d (%s)\n", filename, ret,
                 strerror(errno));
     }
 
     ret = glfs_pwritev(fd, &iov, 1, 4, flags);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         fprintf(stderr, "pwritev(%s): %d (%s)\n", filename, ret,
                 strerror(errno));
     }

--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -811,11 +811,11 @@ retry:
 
     ESTALE_RETRY(ret, errno, reval, &loc, retry);
 
-    if (ret == -1 && errno != ENOENT)
+    if (IS_ERROR(ret) && (errno != ENOENT))
         /* Any other type of error is fatal */
         goto out;
 
-    if (ret == -1 && errno == ENOENT && !loc.parent)
+    if (IS_ERROR(ret) && (errno == ENOENT) && !loc.parent)
         /* The parent directory or an ancestor even
            higher does not exist
         */
@@ -841,7 +841,7 @@ retry:
         }
     }
 
-    if (ret == -1 && errno == ENOENT) {
+    if (IS_ERROR(ret) && (errno == ENOENT)) {
         loc.inode = inode_new(loc.parent->table);
         if (!loc.inode) {
             ret = -1;
@@ -943,7 +943,7 @@ glfs_seek(struct glfs_fd *glfd, off_t offset, int whence)
     ret = syncop_seek(subvol, fd, offset, what, NULL, &off);
     DECODE_SYNCOP_ERR(ret);
 
-    if (ret != -1)
+    if (ret >= 0)
         glfd->offset = off;
 
 done:
@@ -1003,7 +1003,7 @@ pub_glfs_lseek(struct glfs_fd *glfd, off_t offset, int whence)
 
     __GLFS_EXIT_FS;
 
-    if (ret != -1)
+    if (ret >= 0)
         off = glfd->offset;
 
     return off;
@@ -2714,17 +2714,17 @@ retry:
         goto out;
     }
 
-    if (ret == -1 && errno != ENOENT)
+    if (IS_ERROR(ret) && errno != ENOENT)
         /* Any other type of error is fatal */
         goto out;
 
-    if (ret == -1 && errno == ENOENT && !loc.parent)
+    if (IS_ERROR(ret) && errno == ENOENT && !loc.parent)
         /* The parent directory or an ancestor even
            higher does not exist
         */
         goto out;
 
-    /* ret == -1 && errno == ENOENT */
+    /* ret < 0 && errno == ENOENT */
     loc.inode = inode_new(loc.parent->table);
     if (!loc.inode) {
         ret = -1;
@@ -2863,17 +2863,17 @@ retry:
         goto out;
     }
 
-    if (ret == -1 && errno != ENOENT)
+    if (IS_ERROR(ret) && errno != ENOENT)
         /* Any other type of error is fatal */
         goto out;
 
-    if (ret == -1 && errno == ENOENT && !loc.parent)
+    if (IS_ERROR(ret) && errno == ENOENT && !loc.parent)
         /* The parent directory or an ancestor even
            higher does not exist
         */
         goto out;
 
-    /* ret == -1 && errno == ENOENT */
+    /* ret < 0 && errno == ENOENT */
     loc.inode = inode_new(loc.parent->table);
     if (!loc.inode) {
         ret = -1;
@@ -2954,17 +2954,17 @@ retry:
         goto out;
     }
 
-    if (ret == -1 && errno != ENOENT)
+    if (IS_ERROR(ret) && errno != ENOENT)
         /* Any other type of error is fatal */
         goto out;
 
-    if (ret == -1 && errno == ENOENT && !loc.parent)
+    if (IS_ERROR(ret) && errno == ENOENT && !loc.parent)
         /* The parent directory or an ancestor even
            higher does not exist
         */
         goto out;
 
-    /* ret == -1 && errno == ENOENT */
+    /* ret < 0 && errno == ENOENT */
     loc.inode = inode_new(loc.parent->table);
     if (!loc.inode) {
         ret = -1;
@@ -3168,7 +3168,7 @@ retrynew:
     ret = syncop_rename(subvol, &oldloc, &newloc, NULL, NULL);
     DECODE_SYNCOP_ERR(ret);
 
-    if (ret == -1 && errno == ESTALE) {
+    if (IS_ERROR(ret) && errno == ESTALE) {
         if (reval < DEFAULT_REVAL_COUNT) {
             reval++;
             loc_wipe(&oldloc);
@@ -3262,7 +3262,7 @@ retrynew:
     ret = syncop_link(subvol, &oldloc, &newloc, &newiatt, NULL, NULL);
     DECODE_SYNCOP_ERR(ret);
 
-    if (ret == -1 && errno == ESTALE) {
+    if (IS_ERROR(ret) && errno == ESTALE) {
         loc_wipe(&oldloc);
         loc_wipe(&newloc);
         if (reval--)
@@ -3761,7 +3761,7 @@ glfd_entry_next(struct glfs_fd *glfd, int plus)
 
     if (!glfd->offset || !glfd->next) {
         ret = glfd_entry_refresh(glfd, plus);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             return NULL;
     }
 
@@ -5169,7 +5169,7 @@ retry:
 out:
     loc_wipe(&loc);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         if (warn_deprecated && allocpath)
             free(allocpath);
         else if (allocpath)
@@ -5243,7 +5243,7 @@ out:
     __GLFS_EXIT_FS;
 
 invalid_fs:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return NULL;
 
     return buf;
@@ -6322,7 +6322,7 @@ pub_glfs_xreaddirplus_r(struct glfs_fd *glfd, uint32_t flags,
 out:
     GF_REF_PUT(glfd);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(THIS->name, GF_LOG_WARNING, errno, API_MSG_XREADDIRP_R_FAILED,
                 "reason=%s", strerror(errno), NULL);
 

--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -943,7 +943,7 @@ glfs_seek(struct glfs_fd *glfd, off_t offset, int whence)
     ret = syncop_seek(subvol, fd, offset, what, NULL, &off);
     DECODE_SYNCOP_ERR(ret);
 
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         glfd->offset = off;
 
 done:
@@ -1003,7 +1003,7 @@ pub_glfs_lseek(struct glfs_fd *glfd, off_t offset, int whence)
 
     __GLFS_EXIT_FS;
 
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         off = glfd->offset;
 
     return off;
@@ -1059,7 +1059,7 @@ glfs_preadv_common(struct glfs_fd *glfd, const struct iovec *iovec, int iovcnt,
                        fop_attr, NULL);
     DECODE_SYNCOP_ERR(ret);
 
-    if (ret >= 0 && poststat)
+    if (IS_SUCCESS(ret) && poststat)
         glfs_iatt_to_statx(glfd->fs, &iatt, poststat);
 
     if (ret <= 0)
@@ -1552,7 +1552,7 @@ glfs_pwritev_common(struct glfs_fd *glfd, const struct iovec *iovec, int iovcnt,
                         &postiatt, fop_attr, NULL);
     DECODE_SYNCOP_ERR(ret);
 
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         if (prestat)
             glfs_iatt_to_statx(glfd->fs, &preiatt, prestat);
         if (poststat)
@@ -1673,7 +1673,7 @@ pub_glfs_copy_file_range(struct glfs_fd *glfd_in, off64_t *off_in,
                                  NULL);
     DECODE_SYNCOP_ERR(ret);
 
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         pos_in += ret;
         pos_out += ret;
 
@@ -2105,7 +2105,7 @@ glfs_fsync_common(struct glfs_fd *glfd, struct glfs_stat *prestat,
     ret = syncop_fsync(subvol, fd, 0, &preiatt, &postiatt, fop_attr, NULL);
     DECODE_SYNCOP_ERR(ret);
 
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         if (prestat)
             glfs_iatt_to_statx(glfd->fs, &preiatt, prestat);
         if (poststat)
@@ -2302,7 +2302,7 @@ glfs_fdatasync_common(struct glfs_fd *glfd, struct glfs_stat *prestat,
     ret = syncop_fsync(subvol, fd, 1, &preiatt, &postiatt, fop_attr, NULL);
     DECODE_SYNCOP_ERR(ret);
 
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         if (prestat)
             glfs_iatt_to_statx(glfd->fs, &preiatt, prestat);
         if (poststat)
@@ -2420,7 +2420,7 @@ glfs_ftruncate_common(struct glfs_fd *glfd, off_t offset,
                            NULL);
     DECODE_SYNCOP_ERR(ret);
 
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         if (prestat)
             glfs_iatt_to_statx(glfd->fs, &preiatt, prestat);
         if (poststat)
@@ -3707,7 +3707,7 @@ glfd_entry_refresh(struct glfs_fd *glfd, int plus)
         ret = syncop_readdir(subvol, fd, 131072, glfd->offset, &entries, NULL,
                              NULL);
     DECODE_SYNCOP_ERR(ret);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         if (plus) {
             list_for_each_entry(entry, &entries.list, list)
             {

--- a/api/src/glfs-internal.h
+++ b/api/src/glfs-internal.h
@@ -109,7 +109,7 @@
 
 #define ESTALE_RETRY(ret, errno, reval, loc, label)                            \
     do {                                                                       \
-        if (ret == -1 && errno == ESTALE) {                                    \
+        if (IS_ERROR(ret) && errno == ESTALE) {                                \
             if (reval < DEFAULT_REVAL_COUNT) {                                 \
                 reval++;                                                       \
                 loc_wipe(loc);                                                 \

--- a/api/src/glfs-mgmt.c
+++ b/api/src/glfs-mgmt.c
@@ -139,7 +139,7 @@ mgmt_cbk_statedump(struct rpc_clnt *rpc, void *mydata, void *data)
     }
 
     ret = xdr_to_generic(*iov, &target_pid, (xdrproc_t)xdr_gf_statedump);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg("glfs", GF_LOG_ERROR, EINVAL, API_MSG_DECODE_XDR_FAILED, NULL);
         goto out;
     }
@@ -150,7 +150,7 @@ mgmt_cbk_statedump(struct rpc_clnt *rpc, void *mydata, void *data)
         gf_msg_debug("glfs", 0, "Taking statedump for pid: %d", target_pid.pid);
 
         ret = glfs_sysrq(fs, GLFS_SYSRQ_STATEDUMP);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_smsg("glfs", GF_LOG_INFO, 0, API_MSG_STATEDUMP_FAILED, NULL);
         }
     }
@@ -223,7 +223,7 @@ mgmt_submit_request(void *req, call_frame_t *frame, glusterfs_ctx_t *ctx,
 
         /* Create the xdr payload */
         ret = xdr_serialize_generic(iov, req, xdrproc);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_smsg(THIS->name, GF_LOG_WARNING, 0, API_MSG_XDR_PAYLOAD_FAILED,
                     NULL);
             goto out;
@@ -277,7 +277,7 @@ mgmt_get_volinfo_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     fs = ((xlator_t *)ctx->master)->private;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_smsg(frame->this->name, GF_LOG_ERROR, EINVAL,
                 API_MSG_CALL_NOT_SUCCESSFUL, NULL);
         errno = EINVAL;
@@ -287,7 +287,7 @@ mgmt_get_volinfo_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_get_volume_info_rsp);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(frame->this->name, GF_LOG_ERROR, 0,
                 API_MSG_XDR_RESPONSE_DECODE_FAILED, NULL);
         goto out;
@@ -298,7 +298,7 @@ mgmt_get_volinfo_cbk(struct rpc_req *req, struct iovec *iov, int count,
                  "RPC: %d",
                  rsp.op_ret);
 
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         errno = rsp.op_errno;
         ret = -1;
         goto out;
@@ -569,21 +569,21 @@ glfs_mgmt_getspec_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     fs = ((xlator_t *)ctx->master)->private;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         ret = -1;
         need_retry = 1;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_getspec_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(frame->this->name, GF_LOG_ERROR, 0, API_MSG_XDR_DECODE_FAILED,
                 NULL);
         ret = -1;
         goto out;
     }
 
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(frame->this->name, GF_LOG_ERROR, rsp.op_errno,
                 API_MSG_GET_VOLFILE_FAILED, "from server", NULL);
         ret = -1;
@@ -641,7 +641,7 @@ volfile:
 
     /* coverity[secure_temp] mkstemp uses 0600 as the mode and is safe */
     tmp_fd = mkstemp(template);
-    if (-1 == tmp_fd) {
+    if (IS_ERROR(tmp_fd)) {
         ret = -1;
         goto out;
     }
@@ -650,7 +650,7 @@ volfile:
      * terminates the temporary file is deleted.
      */
     ret = sys_unlink(template);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(frame->this->name, GF_LOG_INFO, 0, API_MSG_UNABLE_TO_DEL,
                 "template=%s", template, NULL);
         ret = 0;
@@ -690,7 +690,7 @@ volfile:
         goto out;
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug("glusterfsd-mgmt", 0, "Reconfigure failed !!");
         goto out;
     }
@@ -786,7 +786,7 @@ glfs_volfile_fetch(struct glfs *fs)
 
     ret = dict_allocate_and_serialize(dict, &req.xdata.xdata_val,
                                       &req.xdata.xdata_len);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(THIS->name, GF_LOG_ERROR, 0, API_MSG_DICT_SERIALIZE_FAILED,
                 NULL);
         goto out;

--- a/api/src/glfs-resolve.c
+++ b/api/src/glfs-resolve.c
@@ -168,7 +168,7 @@ priv_glfs_loc_touchup(loc_t *loc)
     int ret = 0;
 
     ret = loc_touchup(loc, loc->name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         errno = -ret;
         ret = -1;
     }
@@ -192,14 +192,14 @@ glfs_resolve_symlink(struct glfs *fs, xlator_t *subvol, inode_t *inode,
     loc.inode = inode_ref(inode);
     gf_uuid_copy(loc.gfid, inode->gfid);
     ret = inode_path(inode, NULL, &rpath);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
     loc.path = rpath;
 
     ret = syncop_readlink(subvol, &loc, &path, 4096, NULL, NULL);
     DECODE_SYNCOP_ERR(ret);
 
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (lpath)
@@ -224,7 +224,7 @@ glfs_resolve_base(struct glfs *fs, xlator_t *subvol, inode_t *inode,
 
     ret = inode_path(loc.inode, NULL, &path);
     loc.path = path;
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = syncop_lookup(subvol, &loc, iatt, NULL, NULL, NULL);
@@ -259,7 +259,7 @@ glfs_resolve_root(struct glfs *fs, xlator_t *subvol, inode_t *inode,
      * Github issue : https://github.com/gluster/glusterfs/issues/232
      */
     loc.parent = inode_ref(inode);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = syncop_lookup(subvol, &loc, iatt, NULL, NULL, NULL);
@@ -399,7 +399,7 @@ glfs_resolve_component(struct glfs *fs, xlator_t *subvol, inode_t *parent,
     }
 
     glret = priv_glfs_loc_touchup(&loc);
-    if (glret < 0) {
+    if (IS_ERROR(glret)) {
         ret = -1;
         goto out;
     }
@@ -549,7 +549,7 @@ priv_glfs_resolve_at(struct glfs *fs, xlator_t *subvol, inode_t *at,
             ret = glfs_resolve_symlink(fs, subvol, inode, &lpath);
             inode_unref(inode);
             inode = NULL;
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 break;
 
             ret = priv_glfs_resolve_at(fs, subvol, parent, lpath, &sym_loc,
@@ -605,7 +605,7 @@ priv_glfs_resolve_at(struct glfs *fs, xlator_t *subvol, inode_t *at,
         ret = 0;
     }
 
-    if (priv_glfs_loc_touchup(loc) < 0) {
+    if (IS_ERROR(priv_glfs_loc_touchup(loc))) {
         ret = -1;
     }
 out:
@@ -686,7 +686,7 @@ glfs_migrate_fd_locks_safe(struct glfs *fs, xlator_t *oldsubvol, fd_t *oldfd,
     ret = syncop_fgetxattr(oldsubvol, oldfd, &lockinfo, GF_XATTR_LOCKINFO_KEY,
                            NULL, NULL);
     DECODE_SYNCOP_ERR(ret);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(fs->volname, GF_LOG_WARNING, errno, API_MSG_FGETXATTR_FAILED,
                 "gfid=%s", uuid_utoa_r(oldfd->inode->gfid, uuid1), "err=%s",
                 strerror(errno), "subvol=%s", graphid_str(oldsubvol), "id=%d",
@@ -703,7 +703,7 @@ glfs_migrate_fd_locks_safe(struct glfs *fs, xlator_t *oldsubvol, fd_t *oldfd,
 
     ret = syncop_fsetxattr(newsubvol, newfd, lockinfo, 0, NULL, NULL);
     DECODE_SYNCOP_ERR(ret);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(fs->volname, GF_LOG_WARNING, 0, API_MSG_FSETXATTR_FAILED,
                 "gfid=%s", uuid_utoa_r(newfd->inode->gfid, uuid1), "err=%s",
                 strerror(errno), "subvol=%s", graphid_str(newsubvol), "id=%d",
@@ -770,7 +770,7 @@ glfs_migrate_fd_safe(struct glfs *fs, xlator_t *newsubvol, fd_t *oldfd)
     loc.inode = inode_ref(newinode);
 
     ret = inode_path(oldfd->inode, NULL, (char **)&loc.path);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(fs->volname, GF_LOG_INFO, 0, API_MSG_INODE_PATH_FAILED, NULL);
         goto out;
     }
@@ -1172,7 +1172,7 @@ glfs_h_resolve_symlink(struct glfs *fs, struct glfs_object *object)
     }
 
     ret = glfs_resolve_symlink(fs, subvol, object->inode, &lpath);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = glfs_resolve_at(fs, subvol, NULL, lpath, &sym_loc, &iatt,

--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -1011,7 +1011,7 @@ pub_glfs_set_logging(struct glfs *fs, const char *logfile, int loglevel)
     }
 
     /* finish log set parameters before init */
-    if (loglevel >= 0)
+    if (IS_SUCCESS(loglevel))
         gf_log_set_loglevel(fs->ctx, loglevel);
 
     ret = gf_log_init(fs->ctx, tmplog, NULL);
@@ -1144,7 +1144,7 @@ out:
     __GLFS_EXIT_FS;
 
     /* Set the initial current working directory to "/" */
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         ret = glfs_chdir(fs, "/");
     }
 

--- a/api/src/glfs.c
+++ b/api/src/glfs.c
@@ -188,7 +188,8 @@ create_master(struct glfs *fs)
     if (!master->name)
         goto err;
 
-    if (xlator_set_type(master, "mount/api") == -1) {
+    ret = xlator_set_type(master, "mount/api");
+    if (IS_ERROR(ret)) {
         gf_smsg("glfs", GF_LOG_ERROR, 0, API_MSG_MASTER_XLATOR_INIT_FAILED,
                 "name=%s", fs->volname, NULL);
         goto err;
@@ -1375,7 +1376,7 @@ pub_glfs_fini(struct glfs *fs)
         syncenv_destroy(ctx->env);
 
         /* Join the poller thread */
-        if (gf_event_dispatch_destroy(ctx->event_pool) < 0)
+        if (IS_ERROR(gf_event_dispatch_destroy(ctx->event_pool)))
             ret = -1;
     }
 
@@ -1787,7 +1788,7 @@ pub_glfs_set_statedump_path(struct glfs *fs, const char *path)
             errno = EINVAL;
             goto err;
         }
-        if (sys_access(path, W_OK | X_OK) < 0) {
+        if (IS_ERROR(sys_access(path, W_OK | X_OK))) {
             gf_log("glfs", GF_LOG_ERROR,
                    "%s: path doesn't have write permission", path);
             errno = EPERM;

--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -373,7 +373,7 @@ cli_cmd_create_disperse_check(struct cli_state *state, int *disperse,
         *disperse = count;
     }
 
-    if (*redundancy == -1) {
+    if (IS_ERROR(*redundancy)) {
         tmp = *disperse - 1;
         for (i = tmp / 2; (i > 0) && ((tmp & -tmp) != tmp); i--, tmp--)
             ;
@@ -437,10 +437,10 @@ cli_validate_disperse_volume(char *word, gf1_cluster_type type,
                     goto out;
                 }
                 ret = gf_string2int(words[index + 1], disperse_count);
-                if (ret == -1 && errno == EINVAL) {
+                if (IS_ERROR(ret) && errno == EINVAL) {
                     *disperse_count = 0;
                     ret = 1;
-                } else if (ret == -1) {
+                } else if (IS_ERROR(ret)) {
                     goto out;
                 } else {
                     if (*disperse_count < 3) {
@@ -460,7 +460,7 @@ cli_validate_disperse_volume(char *word, gf1_cluster_type type,
                     goto out;
                 }
                 ret = gf_string2int(words[index + 1], data_count);
-                if (ret == -1 || *data_count < 2) {
+                if (IS_ERROR(ret) || *data_count < 2) {
                     cli_err("disperse-data must be greater than 1");
                     goto out;
                 }
@@ -474,7 +474,7 @@ cli_validate_disperse_volume(char *word, gf1_cluster_type type,
                     goto out;
                 }
                 ret = gf_string2int(words[index + 1], redundancy_count);
-                if (ret == -1 || *redundancy_count < 1) {
+                if (IS_ERROR(ret) || *redundancy_count < 1) {
                     cli_err("redundancy must be greater than 0");
                     goto out;
                 }
@@ -601,7 +601,7 @@ cli_cmd_volume_create_parse(struct cli_state *state, const char **words,
     GF_ASSERT(volname);
 
     /* Validate the volume name here itself */
-    if (cli_validate_volname(volname) < 0)
+    if (IS_ERROR(cli_validate_volname(volname)))
         goto out;
 
     if (wordcount < 4) {
@@ -657,7 +657,7 @@ cli_cmd_volume_create_parse(struct cli_state *state, const char **words,
             if (words[index]) {
                 if (!strcmp(words[index], "arbiter")) {
                     ret = gf_string2int(words[index + 1], &arbiter_count);
-                    if ((ret == -1) || (arbiter_count != 1)) {
+                    if (IS_ERROR(ret) || (arbiter_count != 1)) {
                         cli_err(
                             "For arbiter "
                             "configuration, "
@@ -675,7 +675,7 @@ cli_cmd_volume_create_parse(struct cli_state *state, const char **words,
                     index += 2;
                 } else if (!strcmp(words[index], "thin-arbiter")) {
                     ret = gf_string2int(words[index + 1], &thin_arbiter_count);
-                    if ((ret == -1) || (thin_arbiter_count != 1) ||
+                    if (IS_ERROR(ret) || (thin_arbiter_count != 1) ||
                         (replica_count != 2)) {
                         cli_err(
                             "For thin-arbiter "
@@ -759,7 +759,7 @@ cli_cmd_volume_create_parse(struct cli_state *state, const char **words,
             ret = cli_validate_disperse_volume(
                 w, type, words, wordcount, index, &disperse_count,
                 &redundancy_count, &disperse_data_count);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
             index += ret;
             type = GF_CLUSTER_TYPE_DISPERSE;
@@ -1156,11 +1156,11 @@ cli_cmd_inode_quota_parse(const char **words, int wordcount, dict_t **options)
     }
 
     /* Validate the volume name here itself */
-    if (cli_validate_volname(volname) < 0)
+    if (IS_ERROR(cli_validate_volname(volname)))
         goto out;
 
     ret = dict_set_str(dict, "volname", volname);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (strcmp(words[3], "enable") != 0) {
@@ -1170,12 +1170,12 @@ cli_cmd_inode_quota_parse(const char **words, int wordcount, dict_t **options)
     }
 
     ret = dict_set_int32(dict, "type", GF_QUOTA_OPTION_TYPE_ENABLE_OBJECTS);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     *options = dict;
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (dict)
             dict_unref(dict);
     }
@@ -1237,11 +1237,11 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
     }
 
     /* Validate the volume name here itself */
-    if (cli_validate_volname(volname) < 0)
+    if (IS_ERROR(cli_validate_volname(volname)))
         goto out;
 
     ret = dict_set_str(dict, "volname", volname);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     w = str_getunamb(words[3], opwords);
@@ -1332,7 +1332,7 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
         }
 
         ret = dict_set_str(dict, "hard-limit", (char *)words[5]);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         if (wordcount == 7) {
@@ -1346,7 +1346,7 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
             }
 
             ret = dict_set_str(dict, "soft-limit", (char *)words[6]);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
         }
 
@@ -1368,7 +1368,7 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
         }
 
         ret = dict_set_str(dict, "path", (char *)words[4]);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
         goto set_type;
     }
@@ -1388,7 +1388,7 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
         }
 
         ret = dict_set_str(dict, "path", (char *)words[4]);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
         goto set_type;
     }
@@ -1407,12 +1407,12 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
             snprintf(key, 20, "path%d", i - 4);
 
             ret = dict_set_str(dict, key, (char *)words[i++]);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
         }
 
         ret = dict_set_int32(dict, "count", i - 4);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         goto set_type;
@@ -1426,7 +1426,7 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
             snprintf(key, 20, "path%d", i - 4);
 
             ret = dict_set_str(dict, key, (char *)words[i++]);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_log("cli", GF_LOG_ERROR,
                        "Failed to set "
                        "quota patch in request dictionary");
@@ -1435,7 +1435,7 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
         }
 
         ret = dict_set_int32(dict, "count", i - 4);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log("cli", GF_LOG_ERROR,
                    "Failed to set quota "
                    "limit count in request dictionary");
@@ -1462,7 +1462,7 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
         }
 
         ret = dict_set_str(dict, "value", (char *)words[4]);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
         goto set_type;
     }
@@ -1484,7 +1484,7 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
         }
 
         ret = dict_set_str(dict, "value", (char *)words[4]);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
         goto set_type;
     }
@@ -1506,7 +1506,7 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
         }
 
         ret = dict_set_str(dict, "value", (char *)words[4]);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
         goto set_type;
     }
@@ -1518,7 +1518,7 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
         type = GF_QUOTA_OPTION_TYPE_DEFAULT_SOFT_LIMIT;
 
         ret = dict_set_str(dict, "value", (char *)words[4]);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
         goto set_type;
     } else {
@@ -1527,12 +1527,12 @@ cli_cmd_quota_parse(const char **words, int wordcount, dict_t **options)
 
 set_type:
     ret = dict_set_int32(dict, "type", type);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     *options = dict;
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (dict)
             dict_unref(dict);
     }
@@ -1555,7 +1555,7 @@ cli_add_key_group_value(dict_t *dict, const char *name, const char *value,
     int32_t ret = -1;
 
     ret = gf_asprintf(&key, "%s%d", name, id);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
     data = gf_strdup(value);
@@ -1597,7 +1597,7 @@ cli_add_key_group(dict_t *dict, char *key, char *value, char **op_errstr)
 
     ret = gf_asprintf(&tagpath, "%s/groups/%s", GLUSTERD_DEFAULT_WORKDIR,
                       value);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         tagpath = NULL;
         goto out;
     }
@@ -1742,7 +1742,7 @@ cli_cmd_volume_set_parse(struct cli_state *state, const char **words,
         }
 
         ret = gf_strip_whitespace(value, strlen(value));
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto out;
 
         if (strlen(value) == 0) {
@@ -1769,7 +1769,7 @@ cli_cmd_volume_set_parse(struct cli_state *state, const char **words,
 
         if (fnmatch("user.*", key, FNM_NOESCAPE) != 0) {
             ret = gf_strip_whitespace(value, strlen(value));
-            if (ret == -1)
+            if (IS_ERROR(ret))
                 goto out;
         }
 
@@ -2222,7 +2222,7 @@ cli_cmd_brick_op_validate_bricks(const char **words, dict_t *dict, int src,
     if (ret)
         goto out;
 
-    if (dst == -1) {
+    if (IS_ERROR(dst)) {
         ret = 0;
         goto out;
     }
@@ -2480,7 +2480,7 @@ cli_cmd_log_level_parse(const char **words, int worcount, dict_t **options)
     GF_ASSERT((strncmp(words[2], "level", 5) == 0));
 
     ret = glusterd_check_log_level(words[5]);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         cli_err("Invalid log level [%s] specified", words[5]);
         cli_err(
             "Valid values for loglevel: (DEBUG|WARNING|ERROR"
@@ -2664,21 +2664,23 @@ config_parse(const char **words, int wordcount, dict_t *dict, unsigned cmdi,
         case 1:
             if (words[cmdi + 1][0] == '!') {
                 (words[cmdi + 1])++;
-                if (gf_asprintf(&subop, "del%s", glob ? "-glob" : "") == -1)
+                ret = gf_asprintf(&subop, "del%s", glob ? "-glob" : "");
+                if (IS_ERROR(ret))
                     subop = NULL;
             } else
                 subop = gf_strdup("get");
 
             ret = dict_set_str(dict, "op_name", ((char *)words[cmdi + 1]));
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
             break;
         default:
-            if (gf_asprintf(&subop, "set%s", glob ? "-glob" : "") == -1)
+            ret = gf_asprintf(&subop, "set%s", glob ? "-glob" : "");
+            if (IS_ERROR(ret))
                 subop = NULL;
 
             ret = dict_set_str(dict, "op_name", ((char *)words[cmdi + 1]));
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
 
             /* join the varargs by spaces to get the op_value */
@@ -2710,7 +2712,7 @@ config_parse(const char **words, int wordcount, dict_t *dict, unsigned cmdi,
                 };
 
                 ret = gettimeofday(&tv, NULL);
-                if (ret == -1)
+                if (IS_ERROR(ret))
                     goto out;
 
                 GF_FREE(append_str);
@@ -3312,7 +3314,7 @@ cli_cmd_volume_top_parse(const char **words, int wordcount, dict_t **options)
             ret = gf_is_str_int(value);
             if (!ret)
                 list_cnt = atoi(value);
-            if (ret || (list_cnt < 0) || (list_cnt > 100)) {
+            if (ret || IS_ERROR(list_cnt) || (list_cnt > 100)) {
                 cli_err("list-cnt should be between 0 to 100");
                 ret = -1;
                 goto out;
@@ -3322,7 +3324,7 @@ cli_cmd_volume_top_parse(const char **words, int wordcount, dict_t **options)
             if (!ret)
                 blk_size = atoi(value);
             if (ret || (blk_size <= 0)) {
-                if (blk_size < 0)
+                if (IS_ERROR(blk_size))
                     cli_err(
                         "block size is an invalid"
                         " number");
@@ -3339,7 +3341,7 @@ cli_cmd_volume_top_parse(const char **words, int wordcount, dict_t **options)
             if (!ret)
                 count = atoi(value);
             if (ret || (count <= 0)) {
-                if (count < 0)
+                if (IS_ERROR(count))
                     cli_err("count is an invalid number");
                 else
                     cli_err(
@@ -3362,7 +3364,7 @@ cli_cmd_volume_top_parse(const char **words, int wordcount, dict_t **options)
             goto out;
         }
     }
-    if (list_cnt == -1)
+    if (IS_ERROR(list_cnt))
         list_cnt = 100;
     ret = dict_set_int32(dict, "list-cnt", list_cnt);
     if (ret) {
@@ -3636,7 +3638,7 @@ cli_cmd_volume_statedump_options_parse(const char **words, int wordcount,
         if (valid_internet_address(ip_addr, _gf_true, _gf_false) && pid &&
             gf_valid_pid(pid, strlen(pid))) {
             ret = gf_asprintf(&option_str, "%s %s %s", words[3], ip_addr, pid);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 goto out;
             }
             option_cnt = 3;
@@ -3655,7 +3657,7 @@ cli_cmd_volume_statedump_options_parse(const char **words, int wordcount,
             ret = gf_asprintf(&option_str, "%s%s ", tmp_str ? tmp_str : "",
                               option);
             GF_FREE(tmp_str);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 goto out;
             }
         }
@@ -4384,7 +4386,7 @@ cli_snap_create_parse(dict_t *dict, const char **words, int wordcount)
         volcount++;
         /* volume index starts from 1 */
         ret = snprintf(key, sizeof(key), "volname%" PRIu64, volcount);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -5426,7 +5428,7 @@ cli_cmd_snapshot_parse(const char **words, int wordcount, dict_t **options,
             if (ret) {
                 /* A positive ret value means user cancelled
                  * the command */
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     gf_log("cli", GF_LOG_ERROR,
                            "Failed to parse "
                            "snapshot delete command");
@@ -5440,7 +5442,7 @@ cli_cmd_snapshot_parse(const char **words, int wordcount, dict_t **options,
              *                            [snap-max-soft-limit <percent>] */
             ret = cli_snap_config_parse(words, wordcount, dict, state);
             if (ret) {
-                if (ret < 0)
+                if (IS_ERROR(ret))
                     gf_log("cli", GF_LOG_ERROR,
                            "config command parsing failed.");
                 goto out;
@@ -5504,7 +5506,7 @@ cli_cmd_snapshot_parse(const char **words, int wordcount, dict_t **options,
             if (ret) {
                 /* A positive ret value means user cancelled
                  * the command */
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     gf_log("cli", GF_LOG_ERROR,
                            "Failed to parse deactivate "
                            "command");
@@ -5812,7 +5814,7 @@ cli_cmd_bitrot_parse(const char **words, int wordcount, dict_t **options)
     }
 set_type:
     ret = dict_set_int32(dict, "type", type);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     *options = dict;
@@ -5864,7 +5866,7 @@ cli_cmd_ganesha_parse(struct cli_state *state, const char **words,
     }
 
     ret = gf_strip_whitespace(value, strlen(value));
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     if (strcmp(key, "nfs-ganesha")) {

--- a/cli/src/cli-cmd-parser.c
+++ b/cli/src/cli-cmd-parser.c
@@ -429,7 +429,7 @@ cli_validate_disperse_volume(char *word, gf1_cluster_type type,
         case GF_CLUSTER_TYPE_NONE:
         case GF_CLUSTER_TYPE_DISPERSE:
             if (strcmp(word, "disperse") == 0) {
-                if (*disperse_count >= 0) {
+                if (IS_SUCCESS(*disperse_count)) {
                     cli_err("disperse option given twice");
                     goto out;
                 }
@@ -452,7 +452,7 @@ cli_validate_disperse_volume(char *word, gf1_cluster_type type,
                     ret = 2;
                 }
             } else if (strcmp(word, "disperse-data") == 0) {
-                if (*data_count >= 0) {
+                if (IS_SUCCESS(*data_count)) {
                     cli_err("disperse-data option given twice");
                     goto out;
                 }
@@ -466,7 +466,7 @@ cli_validate_disperse_volume(char *word, gf1_cluster_type type,
                 }
                 ret = 2;
             } else if (strcmp(word, "redundancy") == 0) {
-                if (*redundancy_count >= 0) {
+                if (IS_SUCCESS(*redundancy_count)) {
                     cli_err("redundancy option given twice");
                     goto out;
                 }

--- a/cli/src/cli-cmd-snapshot.c
+++ b/cli/src/cli-cmd-snapshot.c
@@ -39,7 +39,7 @@ cli_cmd_snapshot_cbk(struct cli_state *state, struct cli_cmd_word *word,
     /* Parses the command entered by the user */
     ret = cli_cmd_snapshot_parse(words, wordcount, &options, state);
     if (ret) {
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             cli_usage_out(word->pattern);
             parse_err = 1;
         } else {

--- a/cli/src/cli-cmd-system.c
+++ b/cli/src/cli-cmd-system.c
@@ -190,7 +190,7 @@ make_seq_dict(int argc, char **argv)
     for (i = 0; i < argc; i++) {
         len = snprintf(index, sizeof(index), "%d", i);
         ret = dict_set_strn(dict, index, len, argv[i]);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             break;
     }
 

--- a/cli/src/cli-cmd-volume.c
+++ b/cli/src/cli-cmd-volume.c
@@ -1205,7 +1205,7 @@ _limits_set_on_volume(char *volname, int type)
     snprintf(quota_conf_file, sizeof quota_conf_file, "%s/vols/%s/quota.conf",
              GLUSTERD_DEFAULT_WORKDIR, volname);
     fd = open(quota_conf_file, O_RDONLY);
-    if (fd == -1)
+    if (IS_ERROR(fd))
         goto out;
 
     ret = quota_conf_read_version(fd, &version);
@@ -1327,7 +1327,7 @@ cli_cmd_quota_handle_list_all(const char **words, dict_t *options)
     snprintf(quota_conf_file, sizeof quota_conf_file, "%s/vols/%s/quota.conf",
              GLUSTERD_DEFAULT_WORKDIR, volname);
     fd = open(quota_conf_file, O_RDONLY);
-    if (fd == -1) {
+    if (IS_ERROR(fd)) {
         // This may because no limits were yet set on the volume
         gf_log("cli", GF_LOG_TRACE,
                "Unable to open "
@@ -1353,7 +1353,7 @@ cli_cmd_quota_handle_list_all(const char **words, dict_t *options)
         ret = quota_conf_read_gfid(fd, buf, &gfid_type, version);
         if (ret == 0) {
             break;
-        } else if (ret < 0) {
+        } else if (IS_ERROR(ret)) {
             gf_log(THIS->name, GF_LOG_CRITICAL,
                    "Quota "
                    "configuration store may be corrupt.");
@@ -1375,7 +1375,7 @@ cli_cmd_quota_handle_list_all(const char **words, dict_t *options)
     }
 
     ret = sys_lseek(fd, 0L, SEEK_SET);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(THIS->name, GF_LOG_ERROR,
                "failed to move offset to "
                "the beginning: %s",
@@ -1390,7 +1390,7 @@ cli_cmd_quota_handle_list_all(const char **words, dict_t *options)
         ret = quota_conf_read_gfid(fd, buf, &gfid_type, version);
         if (ret == 0) {
             break;
-        } else if (ret < 0) {
+        } else if (IS_ERROR(ret)) {
             gf_log(THIS->name, GF_LOG_CRITICAL,
                    "Quota "
                    "configuration store may be corrupt.");
@@ -1484,7 +1484,7 @@ cli_cmd_bitrot_cbk(struct cli_state *state, struct cli_cmd_word *word,
 #endif
 
     ret = cli_cmd_bitrot_parse(words, wordcount, &options);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         cli_usage_out(word->pattern);
         parse_err = 1;
         goto out;
@@ -1600,7 +1600,7 @@ cli_cmd_quota_cbk(struct cli_state *state, struct cli_cmd_word *word,
     // parse **words into options dictionary
     if (strcmp(words[1], "inode-quota") == 0) {
         ret = cli_cmd_inode_quota_parse(words, wordcount, &options);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             cli_usage_out(word->pattern);
             parse_err = 1;
             goto out;
@@ -1613,7 +1613,7 @@ cli_cmd_quota_cbk(struct cli_state *state, struct cli_cmd_word *word,
             ret = 0;
             goto out;
         }
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             cli_usage_out(word->pattern);
             parse_err = 1;
             goto out;
@@ -2104,7 +2104,7 @@ cli_check_gsync_present()
     int ret = 0;
 
     ret = setenv("_GLUSTERD_CALLED_", "1", 1);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         gf_log("", GF_LOG_WARNING,
                "setenv syscall failed, hence could"
                "not assert if geo-replication is installed");
@@ -2115,7 +2115,7 @@ cli_check_gsync_present()
     runner_add_args(&runner, GSYNCD_PREFIX "/gsyncd", "--version", NULL);
     runner_redir(&runner, STDOUT_FILENO, RUN_PIPE);
     ret = runner_start(&runner);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log("", GF_LOG_INFO, "geo-replication not installed");
         goto out;
     }
@@ -2611,7 +2611,7 @@ cli_launch_glfs_heal(int heal_op, dict_t *options)
     if (global_state->mode & GLUSTER_MODE_GLFSHEAL_NOLOG)
         runner_add_args(&runner, "--nolog", NULL);
     ret = runner_start(&runner);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
     while ((
         out = fgets(buff, sizeof(buff), runner_chio(&runner, STDOUT_FILENO)))) {
@@ -2652,11 +2652,11 @@ cli_cmd_volume_heal_cbk(struct cli_state *state, struct cli_cmd_word *word,
         goto out;
     }
     ret = dict_get_int32(options, "heal-op", &heal_op);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
     if (NEEDS_GLFS_HEAL(heal_op)) {
         ret = cli_launch_glfs_heal(heal_op, options);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
         if (heal_op != GF_SHD_OP_GRANULAR_ENTRY_HEAL_ENABLE)
             goto out;

--- a/cli/src/cli-cmd.c
+++ b/cli/src/cli-cmd.c
@@ -383,7 +383,7 @@ cli_cmd_pattern_cmp(void *a, void *b)
     ib = b;
     if (strcmp(ia->pattern, ib->pattern) > 0)
         ret = 1;
-    else if (strcmp(ia->pattern, ib->pattern) < 0)
+    else if (IS_ERROR(strcmp(ia->pattern, ib->pattern)))
         ret = -1;
     else
         ret = 0;

--- a/cli/src/cli-cmd.c
+++ b/cli/src/cli-cmd.c
@@ -383,7 +383,7 @@ cli_cmd_pattern_cmp(void *a, void *b)
     ib = b;
     if (strcmp(ia->pattern, ib->pattern) > 0)
         ret = 1;
-    else if (IS_ERROR(strcmp(ia->pattern, ib->pattern)))
+    else if (strcmp(ia->pattern, ib->pattern) < 0)
         ret = -1;
     else
         ret = 0;

--- a/cli/src/cli-quotad-client.c
+++ b/cli/src/cli-quotad-client.c
@@ -52,7 +52,7 @@ cli_quotad_submit_request(void *req, call_frame_t *frame, rpc_clnt_prog_t *prog,
 
         /* Create the xdr payload */
         ret = xdr_serialize_generic(iov, req, xdrproc);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
         iov.iov_len = ret;

--- a/cli/src/cli-rl.c
+++ b/cli/src/cli-rl.c
@@ -34,7 +34,7 @@ cli_rl_out(struct cli_state *state, const char *fmt, va_list ap)
     int n = rl_end;
     int ret = 0;
 
-    if (rl_end >= 0) {
+    if (IS_SUCCESS(rl_end)) {
         rl_kill_text(0, rl_end);
         rl_redisplay();
     }
@@ -62,7 +62,7 @@ cli_rl_err(struct cli_state *state, const char *fmt, va_list ap)
     int n = rl_end;
     int ret = 0;
 
-    if (rl_end >= 0) {
+    if (IS_SUCCESS(rl_end)) {
         rl_kill_text(0, rl_end);
         rl_redisplay();
     }

--- a/cli/src/cli-rl.c
+++ b/cli/src/cli-rl.c
@@ -381,7 +381,7 @@ cli_rl_enable(struct cli_state *state)
 
     ret = gf_event_register(state->ctx->event_pool, 0, cli_rl_stdin, state, 1,
                             0, 0);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     state->rl_enabled = 1;

--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -4966,7 +4966,7 @@ write_contents_to_common_pem_file(dict_t *dict, int output_count)
     cli_out("Common secret pub file present at %s", common_pem_file);
     ret = 0;
 out:
-    if (fd >= 0)
+    if (IS_SUCCESS(fd))
         sys_close(fd);
 
     gf_log("", GF_LOG_DEBUG, RETURNING, ret);

--- a/cli/src/cli-rpc-ops.c
+++ b/cli/src/cli-rpc-ops.c
@@ -143,12 +143,12 @@ gf_cli_probe_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         // rsp.op_ret   = -1;
@@ -198,12 +198,12 @@ gf_cli_deprobe_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         // rsp.op_ret   = -1;
@@ -418,7 +418,7 @@ gf_cli_list_friends_cbk(struct rpc_req *req, struct iovec *iov, int count,
     call_frame_t *frame = NULL;
     unsigned long flags = 0;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -440,7 +440,7 @@ gf_cli_list_friends_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame->local = NULL;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf1_cli_peer_list_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         // rsp.op_ret   = -1;
         // rsp.op_errno = EINVAL;
@@ -539,11 +539,11 @@ gf_cli_get_state_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_VALIDATE_OR_GOTO("cli", myframe, out);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -738,7 +738,7 @@ gf_cli_get_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status)
+    if (IS_ERROR(req->rpc_status))
         goto out;
 
     frame = myframe;
@@ -748,7 +748,7 @@ gf_cli_get_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -991,7 +991,7 @@ gf_cli_create_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -1002,7 +1002,7 @@ gf_cli_create_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -1065,7 +1065,7 @@ gf_cli_delete_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     call_frame_t *frame = NULL;
     dict_t *rsp_dict = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -1077,7 +1077,7 @@ gf_cli_delete_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -1142,7 +1142,7 @@ gf_cli3_1_uuid_get_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status)
+    if (IS_ERROR(req->rpc_status))
         goto out;
 
     frame = myframe;
@@ -1152,7 +1152,7 @@ gf_cli3_1_uuid_get_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -1222,7 +1222,7 @@ gf_cli3_1_uuid_reset_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -1233,7 +1233,7 @@ gf_cli3_1_uuid_reset_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -1281,7 +1281,7 @@ gf_cli_start_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -1292,7 +1292,7 @@ gf_cli_start_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -1356,7 +1356,7 @@ gf_cli_stop_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -1367,7 +1367,7 @@ gf_cli_stop_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -1670,7 +1670,7 @@ gf_cli_defrag_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     };
     char *task_id_str = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -1683,7 +1683,7 @@ gf_cli_defrag_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -1706,7 +1706,7 @@ gf_cli_defrag_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
         dict = dict_new();
 
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log("glusterd", GF_LOG_ERROR, DICT_UNSERIALIZE_FAIL);
             goto out;
         }
@@ -1745,7 +1745,7 @@ gf_cli_defrag_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     if (cmd == GF_DEFRAG_CMD_STOP) {
-        if (rsp.op_ret == -1) {
+        if (IS_ERROR(rsp.op_ret)) {
             if (strcmp(rsp.op_errstr, ""))
                 snprintf(msg, sizeof(msg), "%s", rsp.op_errstr);
             else
@@ -1767,7 +1767,7 @@ gf_cli_defrag_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
         }
     }
     if (cmd == GF_DEFRAG_CMD_STATUS) {
-        if (rsp.op_ret == -1) {
+        if (IS_ERROR(rsp.op_ret)) {
             if (strcmp(rsp.op_errstr, ""))
                 snprintf(msg, sizeof(msg), "%s", rsp.op_errstr);
             else
@@ -1825,12 +1825,12 @@ gf_cli_rename_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -1875,12 +1875,12 @@ gf_cli_reset_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -1927,12 +1927,12 @@ gf_cli_ganesha_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -2036,12 +2036,12 @@ gf_cli_set_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -2129,12 +2129,12 @@ gf_cli_add_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -2188,7 +2188,7 @@ gf_cli3_remove_brick_status_cbk(struct rpc_req *req, struct iovec *iov,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -2199,7 +2199,7 @@ gf_cli3_remove_brick_status_cbk(struct rpc_req *req, struct iovec *iov,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -2223,7 +2223,7 @@ gf_cli3_remove_brick_status_cbk(struct rpc_req *req, struct iovec *iov,
     }
 
     ret = rsp.op_ret;
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (strcmp(rsp.op_errstr, ""))
             snprintf(msg, sizeof(msg), "volume remove-brick %s: failed: %s",
                      cmd_str, rsp.op_errstr);
@@ -2243,7 +2243,7 @@ gf_cli3_remove_brick_status_cbk(struct rpc_req *req, struct iovec *iov,
         dict = dict_new();
 
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             strncpy(msg, DICT_UNSERIALIZE_FAIL, sizeof(msg));
 
             if (global_state->mode & GLUSTER_MODE_XML) {
@@ -2315,7 +2315,7 @@ gf_cli_remove_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -2326,7 +2326,7 @@ gf_cli_remove_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -2437,7 +2437,7 @@ gf_cli_reset_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -2448,7 +2448,7 @@ gf_cli_reset_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -2471,7 +2471,7 @@ gf_cli_reset_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
         rsp_dict = dict_new();
 
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &rsp_dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(frame->this->name, GF_LOG_ERROR, DICT_UNSERIALIZE_FAIL);
             goto out;
         }
@@ -2550,7 +2550,7 @@ gf_cli_replace_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -2561,7 +2561,7 @@ gf_cli_replace_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -2577,7 +2577,7 @@ gf_cli_replace_brick_cbk(struct rpc_req *req, struct iovec *iov, int count,
         rsp_dict = dict_new();
 
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &rsp_dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(frame->this->name, GF_LOG_ERROR, DICT_UNSERIALIZE_FAIL);
             goto out;
         }
@@ -2644,12 +2644,12 @@ gf_cli_log_rotate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -2698,12 +2698,12 @@ gf_cli_sync_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -2852,7 +2852,7 @@ print_quota_list_output(cli_local_t *local, char *path, char *default_sl,
     GF_ASSERT(path);
 
     if (limit_set) {
-        if (limits->sl < 0) {
+        if (IS_ERROR(limits->sl)) {
             ret = gf_string2percent(default_sl, &sl_num);
             if (ret) {
                 gf_log("cli", GF_LOG_ERROR,
@@ -2865,7 +2865,7 @@ print_quota_list_output(cli_local_t *local, char *path, char *default_sl,
             sl_num = (limits->sl * limits->hl) / 100;
             ret = snprintf(percent_str, sizeof(percent_str), "%" PRIu64 "%%",
                            limits->sl);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
             sl_final = percent_str;
         }
@@ -2924,7 +2924,7 @@ print_quota_list_from_mountdir(cli_local_t *local, char *mountdir,
         key = QUOTA_LIMIT_OBJECTS_KEY;
 
     ret = sys_lgetxattr(mountdir, key, (void *)&limits, sizeof(limits));
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log("cli", GF_LOG_ERROR,
                "Failed to get the xattr %s on %s. Reason : %s", key, mountdir,
                strerror(errno));
@@ -2985,7 +2985,7 @@ enoattr:
         ret = -1;
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log("cli", GF_LOG_ERROR, "Failed to get quota size on path %s: %s",
                mountdir, strerror(errno));
         print_quota_list_empty(path, type);
@@ -3065,7 +3065,7 @@ gf_cli_print_limit_list_from_dict(cli_local_t *local, char *volname,
         keylen = snprintf(key, sizeof(key), "path%d", i++);
 
         ret = dict_get_strn(dict, key, keylen, &path);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log("cli", GF_LOG_DEBUG, "Path not present in limit list");
             continue;
         }
@@ -3151,7 +3151,7 @@ print_quota_list_from_quotad(call_frame_t *frame, dict_t *rsp_dict)
         ret = quota_dict_get_inode_meta(rsp_dict, QUOTA_SIZE_KEY,
                                         SLEN(QUOTA_SIZE_KEY), &used_space);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log("cli", GF_LOG_WARNING, "size key not present in dict");
         print_quota_list_empty(path, type);
         goto out;
@@ -3221,11 +3221,11 @@ cli_quota_compare_path(struct list_head *list1, struct list_head *list2)
     dict2 = node2->ptr;
 
     ret = dict_get_str_sizen(dict1, GET_ANCESTRY_PATH_KEY, &path1);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return 0;
 
     ret = dict_get_str_sizen(dict2, GET_ANCESTRY_PATH_KEY, &path2);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return 0;
 
     return strcmp(path1, path2);
@@ -3276,7 +3276,7 @@ cli_quotad_getlimit_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         if (list_count == 0)
             cli_err(
                 "Connection failed. Please check if quota "
@@ -3286,7 +3286,7 @@ cli_quotad_getlimit_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -3305,7 +3305,7 @@ cli_quotad_getlimit_cbk(struct rpc_req *req, struct iovec *iov, int count,
         dict = dict_new();
 
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log("cli", GF_LOG_ERROR, DICT_UNSERIALIZE_FAIL);
             goto out;
         }
@@ -3321,7 +3321,7 @@ cli_quotad_getlimit_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = dict_get_int32_sizen(local->dict, "max_count", &max_count);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log("cli", GF_LOG_ERROR, "failed to get max_count");
         goto out;
     }
@@ -3352,7 +3352,7 @@ out:
      * Broadcasting response in a separate thread which is not a
      * good fix. This needs to be re-visted with better solution
      */
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         ret = pthread_create(&th_id, NULL, cli_cmd_broadcast_response_detached,
                              (void *)-1);
         if (ret)
@@ -3385,7 +3385,7 @@ cli_quotad_getlimit(call_frame_t *frame, xlator_t *this, void *data)
 
     ret = dict_allocate_and_serialize(dict, &req.dict.dict_val,
                                       &req.dict.dict_len);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_ERROR, DICT_SERIALIZE_FAIL);
 
         goto out;
@@ -3438,7 +3438,7 @@ gf_cli_quota_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -3449,7 +3449,7 @@ gf_cli_quota_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -3475,7 +3475,7 @@ gf_cli_quota_cbk(struct rpc_req *req, struct iovec *iov, int count,
         dict = dict_new();
 
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log("cli", GF_LOG_ERROR, DICT_UNSERIALIZE_FAIL);
             goto out;
         }
@@ -3524,7 +3524,7 @@ gf_cli_quota_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
         if (global_state->mode & GLUSTER_MODE_XML) {
             ret = cli_xml_output_vol_quota_limit_list_end(local);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 ret = -1;
                 gf_log("cli", GF_LOG_ERROR, XML_ERROR);
             }
@@ -3575,18 +3575,18 @@ gf_cli_getspec_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_getspec_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
     }
 
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                "getspec failed");
         ret = -1;
@@ -3626,18 +3626,18 @@ gf_cli_pmap_b2p_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_pmap_port_by_brick_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
     }
 
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                "pump_b2p failed");
         ret = -1;
@@ -4065,7 +4065,7 @@ gf_cli_rename_volume(call_frame_t *frame, xlator_t *this, void *data)
 
     ret = dict_allocate_and_serialize(dict, &req.dict.dict_val,
                                       &req.dict.dict_len);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_ERROR, DICT_SERIALIZE_FAIL);
 
         goto out;
@@ -4387,7 +4387,7 @@ gf_cli_getspec(call_frame_t *frame, xlator_t *this, void *data)
 
     ret = dict_allocate_and_serialize(op_dict, &req.xdata.xdata_val,
                                       &req.xdata.xdata_len);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(THIS->name, GF_LOG_ERROR, DICT_SERIALIZE_FAIL);
         goto out;
     }
@@ -4475,12 +4475,12 @@ gf_cli_fsm_log_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf1_cli_fsm_log_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -4930,7 +4930,7 @@ write_contents_to_common_pem_file(dict_t *dict, int output_count)
     sys_unlink(common_pem_file);
 
     fd = open(common_pem_file, O_WRONLY | O_CREAT, 0600);
-    if (fd == -1) {
+    if (IS_ERROR(fd)) {
         gf_log("", GF_LOG_ERROR, "Failed to open %s Error : %s",
                common_pem_file, strerror(errno));
         ret = -1;
@@ -4990,12 +4990,12 @@ gf_cli_sys_exec_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (req->rpc_status == -1) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -5072,12 +5072,12 @@ gf_cli_copy_file_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (req->rpc_status == -1) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -5128,12 +5128,12 @@ gf_cli_gsync_set_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (req->rpc_status == -1) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -5434,7 +5434,7 @@ cmd_profile_volume_brick_out(dict_t *dict, int count, int interval)
         gf_log("cli", GF_LOG_DEBUG, "failed to get %s from dict", key);
     }
 
-    if (interval == -1)
+    if (IS_ERROR(interval))
         cli_out("Cumulative Stats:");
     else
         cli_out("Interval %d Stats:", interval);
@@ -5548,13 +5548,13 @@ gf_cli_profile_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     gf_log("cli", GF_LOG_DEBUG, "Received resp to profile");
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -5743,13 +5743,13 @@ gf_cli_top_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     gf_log("cli", GF_LOG_DEBUG, "Received resp to top");
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -5967,18 +5967,18 @@ gf_cli_getwd_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf1_cli_getwd_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
     }
 
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         cli_err("getwd failed");
         ret = rsp.op_ret;
         goto out;
@@ -7186,11 +7186,11 @@ gf_cli_status_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (req->rpc_status == -1)
+    if (IS_ERROR(req->rpc_status))
         goto out;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -7416,12 +7416,12 @@ gf_cli_status_cbk(struct rpc_req *req, struct iovec *iov, int count,
         ret = dict_get_int32(dict, key, &pid);
         if (ret)
             continue;
-        if (pid == -1)
+        if (IS_ERROR(pid))
             ret = gf_asprintf(&(status.pid_str), "%s", "N/A");
         else
             ret = gf_asprintf(&(status.pid_str), "%d", pid);
 
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto out;
 
         if ((cmd & GF_CLI_STATUS_DETAIL)) {
@@ -7597,12 +7597,12 @@ gf_cli_mount_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf1_cli_mount_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -7674,12 +7674,12 @@ gf_cli_umount_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf1_cli_umount_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -7960,7 +7960,7 @@ gf_cli_heal_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -7971,7 +7971,7 @@ gf_cli_heal_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -8158,11 +8158,11 @@ gf_cli_statedump_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status)
+    if (IS_ERROR(req->rpc_status))
         goto out;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -8230,11 +8230,11 @@ gf_cli_list_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status)
+    if (IS_ERROR(req->rpc_status))
         goto out;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -8319,11 +8319,11 @@ gf_cli_clearlocks_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status)
+    if (IS_ERROR(req->rpc_status))
         goto out;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -8675,7 +8675,7 @@ cli_get_each_volinfo_in_snap(dict_t *dict, char *keyprefix,
 
     if (snap_driven) {
         ret = snprintf(key, sizeof(key), "%s.volname", keyprefix);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -8688,7 +8688,7 @@ cli_get_each_volinfo_in_snap(dict_t *dict, char *keyprefix,
                 get_buffer);
 
         ret = snprintf(key, sizeof(key), "%s.origin-volname", keyprefix);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -8701,7 +8701,7 @@ cli_get_each_volinfo_in_snap(dict_t *dict, char *keyprefix,
                 volname);
 
         ret = snprintf(key, sizeof(key), "%s.snapcount", keyprefix);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -8714,7 +8714,7 @@ cli_get_each_volinfo_in_snap(dict_t *dict, char *keyprefix,
                 value);
 
         ret = snprintf(key, sizeof(key), "%s.snaps-available", keyprefix);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -8728,7 +8728,7 @@ cli_get_each_volinfo_in_snap(dict_t *dict, char *keyprefix,
     }
 
     ret = snprintf(key, sizeof(key), "%s.vol-status", keyprefix);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -8758,14 +8758,14 @@ cli_get_volinfo_in_snap(dict_t *dict, char *keyprefix)
     GF_ASSERT(keyprefix);
 
     ret = snprintf(key, sizeof(key), "%s.vol-count", keyprefix);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
     ret = dict_get_int32(dict, key, &volcount);
     for (i = 1; i <= volcount; i++) {
         ret = snprintf(key, sizeof(key), "%s.vol%d", keyprefix, i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
         ret = cli_get_each_volinfo_in_snap(dict, key, _gf_true);
@@ -8796,7 +8796,7 @@ cli_get_each_snap_info(dict_t *dict, char *prefix_str, gf_boolean_t snap_driven)
         strcat(indent, "\t");
 
     ret = snprintf(key_buffer, sizeof(key_buffer), "%s.snapname", prefix_str);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -8808,7 +8808,7 @@ cli_get_each_snap_info(dict_t *dict, char *prefix_str, gf_boolean_t snap_driven)
     cli_out("%s" INDENT_MAIN_HEAD "%s", indent, "Snapshot", ":", get_buffer);
 
     ret = snprintf(key_buffer, sizeof(key_buffer), "%s.snap-id", prefix_str);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -8820,7 +8820,7 @@ cli_get_each_snap_info(dict_t *dict, char *prefix_str, gf_boolean_t snap_driven)
     cli_out("%s" INDENT_MAIN_HEAD "%s", indent, "Snap UUID", ":", get_buffer);
 
     ret = snprintf(key_buffer, sizeof(key_buffer), "%s.snap-desc", prefix_str);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -8832,7 +8832,7 @@ cli_get_each_snap_info(dict_t *dict, char *prefix_str, gf_boolean_t snap_driven)
     }
 
     ret = snprintf(key_buffer, sizeof(key_buffer), "%s.snap-time", prefix_str);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -8881,7 +8881,7 @@ cli_call_snapshot_info(dict_t *dict, gf_boolean_t bool_snap_driven)
 
     for (i = 1; i <= snap_count; i++) {
         ret = snprintf(key, sizeof(key), "snap%d", i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
         ret = cli_get_each_snap_info(dict, key, bool_snap_driven);
@@ -8936,7 +8936,7 @@ cli_get_snaps_in_volume(dict_t *dict)
         }
 
         ret = snprintf(key, sizeof(key), "snap%d.vol1", i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
         ret = cli_get_each_volinfo_in_snap(dict, key, _gf_false);
@@ -8975,7 +8975,7 @@ cli_snapshot_list(dict_t *dict)
 
     for (i = 1; i <= snapcount; i++) {
         ret = snprintf(key, sizeof(key), "snapname%d", i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -9005,7 +9005,7 @@ cli_get_snap_volume_status(dict_t *dict, char *key_prefix)
     GF_ASSERT(key_prefix);
 
     ret = snprintf(key, sizeof(key), "%s.brickcount", key_prefix);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
     ret = dict_get_int32(dict, key, &brickcount);
@@ -9016,7 +9016,7 @@ cli_get_snap_volume_status(dict_t *dict, char *key_prefix)
 
     for (i = 0; i < brickcount; i++) {
         ret = snprintf(key, sizeof(key), "%s.brick%d.path", key_prefix, i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -9028,7 +9028,7 @@ cli_get_snap_volume_status(dict_t *dict, char *key_prefix)
         cli_out("\n\t%-17s %s   %s", "Brick Path", ":", buffer);
 
         ret = snprintf(key, sizeof(key), "%s.brick%d.vgname", key_prefix, i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -9040,7 +9040,7 @@ cli_get_snap_volume_status(dict_t *dict, char *key_prefix)
             cli_out("\t%-17s %s   %s", "Volume Group", ":", buffer);
 
         ret = snprintf(key, sizeof(key), "%s.brick%d.status", key_prefix, i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -9052,7 +9052,7 @@ cli_get_snap_volume_status(dict_t *dict, char *key_prefix)
             cli_out("\t%-17s %s   %s", "Brick Running", ":", buffer);
 
         ret = snprintf(key, sizeof(key), "%s.brick%d.pid", key_prefix, i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -9064,7 +9064,7 @@ cli_get_snap_volume_status(dict_t *dict, char *key_prefix)
             cli_out("\t%-17s %s   %d", "Brick PID", ":", pid);
 
         ret = snprintf(key, sizeof(key), "%s.brick%d.data", key_prefix, i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -9076,7 +9076,7 @@ cli_get_snap_volume_status(dict_t *dict, char *key_prefix)
             cli_out("\t%-17s %s   %s", "Data Percentage", ":", buffer);
 
         ret = snprintf(key, sizeof(key), "%s.brick%d.lvsize", key_prefix, i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
         ret = dict_get_str(dict, key, &buffer);
@@ -9105,7 +9105,7 @@ cli_get_single_snap_status(dict_t *dict, char *keyprefix)
     GF_ASSERT(keyprefix);
 
     ret = snprintf(key, sizeof(key), "%s.snapname", keyprefix);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -9117,7 +9117,7 @@ cli_get_single_snap_status(dict_t *dict, char *keyprefix)
     cli_out("\nSnap Name : %s", get_buffer);
 
     ret = snprintf(key, sizeof(key), "%s.uuid", keyprefix);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -9129,7 +9129,7 @@ cli_get_single_snap_status(dict_t *dict, char *keyprefix)
     cli_out("Snap UUID : %s", get_buffer);
 
     ret = snprintf(key, sizeof(key), "%s.volcount", keyprefix);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -9141,7 +9141,7 @@ cli_get_single_snap_status(dict_t *dict, char *keyprefix)
 
     for (i = 0; i < volcount; i++) {
         ret = snprintf(key, sizeof(key), "%s.vol%d", keyprefix, i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -9173,7 +9173,7 @@ cli_populate_req_dict_for_delete(dict_t *snap_dict, dict_t *dict, size_t index)
     }
 
     ret = snprintf(key, sizeof(key), "snapname%zu", index);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -9221,7 +9221,7 @@ cli_populate_req_dict_for_status(dict_t *snap_dict, dict_t *dict, int index)
     }
 
     ret = snprintf(key, sizeof(key), "status.snap%d.snapname", index);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -9680,14 +9680,14 @@ gf_cli_snapshot_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (req->rpc_status == -1) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     frame = myframe;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, XDR_DECODE_FAIL);
         goto out;
     }
@@ -10257,11 +10257,11 @@ gf_cli_barrier_volume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status)
+    if (IS_ERROR(req->rpc_status))
         goto out;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -10326,11 +10326,11 @@ gf_cli_get_vol_opt_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (-1 == req->rpc_status)
+    if (IS_ERROR(req->rpc_status))
         goto out;
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;
@@ -10518,7 +10518,7 @@ cli_to_glusterd(gf_cli_req *req, call_frame_t *frame, fop_cbk_fn_t cbkfn,
     ret = dict_allocate_and_serialize(dict, &(req->dict).dict_val,
                                       &(req->dict).dict_len);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_DEBUG,
                "failed to get serialized length of dict");
         goto out;
@@ -10718,12 +10718,12 @@ gf_cli_bitrot_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     GF_ASSERT(myframe);
 
-    if (req->rpc_status == -1) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_cli_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(((call_frame_t *)myframe)->this->name, GF_LOG_ERROR,
                XDR_DECODE_FAIL);
         goto out;

--- a/cli/src/cli-xml-output.c
+++ b/cli/src/cli-xml-output.c
@@ -51,7 +51,7 @@ enum gf_task_types { GF_TASK_TYPE_REBALANCE, GF_TASK_TYPE_REMOVE_BRICK };
 
 #define XML_RET_CHECK_AND_GOTO(ret, label)                                     \
     do {                                                                       \
-        if (ret < 0) {                                                         \
+        if (IS_ERROR(ret)) {                                                   \
             ret = -1;                                                          \
             goto label;                                                        \
         } else                                                                 \
@@ -1937,7 +1937,7 @@ cli_xml_output_vol_profile_stats(xmlTextWriterPtr writer, dict_t *dict,
     int i = 0;
 
     /* <cumulativeStats> || <intervalStats> */
-    if (interval == -1)
+    if (IS_ERROR(interval))
         ret = xmlTextWriterStartElement(writer, (xmlChar *)"cumulativeStats");
     else
         ret = xmlTextWriterStartElement(writer, (xmlChar *)"intervalStats");
@@ -2781,7 +2781,7 @@ cli_xml_output_peer_hostnames(xmlTextWriterPtr writer, dict_t *dict,
 
     for (i = 0; i < count; i++) {
         ret = snprintf(key, sizeof(key), "%s.hostname%d", prefix, i);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
         ret = dict_get_str(dict, key, &hostname);
         if (ret)
@@ -3087,7 +3087,7 @@ cli_xml_output_vol_rebalance_status(xmlTextWriterPtr writer, dict_t *dict,
          * glusterd-utils.c
          */
 
-        if (-1 == overall_status)
+        if (IS_ERROR(overall_status))
             overall_status = status_rcd;
         int rank[] = {[GF_DEFRAG_STATUS_STARTED] = 1,
                       [GF_DEFRAG_STATUS_FAILED] = 2,
@@ -3127,7 +3127,7 @@ cli_xml_output_vol_rebalance_status(xmlTextWriterPtr writer, dict_t *dict,
                                           "%" PRIu64, total_skipped);
     XML_RET_CHECK_AND_GOTO(ret, out);
 
-    if (overall_status == -1) {
+    if (IS_ERROR(overall_status)) {
         overall_status = status_rcd;
     }
 
@@ -4078,7 +4078,7 @@ cli_xml_snapshot_list(xmlTextWriterPtr writer, xmlDocPtr doc, dict_t *dict)
 
     for (i = 1; i <= snapcount; ++i) {
         ret = snprintf(key, sizeof(key), "snapname%d", i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -4206,7 +4206,7 @@ cli_xml_snapshot_info_snap_vol(xmlTextWriterPtr writer, xmlDocPtr doc,
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     ret = snprintf(key, sizeof(key), "%s.volname", keyprefix);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_get_str(dict, key, &buffer);
@@ -4220,7 +4220,7 @@ cli_xml_snapshot_info_snap_vol(xmlTextWriterPtr writer, xmlDocPtr doc,
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     ret = snprintf(key, sizeof(key), "%s.vol-status", keyprefix);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_get_str(dict, key, &buffer);
@@ -4237,7 +4237,7 @@ cli_xml_snapshot_info_snap_vol(xmlTextWriterPtr writer, xmlDocPtr doc,
      * info. Else this is shown in the start of info display.*/
     if (snap_driven) {
         ret = snprintf(key, sizeof(key), "%s.", keyprefix);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = cli_xml_snapshot_info_orig_vol(writer, doc, dict, key);
@@ -4291,7 +4291,7 @@ cli_xml_snapshot_info_per_snap(xmlTextWriterPtr writer, xmlDocPtr doc,
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     ret = snprintf(key_buffer, sizeof(key_buffer), "%s.snapname", keyprefix);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_get_str(dict, key_buffer, &buffer);
@@ -4305,7 +4305,7 @@ cli_xml_snapshot_info_per_snap(xmlTextWriterPtr writer, xmlDocPtr doc,
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     ret = snprintf(key_buffer, sizeof(key_buffer), "%s.snap-id", keyprefix);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_get_str(dict, key_buffer, &buffer);
@@ -4319,7 +4319,7 @@ cli_xml_snapshot_info_per_snap(xmlTextWriterPtr writer, xmlDocPtr doc,
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     ret = snprintf(key_buffer, sizeof(key_buffer), "%s.snap-desc", keyprefix);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_get_str(dict, key_buffer, &buffer);
@@ -4333,7 +4333,7 @@ cli_xml_snapshot_info_per_snap(xmlTextWriterPtr writer, xmlDocPtr doc,
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     ret = snprintf(key_buffer, sizeof(key_buffer), "%s.snap-time", keyprefix);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_get_str(dict, key_buffer, &buffer);
@@ -4347,7 +4347,7 @@ cli_xml_snapshot_info_per_snap(xmlTextWriterPtr writer, xmlDocPtr doc,
     XML_RET_CHECK_AND_GOTO(ret, out);
 
     ret = snprintf(key_buffer, sizeof(key_buffer), "%s.vol-count", keyprefix);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_get_int32(dict, key_buffer, &volcount);
@@ -4365,7 +4365,7 @@ cli_xml_snapshot_info_per_snap(xmlTextWriterPtr writer, xmlDocPtr doc,
     for (i = 1; i <= volcount; i++) {
         ret = snprintf(key_buffer, sizeof(key_buffer), "%s.vol%d", keyprefix,
                        i);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = cli_xml_snapshot_info_snap_vol(writer, doc, dict, key_buffer,
@@ -4491,7 +4491,7 @@ cli_xml_snapshot_volume_status(xmlTextWriterPtr writer, xmlDocPtr doc,
     GF_ASSERT(keyprefix);
 
     ret = snprintf(key, sizeof(key), "%s.brickcount", keyprefix);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_get_int32(dict, key, &brickcount);
@@ -4511,7 +4511,7 @@ cli_xml_snapshot_volume_status(xmlTextWriterPtr writer, xmlDocPtr doc,
         XML_RET_CHECK_AND_GOTO(ret, out);
 
         ret = snprintf(key, sizeof(key), "%s.brick%d.path", keyprefix, i);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = dict_get_str(dict, key, &buffer);
@@ -4532,7 +4532,7 @@ cli_xml_snapshot_volume_status(xmlTextWriterPtr writer, xmlDocPtr doc,
         XML_RET_CHECK_AND_GOTO(ret, out);
 
         ret = snprintf(key, sizeof(key), "%s.brick%d.vgname", keyprefix, i);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = dict_get_str(dict, key, &buffer);
@@ -4547,7 +4547,7 @@ cli_xml_snapshot_volume_status(xmlTextWriterPtr writer, xmlDocPtr doc,
         XML_RET_CHECK_AND_GOTO(ret, out);
 
         ret = snprintf(key, sizeof(key), "%s.brick%d.status", keyprefix, i);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = dict_get_str(dict, key, &buffer);
@@ -4562,7 +4562,7 @@ cli_xml_snapshot_volume_status(xmlTextWriterPtr writer, xmlDocPtr doc,
         XML_RET_CHECK_AND_GOTO(ret, out);
 
         ret = snprintf(key, sizeof(key), "%s.brick%d.pid", keyprefix, i);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = dict_get_int32(dict, key, &pid);
@@ -4577,7 +4577,7 @@ cli_xml_snapshot_volume_status(xmlTextWriterPtr writer, xmlDocPtr doc,
         XML_RET_CHECK_AND_GOTO(ret, out);
 
         ret = snprintf(key, sizeof(key), "%s.brick%d.data", keyprefix, i);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = dict_get_str(dict, key, &buffer);
@@ -4592,7 +4592,7 @@ cli_xml_snapshot_volume_status(xmlTextWriterPtr writer, xmlDocPtr doc,
         XML_RET_CHECK_AND_GOTO(ret, out);
 
         ret = snprintf(key, sizeof(key), "%s.brick%d.lvsize", keyprefix, i);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = dict_get_str(dict, key, &buffer);
@@ -4760,7 +4760,7 @@ cli_xml_snapshot_status(xmlTextWriterPtr writer, xmlDocPtr doc, dict_t *dict)
         snprintf(key, sizeof(key), "status.snap%d", i);
 
         ret = cli_xml_snapshot_status_per_snap(writer, doc, dict, key);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log("cli", GF_LOG_ERROR,
                    "failed to create xml "
                    "output for snapshot status");

--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -218,7 +218,7 @@ logging_init(glusterfs_ctx_t *ctx, struct cli_state *state)
                          "/cli.log";
 
     /* passing ident as NULL means to use default ident for syslog */
-    if (gf_log_init(ctx, log_file, NULL) == -1) {
+    if (IS_ERROR(gf_log_init(ctx, log_file, NULL))) {
         fprintf(stderr, "ERROR: failed to open logfile %s\n", log_file);
     }
 
@@ -270,7 +270,7 @@ cli_submit_request(struct rpc_clnt *rpc, void *req, call_frame_t *frame,
 
         /* Create the xdr payload */
         ret = xdr_serialize_generic(iov, req, xdrproc);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
         iov.iov_len = ret;
@@ -461,7 +461,7 @@ cli_opt_parse(char *opt, struct cli_state *state)
     oarg = strtail(opt, "log-level=");
     if (oarg) {
         int log_level = glusterd_check_log_level(oarg);
-        if (log_level == -1)
+        if (IS_ERROR(log_level))
             return -1;
         state->log_level = (gf_loglevel_t)log_level;
         return 0;
@@ -516,7 +516,7 @@ parse_cmdline(int argc, char *argv[], struct cli_state *state)
         if (!opt)
             continue;
         ret = cli_opt_parse(opt, state);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             cli_out("unrecognized option --%s\n", opt);
             usage();
             return ret;

--- a/contrib/fuse-lib/mount.c
+++ b/contrib/fuse-lib/mount.c
@@ -94,7 +94,7 @@ gf_fuse_unmount_daemon (const char *mountpoint, int fd)
         int ump[2] = {0,};
 
         ret = pipe(ump);
-        if (ret == -1) {
+        if (ret < 0) {
                 close (fd);
                 return -1;
         }
@@ -186,7 +186,7 @@ fuse_mount_fusermount (const char *mountpoint, char *fsname,
                         "%s,fsname=%s,nonempty,subtype=glusterfs",
                         mnt_param, efsname);
         FREE (efsname);
-        if (ret == -1) {
+        if (ret < 0) {
                 GFFUSE_LOGERR ("Out of memory");
 
                 goto out;
@@ -371,7 +371,7 @@ fuse_mount_sys (const char *mountpoint, char *fsname,
                                 "%s,fd=%i,rootmode=%o,user_id=%i,group_id=%i",
                                 mnt_param_new, fd, S_IFDIR, getuid (),
                                 getgid ());
-        if (ret == -1) {
+        if (ret < 0) {
                 GFFUSE_LOGERR ("Out of memory");
 
                 goto out;
@@ -396,13 +396,13 @@ fuse_mount_sys (const char *mountpoint, char *fsname,
                      mnt_param_mnt);
 #endif /* __FreeBSD__ */
 #ifdef GF_LINUX_HOST_OS
-        if (ret == -1 && errno == ENODEV) {
+        if (IS_ERROR(ret) && errno == ENODEV) {
                 /* fs subtype support was added by 79c0b2df aka
                    v2.6.21-3159-g79c0b2d. Probably we have an
                    older kernel ... */
                 fstype = "fuse";
                 ret = asprintf (&source, "glusterfs#%s", fsname);
-                if (ret == -1) {
+                if (ret < 0) {
                         GFFUSE_LOGERR ("Out of memory");
 
                         goto out;
@@ -411,7 +411,7 @@ fuse_mount_sys (const char *mountpoint, char *fsname,
                              mnt_param_mnt);
         }
 #endif /* GF_LINUX_HOST_OS */
-        if (ret == -1)
+        if (ret < 0)
                 goto out;
         else
                 mounted = 1;
@@ -430,7 +430,7 @@ fuse_mount_sys (const char *mountpoint, char *fsname,
                 ret = asprintf (&mnt_param_mtab, "%s%s",
                                 mountflags & MS_RDONLY ? "ro," : "",
                                 mnt_param_new);
-                if (ret == -1)
+                if (ret < 0)
                         GFFUSE_LOGERR ("Out of memory");
                 else {
                         ret = fuse_mnt_add_mount ("fuse", source, newmnt,
@@ -439,7 +439,7 @@ fuse_mount_sys (const char *mountpoint, char *fsname,
                 }
 
                 FREE (newmnt);
-                if (ret == -1) {
+                if (ret < 0) {
                         GFFUSE_LOGERR ("failed to add mtab entry");
 
                         goto out;
@@ -448,7 +448,7 @@ fuse_mount_sys (const char *mountpoint, char *fsname,
 #endif /* GF_LINUX_HOST_OS */
 
 out:
-        if (ret == -1) {
+        if (ret < 0) {
                 GFFUSE_LOGERR("ret = -1\n");
                 if (mounted)
                         umount2 (mountpoint, 2); /* lazy umount */
@@ -491,7 +491,7 @@ gf_fuse_mount (const char *mountpoint, char *fsname,
                 }
 
                 ret = fuse_mount_sys (mountpoint, fsname, mnt_param, fd);
-                if (ret == -1) {
+                if (ret < 0) {
                         gf_log ("glusterfs-fuse", GF_LOG_INFO,
                                 "direct mount failed (%s) errno %d",
                                 strerror (errno), errno);
@@ -505,7 +505,7 @@ gf_fuse_mount (const char *mountpoint, char *fsname,
                         }
                 }
 
-                if (ret == -1)
+                if (ret < 0)
                         GFFUSE_LOGERR ("mount of %s to %s (%s) failed",
                                        fsname, mountpoint, mnt_param);
 

--- a/contrib/macfuse/mount_darwin.c
+++ b/contrib/macfuse/mount_darwin.c
@@ -214,7 +214,7 @@ mount:
         }
         ret = fd;
 err:
-        if (ret == -1) {
+        if (ret < 0) {
                 if (fd > 0) {
                         close(fd);
                 }

--- a/doc/developer-guide/coding-standard.md
+++ b/doc/developer-guide/coding-standard.md
@@ -241,7 +241,7 @@ even existed) and boolean negation.
 *Bad:*
 
 ```
-if (op_ret == -1 && errno != ENOENT)
+if (IS_ERROR(op_ret) && errno != ENOENT)
 ++foo->bar      /* incrementing foo, or incrementing foo->bar? */
 a && b || !c
 ```
@@ -249,7 +249,7 @@ a && b || !c
 *Good:*
 
 ```
-if ((op_ret == -1) && (errno != ENOENT))
+if (IS_ERROR(op_ret) && (errno != ENOENT))
 (++foo)->bar
 ++(foo->bar)
 (a && b) || !c
@@ -674,7 +674,7 @@ sample_fop (call_frame_t *frame, xlator_t *this, ...)
         /* ... */
 
  out:
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
 
           /* check for all the cleanup that needs to be
              done */

--- a/extras/benchmarking/glfs-bm.c
+++ b/extras/benchmarking/glfs-bm.c
@@ -157,7 +157,7 @@ do_mode_posix_iface_fileio_write(struct state *state)
         sprintf(filename, "%s.%06ld", state->prefix, i);
 
         fd = open(filename, O_CREAT | O_WRONLY, 00600);
-        if (fd == -1) {
+        if (IS_ERROR(fd)) {
             fprintf(stderr, "open(%s) => %s\n", filename, strerror(errno));
             break;
         }
@@ -189,12 +189,12 @@ do_mode_posix_iface_fileio_read(struct state *state)
         sprintf(filename, "%s.%06ld", state->prefix, i);
 
         fd = open(filename, O_RDONLY);
-        if (fd == -1) {
+        if (IS_ERROR(fd)) {
             fprintf(stderr, "open(%s) => %s\n", filename, strerror(errno));
             break;
         }
         ret = read(fd, block, state->block_size);
-        if (ret == -1) {
+        if (ret < 0) {
             fprintf(stderr, "read(%s) => %d/%s\n", filename, ret,
                     strerror(errno));
             close(fd);

--- a/extras/snap_scheduler/snap_scheduler.py
+++ b/extras/snap_scheduler/snap_scheduler.py
@@ -600,7 +600,7 @@ def get_selinux_status():
 
 def set_cronjob_user_share():
     selinux_status = get_selinux_status()
-    if (selinux_status == -1):
+    if (IS_ERROR(selinux_status)):
         log.error("Failed to get selinux status")
         return -1
     elif (selinux_status == "Disabled"):

--- a/extras/test/ld-preload-test/ld-preload-test.c
+++ b/extras/test/ld-preload-test/ld-preload-test.c
@@ -57,7 +57,7 @@ check_err(int ret, char *call, int tabs)
         fprintf(stdout, "\t");
         --tabs;
     }
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         fprintf(stdout, "Not intercepted: %s\n", call);
         return;
     }

--- a/extras/test/ld-preload-test/ld-preload-test.c
+++ b/extras/test/ld-preload-test/ld-preload-test.c
@@ -57,7 +57,7 @@ check_err(int ret, char *call, int tabs)
         fprintf(stdout, "\t");
         --tabs;
     }
-    if (ret != -1) {
+    if (ret >= 0) {
         fprintf(stdout, "Not intercepted: %s\n", call);
         return;
     }

--- a/geo-replication/src/gsyncd.c
+++ b/geo-replication/src/gsyncd.c
@@ -84,7 +84,7 @@ str2argv(char *str, char ***argv)
         argc++;
         if (argc == argv_len) {
             ret = duplexpand((void *)argv, sizeof(**argv), &argv_len);
-            if (ret == -1)
+            if (IS_ERROR(ret))
                 goto error;
         }
         temp1 = strdup(p);
@@ -161,7 +161,7 @@ find_gsyncd(pid_t pid, pid_t ppid, char *name, void *data)
         return 0;
     ret = sys_read(fd, buf, sizeof(buf));
     sys_close(fd);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         return 0;
     for (zeros = 0, p = buf; zeros < 2 && p < buf + ret; p++)
         zeros += !*p;
@@ -224,7 +224,7 @@ invoke_rsync(int argc, char **argv)
     /* look up sshd we are spawned from */
     for (pid = getpid();; pid = ppid) {
         ppid = pidinfo(pid, &name);
-        if (ppid < 0) {
+        if (IS_ERROR(ppid)) {
             fprintf(stderr, "sshd ancestor not found\n");
             goto error;
         }
@@ -237,14 +237,14 @@ invoke_rsync(int argc, char **argv)
     /* look up "ssh-sibling" gsyncd */
     pida[0] = pid;
     ret = prociter(find_gsyncd, pida);
-    if (ret == -1 || pida[1] == -1) {
+    if (IS_ERROR(ret) || pida[1] == -1) {
         fprintf(stderr, "gsyncd sibling not found\n");
         goto error;
     }
     /* check if rsync target matches gsyncd target */
     snprintf(path, sizeof path, PROC "/%d/cwd", pida[1]);
     ret = sys_readlink(path, buf, sizeof(buf));
-    if (ret == -1 || ret == sizeof(buf))
+    if (IS_ERROR(ret) || ret == sizeof(buf))
         goto error;
     if (strcmp(argv[argc - 1], "/") == 0 /* root dir cannot be a target */ ||
         (strcmp(argv[argc - 1], path) /* match against gluster target */ &&

--- a/geo-replication/src/procdiggy.c
+++ b/geo-replication/src/procdiggy.c
@@ -74,7 +74,7 @@ pidinfo(pid_t pid, char **name)
     while (isspace(*++p))
         ;
     ret = gf_string2int(p, &lpid);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         lpid = -1;
 
 out:

--- a/geo-replication/src/procdiggy.c
+++ b/geo-replication/src/procdiggy.c
@@ -112,7 +112,7 @@ prociter(int (*proch)(pid_t pid, pid_t ppid, char *tmpname, void *data),
         if (!de || errno != 0)
             break;
 
-        if (gf_string2int(de->d_name, &pid) != -1 && pid >= 0) {
+        if (IS_SUCCESS(gf_string2int(de->d_name, &pid)) && pid) {
             ppid = pidinfo(pid, &name);
             switch (ppid) {
                 case -1:

--- a/glusterfsd/src/gf_attach.c
+++ b/glusterfsd/src/gf_attach.c
@@ -82,7 +82,7 @@ send_brick_req(xlator_t *this, struct rpc_clnt *rpc, char *path, int op)
 
     /* Create the xdr payload */
     ret = xdr_serialize_generic(iov, req, (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     iov.iov_len = ret;

--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -116,7 +116,7 @@ mgmt_process_volfile(const char *volfile, ssize_t size, char *volfile_id,
 
         /* coverity[secure_temp] mkstemp uses 0600 as the mode */
         tmp_fd = mkstemp(template);
-        if (-1 == tmp_fd) {
+        if (IS_ERROR(tmp_fd)) {
             UNLOCK(&ctx->volfile_lock);
             gf_smsg(THIS->name, GF_LOG_ERROR, 0, glusterfsd_msg_39,
                     "create template=%s", template, NULL);
@@ -128,7 +128,7 @@ mgmt_process_volfile(const char *volfile, ssize_t size, char *volfile_id,
          * terminates the temporary file is deleted.
          */
         ret = sys_unlink(template);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_smsg(THIS->name, GF_LOG_INFO, 0, glusterfsd_msg_39,
                     "delete template=%s", template, NULL);
             ret = 0;
@@ -157,7 +157,7 @@ mgmt_process_volfile(const char *volfile, ssize_t size, char *volfile_id,
         }
         ret = glusterfs_mux_volfile_reconfigure(tmpfp, ctx, volfile_obj,
                                                 sha256_hash, dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg_debug("glusterfsd-mgmt", EINVAL, "Reconfigure failed !!");
         }
     }
@@ -203,14 +203,14 @@ glusterfs_serialize_reply(rpcsvc_request_t *req, void *arg,
      * need -1 for error notification during encoding.
      */
     retlen = xdr_serialize_generic(*outmsg, arg, xdrproc);
-    if (retlen == -1) {
+    if (IS_ERROR(retlen)) {
         gf_log(THIS->name, GF_LOG_ERROR, "Failed to encode message");
         goto ret;
     }
 
     outmsg->iov_len = retlen;
 ret:
-    if (retlen == -1) {
+    if (IS_ERROR(retlen)) {
         iob = NULL;
     }
 
@@ -257,7 +257,7 @@ glusterfs_submit_reply(rpcsvc_request_t *req, void *arg, struct iovec *payload,
      * we can safely unref the iob in the hope that RPC layer must have
      * ref'ed the iob on receiving into the txlist.
      */
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(THIS->name, GF_LOG_ERROR, "Reply submission failed");
         goto out;
     }
@@ -318,7 +318,7 @@ glusterfs_handle_terminate(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &xlator_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         return -1;
     }
@@ -493,7 +493,7 @@ glusterfs_handle_translator_info_get(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &xlator_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         goto out;
@@ -502,7 +502,7 @@ glusterfs_handle_translator_info_get(rpcsvc_request_t *req)
     dict = dict_new();
     ret = dict_unserialize(xlator_req.input.input_val,
                            xlator_req.input.input_len, &dict);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_ERROR,
                "failed to "
                "unserialize req-buffer to dictionary");
@@ -606,7 +606,7 @@ glusterfs_volume_top_perf(const char *brick_path, dict_t *dict,
     snprintf(export_path, sizeof(export_path), "%s/%s", brick_path,
              ".gf-tmp-stats-perf");
     fd = open(export_path, O_CREAT | O_RDWR, S_IRWXU);
-    if (-1 == fd) {
+    if (IS_ERROR(fd)) {
         ret = -1;
         gf_log("glusterd", GF_LOG_ERROR, "Could not open tmp file");
         goto out;
@@ -655,7 +655,7 @@ glusterfs_volume_top_perf(const char *brick_path, dict_t *dict,
     }
 
     output_fd = open("/dev/null", O_RDWR);
-    if (-1 == output_fd) {
+    if (IS_ERROR(output_fd)) {
         ret = -1;
         gf_log("glusterd", GF_LOG_ERROR, "Could not open output file");
         goto out;
@@ -737,7 +737,7 @@ glusterfs_handle_translator_op(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &xlator_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         goto out;
@@ -755,7 +755,7 @@ glusterfs_handle_translator_op(rpcsvc_request_t *req)
     input = dict_new();
     ret = dict_unserialize(xlator_req.input.input_val,
                            xlator_req.input.input_len, &input);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_ERROR,
                "failed to "
                "unserialize req-buffer to dictionary");
@@ -842,7 +842,7 @@ glusterfs_handle_bitrot(rpcsvc_request_t *req)
     ret = xdr_to_generic(req->msg[0], &xlator_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /*failed to decode msg;*/
         req->rpc_err = GARBAGE_ARGS;
         goto out;
@@ -866,7 +866,7 @@ glusterfs_handle_bitrot(rpcsvc_request_t *req)
     ret = dict_unserialize(xlator_req.input.input_val,
                            xlator_req.input.input_len, &input);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, glusterfsd_msg_35, NULL);
         goto out;
     }
@@ -949,7 +949,7 @@ glusterfs_handle_attach(rpcsvc_request_t *req)
     ret = xdr_to_generic(req->msg[0], &xlator_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /*failed to decode msg;*/
         req->rpc_err = GARBAGE_ARGS;
         return -1;
@@ -1024,7 +1024,7 @@ glusterfs_handle_svc_attach(rpcsvc_request_t *req)
     ret = xdr_to_generic(req->msg[0], &xlator_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /*failed to decode msg;*/
         req->rpc_err = GARBAGE_ARGS;
         goto out;
@@ -1077,7 +1077,7 @@ glusterfs_handle_svc_detach(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &xlator_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         return -1;
     }
@@ -1146,7 +1146,7 @@ glusterfs_handle_dump_metrics(rpcsvc_request_t *req)
     ret = xdr_to_generic(req->msg[0], &xlator_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /*failed to decode msg;*/
         req->rpc_err = GARBAGE_ARGS;
         return -1;
@@ -1160,10 +1160,10 @@ glusterfs_handle_dump_metrics(rpcsvc_request_t *req)
         goto out;
 
     fd = sys_open(filepath, O_RDONLY, 0);
-    if (fd < 0)
+    if (IS_ERROR(fd))
         goto out;
 
-    if (sys_fstat(fd, &statbuf) < 0)
+    if (IS_ERROR(sys_fstat(fd, &statbuf)))
         goto out;
 
     if (statbuf.st_size > GF_UNIT_MB) {
@@ -1175,7 +1175,7 @@ glusterfs_handle_dump_metrics(rpcsvc_request_t *req)
         goto out;
 
     ret = sys_read(fd, msg, statbuf.st_size);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     /* Send all the data in errstr, instead of dictionary for now */
@@ -1228,7 +1228,7 @@ glusterfs_handle_defrag(rpcsvc_request_t *req)
     any = active->first;
     ret = xdr_to_generic(req->msg[0], &xlator_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         goto out;
@@ -1239,7 +1239,7 @@ glusterfs_handle_defrag(rpcsvc_request_t *req)
 
     ret = dict_unserialize(xlator_req.input.input_val,
                            xlator_req.input.input_len, &dict);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_ERROR,
                "failed to "
                "unserialize req-buffer to dictionary");
@@ -1299,7 +1299,7 @@ glusterfs_handle_brick_status(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &brick_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto out;
     }
@@ -1307,7 +1307,7 @@ glusterfs_handle_brick_status(rpcsvc_request_t *req)
     dict = dict_new();
     ret = dict_unserialize(brick_req.input.input_val, brick_req.input.input_len,
                            &dict);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_ERROR,
                "Failed to unserialize "
                "req-buffer to dictionary");
@@ -1449,7 +1449,7 @@ glusterfs_handle_node_status(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &node_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto out;
     }
@@ -1457,7 +1457,7 @@ glusterfs_handle_node_status(rpcsvc_request_t *req)
     dict = dict_new();
     ret = dict_unserialize(node_req.input.input_val, node_req.input.input_len,
                            &dict);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(THIS->name, GF_LOG_ERROR,
                "Failed to unserialize "
                "req buffer to dictionary");
@@ -1503,7 +1503,7 @@ glusterfs_handle_node_status(rpcsvc_request_t *req)
         ret = -1;
         goto out;
     }
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(THIS->name, GF_LOG_ERROR, "Failed to set node xlator name");
         goto out;
     }
@@ -1529,7 +1529,7 @@ glusterfs_handle_node_status(rpcsvc_request_t *req)
         ret = -1;
         goto out;
     }
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(THIS->name, GF_LOG_ERROR, "Failed to set node xlator name");
         goto out;
     }
@@ -1643,7 +1643,7 @@ glusterfs_handle_nfs_profile(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &nfs_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto out;
     }
@@ -1651,7 +1651,7 @@ glusterfs_handle_nfs_profile(rpcsvc_request_t *req)
     dict = dict_new();
     ret = dict_unserialize(nfs_req.input.input_val, nfs_req.input.input_len,
                            &dict);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(THIS->name, GF_LOG_ERROR,
                "Failed to "
                "unserialize req-buffer to dict");
@@ -1758,7 +1758,7 @@ glusterfs_handle_volume_barrier_op(rpcsvc_request_t *req)
     any = active->first;
     ret = xdr_to_generic(req->msg[0], &xlator_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         goto out;
@@ -1769,7 +1769,7 @@ glusterfs_handle_volume_barrier_op(rpcsvc_request_t *req)
 
     ret = dict_unserialize(xlator_req.input.input_val,
                            xlator_req.input.input_len, &dict);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_ERROR,
                "failed to "
                "unserialize req-buffer to dictionary");
@@ -1826,7 +1826,7 @@ glusterfs_handle_barrier(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &brick_req,
                          (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto out;
     }
@@ -1860,7 +1860,7 @@ glusterfs_handle_barrier(rpcsvc_request_t *req)
 
     ret = dict_unserialize(brick_req.input.input_val, brick_req.input.input_len,
                            &dict);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(THIS->name, GF_LOG_ERROR,
                "Failed to unserialize "
                "request dictionary");
@@ -2073,7 +2073,7 @@ mgmt_submit_request(void *req, call_frame_t *frame, glusterfs_ctx_t *ctx,
 
         /* Create the xdr payload */
         ret = xdr_serialize_generic(iov, req, xdrproc);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_log(THIS->name, GF_LOG_WARNING, "failed to create XDR payload");
             goto out;
         }
@@ -2120,19 +2120,19 @@ mgmt_getspec_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     ctx = frame->this->ctx;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         ret = -1;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_getspec_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, "XDR decoding error");
         ret = -1;
         goto out;
     }
 
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR,
                "failed to get the 'volume file' from server");
         ret = rsp.op_errno;
@@ -2211,7 +2211,7 @@ volfile:
 
         /* coverity[secure_temp] mkstemp uses 0600 as the mode */
         tmp_fd = mkstemp(template);
-        if (-1 == tmp_fd) {
+        if (IS_ERROR(tmp_fd)) {
             UNLOCK(&ctx->volfile_lock);
             gf_smsg(frame->this->name, GF_LOG_ERROR, 0, glusterfsd_msg_39,
                     "create template=%s", template, NULL);
@@ -2223,7 +2223,7 @@ volfile:
          * terminates the temporary file is deleted.
          */
         ret = sys_unlink(template);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_smsg(frame->this->name, GF_LOG_INFO, 0, glusterfsd_msg_39,
                     "delete template=%s", template, NULL);
             ret = 0;
@@ -2268,7 +2268,7 @@ volfile:
             goto out;
         }
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             UNLOCK(&ctx->volfile_lock);
             gf_log("glusterfsd-mgmt", GF_LOG_DEBUG, "Reconfigure failed !!");
             goto post_unlock;
@@ -2427,7 +2427,7 @@ glusterfs_volfile_fetch_one(glusterfs_ctx_t *ctx, char *volfile_id)
 
     ret = dict_allocate_and_serialize(dict, &req.xdata.xdata_val,
                                       &req.xdata.xdata_len);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(THIS->name, GF_LOG_ERROR, "Failed to serialize dictionary");
         goto out;
     }
@@ -2504,19 +2504,19 @@ mgmt_event_notify_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         ret = -1;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_event_notify_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, "XDR decoding error");
         ret = -1;
         goto out;
     }
 
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR,
                "failed to get the rsp from server");
         ret = -1;
@@ -2539,7 +2539,7 @@ glusterfs_rebalance_event_notify_cbk(struct rpc_req *req, struct iovec *iov,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_log(frame->this->name, GF_LOG_ERROR,
                "failed to get the rsp from server");
         ret = -1;
@@ -2547,13 +2547,13 @@ glusterfs_rebalance_event_notify_cbk(struct rpc_req *req, struct iovec *iov,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_event_notify_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, "XDR decoding error");
         ret = -1;
         goto out;
     }
 
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR,
                "Received error (%s) from server", strerror(rsp.op_errno));
         ret = -1;
@@ -2903,7 +2903,7 @@ mgmt_pmap_signin2_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ctx = glusterfsd_ctx;
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         ret = -1;
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2911,14 +2911,14 @@ mgmt_pmap_signin2_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_pmap_signin_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, "XDR decode error");
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
         goto out;
     }
 
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR,
                "failed to register the port with glusterd");
         ret = -1;
@@ -2957,7 +2957,7 @@ mgmt_pmap_signin_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ctx = glusterfsd_ctx;
     cmd_args = &ctx->cmd_args;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         ret = -1;
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
@@ -2965,14 +2965,14 @@ mgmt_pmap_signin_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_pmap_signin_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, "XDR decode error");
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
         goto out;
     }
 
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR,
                "failed to register the port with glusterd");
         ret = -1;
@@ -2998,7 +2998,7 @@ mgmt_pmap_signin_cbk(struct rpc_req *req, struct iovec *iov, int count,
     return 0;
 
 out:
-    if (need_emancipate && (ret < 0 || !cmd_args->brick_port2))
+    if (need_emancipate && (IS_ERROR(ret) || !cmd_args->brick_port2))
         emancipate(ctx, emancipate_ret);
 
     STACK_DESTROY(frame->root);
@@ -3038,7 +3038,7 @@ glusterfs_mgmt_pmap_signin(glusterfs_ctx_t *ctx)
             ret = mgmt_submit_request(&req, frame, ctx, &clnt_pmap_prog,
                                       GF_PMAP_SIGNIN, mgmt_pmap_signin_cbk,
                                       (xdrproc_t)xdr_pmap_signin_req);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_log(THIS->name, GF_LOG_WARNING,
                        "failed to send sign in request; brick = %s", req.brick);
             }
@@ -3048,7 +3048,7 @@ glusterfs_mgmt_pmap_signin(glusterfs_ctx_t *ctx)
     /* unfortunately, the caller doesn't care about the returned value */
 
 out:
-    if (need_emancipate && ret < 0)
+    if (need_emancipate && IS_ERROR(ret))
         emancipate(ctx, emancipate_ret);
     return ret;
 }

--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -692,9 +692,9 @@ glusterfs_volume_top_perf(const char *brick_path, dict_t *dict,
            throughput, time, total_blks);
     ret = 0;
 out:
-    if (fd >= 0)
+    if (IS_SUCCESS(fd))
         sys_close(fd);
-    if (output_fd >= 0)
+    if (IS_SUCCESS(output_fd))
         sys_close(output_fd);
     GF_FREE(buf);
     sys_unlink(export_path);
@@ -1183,7 +1183,7 @@ glusterfs_handle_dump_metrics(rpcsvc_request_t *req)
 
     ret = 0;
 out:
-    if (fd >= 0)
+    if (IS_SUCCESS(fd))
         sys_close(fd);
 
     GF_FREE(msg);

--- a/glusterfsd/src/glusterfsd.c
+++ b/glusterfsd/src/glusterfsd.c
@@ -335,17 +335,17 @@ set_fuse_mount_options(glusterfs_ctx_t *ctx, dict_t *options)
     DICT_SET_VAL(dict_set_dynstr_sizen, options, ZR_MOUNTPOINT_OPT, mount_point,
                  glusterfsd_msg_3);
 
-    if (cmd_args->fuse_attribute_timeout >= 0) {
+    if (IS_SUCCESS(cmd_args->fuse_attribute_timeout)) {
         DICT_SET_VAL(dict_set_double, options, ZR_ATTR_TIMEOUT_OPT,
                      cmd_args->fuse_attribute_timeout, glusterfsd_msg_3);
     }
 
-    if (cmd_args->fuse_entry_timeout >= 0) {
+    if (IS_SUCCESS(cmd_args->fuse_entry_timeout)) {
         DICT_SET_VAL(dict_set_double, options, ZR_ENTRY_TIMEOUT_OPT,
                      cmd_args->fuse_entry_timeout, glusterfsd_msg_3);
     }
 
-    if (cmd_args->fuse_negative_timeout >= 0) {
+    if (IS_SUCCESS(cmd_args->fuse_negative_timeout)) {
         DICT_SET_VAL(dict_set_double, options, ZR_NEGATIVE_TIMEOUT_OPT,
                      cmd_args->fuse_negative_timeout, glusterfsd_msg_3);
     }
@@ -426,12 +426,12 @@ set_fuse_mount_options(glusterfs_ctx_t *ctx, dict_t *options)
                      glusterfsd_msg_3);
     }
 
-    if (cmd_args->lru_limit >= 0) {
+    if (IS_SUCCESS(cmd_args->lru_limit)) {
         DICT_SET_VAL(dict_set_int32_sizen, options, "lru-limit",
                      cmd_args->lru_limit, glusterfsd_msg_3);
     }
 
-    if (cmd_args->invalidate_limit >= 0) {
+    if (IS_SUCCESS(cmd_args->invalidate_limit)) {
         DICT_SET_VAL(dict_set_int32_sizen, options, "invalidate-limit",
                      cmd_args->invalidate_limit, glusterfsd_msg_3);
     }

--- a/heal/src/glfs-heal.c
+++ b/heal/src/glfs-heal.c
@@ -268,9 +268,9 @@ glfsh_print_xml_heal_op_status(int ret, uint64_t num_entries, char *fmt_str)
         }
     }
 out:
-    if (x_ret >= 0) {
+    if (IS_SUCCESS(x_ret)) {
         x_ret = xmlTextWriterEndElement(glfsh_writer);
-        if (x_ret >= 0) {
+        if (IS_SUCCESS(x_ret)) {
             xmlTextWriterFlush(glfsh_writer);
             x_ret = 0;
         } else {
@@ -335,7 +335,7 @@ glfsh_print_xml_heal_op_summary(int ret, num_entries_t *num_entries)
         XML_RET_CHECK_AND_GOTO(x_ret, out);
     }
 out:
-    if (x_ret >= 0) {
+    if (IS_SUCCESS(x_ret)) {
         x_ret = xmlTextWriterEndElement(glfsh_writer);
     }
     return x_ret;

--- a/heal/src/glfs-heal.c
+++ b/heal/src/glfs-heal.c
@@ -31,7 +31,7 @@ xmlDocPtr glfsh_doc = NULL;
 
 #define XML_RET_CHECK_AND_GOTO(ret, label)                                     \
     do {                                                                       \
-        if (ret < 0) {                                                         \
+        if (IS_ERROR(ret)) {                                                   \
             ret = -1;                                                          \
             goto label;                                                        \
         } else                                                                 \
@@ -94,7 +94,7 @@ glfsh_end_op_granular_entry_heal(int op_ret, char *op_errstr)
 
     if (op_errstr) {
         printf("%s\n", op_errstr);
-    } else if (op_ret < 0) {
+    } else if (IS_ERROR(op_ret)) {
         if (op_ret == -EAGAIN)
             printf(
                 "One or more entries need heal. Please execute "
@@ -181,7 +181,7 @@ glfsh_xml_end(int op_ret, char *op_errstr)
     int op_errno = 0;
     gf_boolean_t alloc = _gf_false;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         op_errno = -op_ret;
         op_ret = -1;
         if (op_errstr == NULL) {
@@ -234,7 +234,7 @@ int
 glfsh_print_xml_heal_op_status(int ret, uint64_t num_entries, char *fmt_str)
 {
     int x_ret = 0;
-    if (ret < 0 && num_entries == 0) {
+    if (IS_ERROR(ret) && num_entries == 0) {
         x_ret = xmlTextWriterWriteFormatElement(
             glfsh_writer, (xmlChar *)"status", "%s", strerror(-ret));
         XML_RET_CHECK_AND_GOTO(x_ret, out);
@@ -250,7 +250,7 @@ glfsh_print_xml_heal_op_status(int ret, uint64_t num_entries, char *fmt_str)
         XML_RET_CHECK_AND_GOTO(x_ret, out);
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (fmt_str) {
             x_ret = xmlTextWriterWriteFormatElement(
                 glfsh_writer, (xmlChar *)"status",
@@ -285,7 +285,7 @@ glfsh_print_xml_heal_op_summary(int ret, num_entries_t *num_entries)
 {
     int x_ret = 0;
 
-    if (ret < 0 && num_entries == 0) {
+    if (IS_ERROR(ret) && num_entries == 0) {
         x_ret = xmlTextWriterWriteFormatElement(
             glfsh_writer, (xmlChar *)"status", "%s", strerror(-ret));
         XML_RET_CHECK_AND_GOTO(x_ret, out);
@@ -308,7 +308,7 @@ glfsh_print_xml_heal_op_summary(int ret, num_entries_t *num_entries)
         XML_RET_CHECK_AND_GOTO(x_ret, out);
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         x_ret = xmlTextWriterWriteFormatElement(
             glfsh_writer, (xmlChar *)"status",
             "Failed to process entries"
@@ -370,19 +370,19 @@ glfsh_print_xml_brick_from_xl(xlator_t *xl, loc_t *rootloc)
     int x_ret = 0;
 
     ret = dict_get_str(xl->options, "remote-host", &remote_host);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto print;
 
     ret = dict_get_str(xl->options, "remote-subvolume", &remote_subvol);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto print;
     ret = syncop_getxattr(xl, rootloc, &xl->options, GF_XATTR_NODE_UUID_KEY,
                           NULL, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto print;
 
     ret = dict_get_str(xl->options, GF_XATTR_NODE_UUID_KEY, &uuid);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto print;
 print:
 
@@ -428,7 +428,7 @@ glfsh_no_print_hr_heal_op_status(int ret, uint64_t num_entries, char *fmt_str)
 int
 glfsh_print_hr_heal_op_summary(int ret, num_entries_t *num_entries)
 {
-    if (ret < 0 && num_entries->num_entries == 0) {
+    if (IS_ERROR(ret) && num_entries->num_entries == 0) {
         printf("Status: %s\n", strerror(-ret));
         printf("Total Number of entries: -\n");
         printf("Number of entries in heal pending: -\n");
@@ -439,7 +439,7 @@ glfsh_print_hr_heal_op_summary(int ret, num_entries_t *num_entries)
         printf("Status: Connected\n");
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         printf(
             "Status: Failed to process entries completely. "
             "(%s)\nTotal Number of entries: %" PRIu64 "\n",
@@ -463,7 +463,7 @@ out:
 int
 glfsh_print_hr_heal_op_status(int ret, uint64_t num_entries, char *fmt_str)
 {
-    if (ret < 0 && num_entries == 0) {
+    if (IS_ERROR(ret) && num_entries == 0) {
         printf("Status: %s\n", strerror(-ret));
         if (fmt_str)
             printf("%s -\n", fmt_str);
@@ -472,7 +472,7 @@ glfsh_print_hr_heal_op_status(int ret, uint64_t num_entries, char *fmt_str)
         printf("Status: Connected\n");
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (fmt_str)
             printf(
                 "Status: Failed to process entries completely. "
@@ -520,13 +520,13 @@ glfsh_get_index_dir_loc(loc_t *rootloc, xlator_t *xl, loc_t *dirloc,
     struct iatt parent = {0};
 
     ret = syncop_getxattr(xl, rootloc, &xattr, vgfid, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         *op_errno = -ret;
         goto out;
     }
 
     ret = dict_get_ptr(xattr, vgfid, &index_gfid);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         *op_errno = EINVAL;
         goto out;
     }
@@ -536,7 +536,7 @@ glfsh_get_index_dir_loc(loc_t *rootloc, xlator_t *xl, loc_t *dirloc,
     dirloc->inode = inode_new(rootloc->inode->table);
     ret = syncop_lookup(xl, dirloc, &iattr, &parent, NULL, NULL);
     dirloc->path = NULL;
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         *op_errno = -ret;
         goto out;
     }
@@ -545,7 +545,7 @@ glfsh_get_index_dir_loc(loc_t *rootloc, xlator_t *xl, loc_t *dirloc,
         goto out;
 
     ret = glfs_loc_touchup(dirloc);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         *op_errno = errno;
         goto out;
     }
@@ -679,30 +679,30 @@ glfsh_print_heal_status(dict_t *dict, char *path, uuid_t gfid,
 
     if (!strcmp(value, "heal")) {
         ret = gf_asprintf(&status, " ");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     } else if (!strcmp(value, "possibly-healing")) {
         ret = gf_asprintf(&status, " - Possibly undergoing heal");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     } else if (!strcmp(value, "split-brain")) {
         ret = gf_asprintf(&status, " - Is in split-brain");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     } else if (!strcmp(value, "heal-pending")) {
         pending = _gf_true;
         ret = gf_asprintf(&status, " ");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     } else if (!strcmp(value, "split-brain-pending")) {
         pending = _gf_true;
         ret = gf_asprintf(&status, " - Is in split-brain");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     } else if (!strcmp(value, "possibly-healing-pending")) {
         pending = _gf_true;
         ret = gf_asprintf(&status, " - Possibly undergoing heal");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 out:
@@ -719,7 +719,7 @@ out:
             return 0;
         }
     }
-    if (ret == -1)
+    if (IS_ERROR(ret))
         status = NULL;
 
     (num_entries->num_entries)++;
@@ -875,19 +875,19 @@ glfsh_crawl_directory(glfs_t *fs, xlator_t *top_subvol, loc_t *rootloc,
             ret = glfsh_process_entries(readdir_xl, fd, &entries, &offset,
                                         num_entries, glfsh_print_heal_status,
                                         ignore, mode);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
         } else if (heal_op == GF_SHD_OP_SPLIT_BRAIN_FILES) {
             ret = glfsh_process_entries(readdir_xl, fd, &entries, &offset,
                                         num_entries, glfsh_print_spb_status,
                                         ignore, mode);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
         } else if (heal_op == GF_SHD_OP_HEAL_SUMMARY) {
             ret = glfsh_process_entries(readdir_xl, fd, &entries, &offset,
                                         num_entries, glfsh_print_summary_status,
                                         ignore, mode);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
         } else if (heal_op == GF_SHD_OP_SBRAIN_HEAL_FROM_BRICK) {
             glfsh_heal_entries(fs, top_subvol, rootloc, &entries, &offset,
@@ -896,7 +896,7 @@ glfsh_crawl_directory(glfs_t *fs, xlator_t *top_subvol, loc_t *rootloc,
             ret = glfsh_process_entries(readdir_xl, fd, &entries, &offset,
                                         num_entries, glfsh_heal_status_boolean,
                                         ignore, mode);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
         }
         gf_dirent_free(&entries);
@@ -923,14 +923,14 @@ glfsh_print_brick_from_xl(xlator_t *xl, loc_t *rootloc)
     int ret = 0;
 
     ret = dict_get_str(xl->options, "remote-host", &remote_host);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_get_str(xl->options, "remote-subvolume", &remote_subvol);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 out:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         printf("Brick - Not able to get brick information\n");
     else
         printf("Brick %s:%s\n", remote_host, remote_subvol);
@@ -953,7 +953,7 @@ glfsh_print_pending_heals_type(glfs_t *fs, xlator_t *top_subvol, loc_t *rootloc,
         ignore = _gf_true;
 
     ret = glfsh_get_index_dir_loc(rootloc, xl, &dirloc, &op_errno, vgfid);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (op_errno == ESTALE || op_errno == ENOENT || op_errno == ENOTSUP)
             ret = 0;
         else
@@ -1004,14 +1004,14 @@ glfsh_print_pending_heals(glfs_t *fs, xlator_t *top_subvol, loc_t *rootloc,
     }
 
     ret = glfsh_output->print_brick_from_xl(xl, rootloc);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = glfsh_print_pending_heals_type(fs, top_subvol, rootloc, xl, heal_op,
                                          xattr_req, GF_XATTROP_INDEX_GFID,
                                          &num_entries);
 
-    if (ret < 0 && heal_op == GF_SHD_OP_GRANULAR_ENTRY_HEAL_ENABLE)
+    if (IS_ERROR(ret) && heal_op == GF_SHD_OP_GRANULAR_ENTRY_HEAL_ENABLE)
         goto out;
 
     total.num_entries += num_entries.num_entries;
@@ -1115,10 +1115,10 @@ _brick_path_to_client_xlator(xlator_t *top_subvol, char *hostname,
     while (xl) {
         if (!strcmp(xl->type, "protocol/client")) {
             ret = dict_get_str(xl->options, "remote-host", &remote_host);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
             ret = dict_get_str(xl->options, "remote-subvolume", &remote_subvol);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
             if (!strcmp(hostname, remote_host) &&
                 !strcmp(brickpath, remote_subvol))
@@ -1155,7 +1155,7 @@ glfsh_gather_heal_info(glfs_t *fs, xlator_t *top_subvol, loc_t *rootloc,
                     !strcmp(heal_xl->type, "cluster/replicate"));
                 THIS = old_THIS;
 
-                if ((ret < 0) &&
+                if (IS_ERROR(ret) &&
                     (heal_op == GF_SHD_OP_GRANULAR_ENTRY_HEAL_ENABLE))
                     goto out;
             }
@@ -1366,7 +1366,7 @@ glfsh_heal_from_brick_type(glfs_t *fs, xlator_t *top_subvol, loc_t *rootloc,
     int ret = -1;
 
     ret = glfsh_get_index_dir_loc(rootloc, client, &dirloc, &op_errno, vgfid);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (op_errno == ESTALE || op_errno == ENOENT)
             ret = 0;
         else
@@ -1433,7 +1433,7 @@ glfsh_heal_from_brick(glfs_t *fs, xlator_t *top_subvol, loc_t *rootloc,
                                          brickpath, client, xattr_req,
                                          GF_XATTROP_DIRTY_GFID, &num_entries);
         total.num_entries += num_entries.num_entries;
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 out:
@@ -1678,7 +1678,7 @@ main(int argc, char **argv)
     snprintf(logfilepath, sizeof(logfilepath),
              DEFAULT_HEAL_LOG_FILE_DIRECTORY "/glfsheal-%s.log", volname);
     ret = glfs_set_logging(fs, logfilepath, log_level);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -errno;
         gf_asprintf(&op_errstr,
                     "Failed to set the log file path, "
@@ -1694,7 +1694,7 @@ main(int argc, char **argv)
     }
 
     ret = glfs_init(fs);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -errno;
         if (errno == ENOENT) {
             gf_asprintf(&op_errstr, "Volume %s does not exist", volname);
@@ -1731,7 +1731,7 @@ main(int argc, char **argv)
                         : "replicate";
 
     ret = glfsh_validate_volume(top_subvol, heal_op);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -EINVAL;
         gf_asprintf(&op_errstr,
                     "This command is supported "
@@ -1742,7 +1742,7 @@ main(int argc, char **argv)
     }
     rootloc.inode = inode_ref(top_subvol->itable->root);
     ret = glfs_loc_touchup(&rootloc);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -errno;
         goto out;
     }
@@ -1769,7 +1769,7 @@ main(int argc, char **argv)
     }
 
     glfsh_output->end(ret, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         ret = -ret;
     loc_wipe(&rootloc);
     glfs_subvol_done(fs, top_subvol);

--- a/libglusterfs/src/async.c
+++ b/libglusterfs/src/async.c
@@ -330,7 +330,7 @@ gf_async_worker_create(void)
         worker = caa_container_of(node, gf_async_worker_t, stack);
 
         ret = gf_async_thread_create(&worker->thread, worker->id, worker);
-        if (caa_likely(ret >= 0)) {
+        if (IS_SUCCESS(caa_likely(ret))) {
             return 0;
         }
 

--- a/libglusterfs/src/circ-buff.c
+++ b/libglusterfs/src/circ-buff.c
@@ -55,7 +55,7 @@ __cb_add_entry_buffer(buffer_t *buffer, void *item)
 
         buffer->cb[buffer->w_index]->data = item;
         ret = gettimeofday(&buffer->cb[buffer->w_index]->tv, NULL);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             gf_msg_callingfn("circ-buff", GF_LOG_WARNING, 0,
                              LG_MSG_GETTIMEOFDAY_FAILED,
                              "getting time of the day failed");

--- a/libglusterfs/src/client_t.c
+++ b/libglusterfs/src/client_t.c
@@ -431,7 +431,7 @@ __client_ctx_set_int(client_t *client, void *key, void *value)
 
     for (index = 0; index < client->scratch_ctx.count; index++) {
         if (!client->scratch_ctx.ctx[index].ctx_key) {
-            if (set_idx == -1)
+            if (IS_ERROR(set_idx))
                 set_idx = index;
             /* don't break, to check if key already exists
                further on */
@@ -442,7 +442,7 @@ __client_ctx_set_int(client_t *client, void *key, void *value)
         }
     }
 
-    if (set_idx == -1) {
+    if (IS_ERROR(set_idx)) {
         ret = -1;
         goto out;
     }

--- a/libglusterfs/src/cluster-syncop.c
+++ b/libglusterfs/src/cluster-syncop.c
@@ -1077,7 +1077,7 @@ cluster_inodelk(xlator_t **subvols, unsigned char *on, int numsubvols,
                &loc, F_SETLK, &flock, NULL);
 
     for (i = 0; i < numsubvols; i++) {
-        if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == EAGAIN) {
             cluster_fop_success_fill(replies, numsubvols, locked_on);
             cluster_uninodelk(subvols, locked_on, numsubvols, replies, output,
                               frame, this, dom, inode, off, size);
@@ -1147,7 +1147,7 @@ cluster_entrylk(xlator_t **subvols, unsigned char *on, int numsubvols,
                &loc, name, ENTRYLK_LOCK_NB, ENTRYLK_WRLCK, NULL);
 
     for (i = 0; i < numsubvols; i++) {
-        if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == EAGAIN) {
             cluster_fop_success_fill(replies, numsubvols, locked_on);
             cluster_unentrylk(subvols, locked_on, numsubvols, replies, output,
                               frame, this, dom, inode, name);
@@ -1195,7 +1195,7 @@ cluster_tiebreaker_inodelk(xlator_t **subvols, unsigned char *on,
         /* TODO: If earlier subvols fail with an error other
          * than EAGAIN, we could still have 2 clients competing
          * for the lock*/
-        if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == EAGAIN) {
             cluster_fop_success_fill(replies, numsubvols, locked_on);
             cluster_uninodelk(subvols, locked_on, numsubvols, replies, output,
                               frame, this, dom, inode, off, size);
@@ -1239,7 +1239,7 @@ cluster_tiebreaker_entrylk(xlator_t **subvols, unsigned char *on,
             num_success++;
             continue;
         }
-        if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == EAGAIN) {
             cluster_fop_success_fill(replies, numsubvols, locked_on);
             cluster_unentrylk(subvols, locked_on, numsubvols, replies, output,
                               frame, this, dom, inode, name);

--- a/libglusterfs/src/cluster-syncop.c
+++ b/libglusterfs/src/cluster-syncop.c
@@ -98,7 +98,7 @@ cluster_fop_success_fill(default_args_cbk_t *replies, int numsubvols,
     int count = 0;
 
     for (i = 0; i < numsubvols; i++) {
-        if (replies[i].valid && replies[i].op_ret >= 0) {
+        if (IS_SUCCESS(replies[i].valid && replies[i].op_ret)) {
             success[i] = 1;
             count++;
         } else {

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -872,7 +872,7 @@ gf_dump_config_flags()
         int ret = -1;
 
         ret = gf_asprintf(&msg, "package-string: %s", PACKAGE_STRING);
-        if (ret >= 0) {
+        if (IS_SUCCESS(ret)) {
             gf_msg_plain_nomem(GF_LOG_ALERT, msg);
             GF_FREE(msg);
         }
@@ -2956,7 +2956,7 @@ gf_array_insertionsort(void *A, int l, int r, size_t elem_size, gf_cmp cmp)
     for (i = l; i < N; i++) {
         Temp = gf_array_elem(A, i, elem_size);
         j = i - 1;
-        while ((j >= 0) &&
+        while (IS_SUCCESS((j)) &&
                IS_ERROR(cmp(Temp, gf_array_elem(A, j, elem_size)))) {
             gf_elem_swap(Temp, gf_array_elem(A, j, elem_size), elem_size);
             Temp = gf_array_elem(A, j, elem_size);
@@ -5231,7 +5231,7 @@ gf_getgrouplist(const char *user, gid_t group, gid_t **groups)
     for (;;) {
         int ngroups_old = ngroups;
         ret = getgrouplist(user, group, *groups, &ngroups);
-        if (ret >= 0)
+        if (IS_SUCCESS(ret))
             break;
 
         if (ngroups >= GF_MAX_AUX_GROUPS) {

--- a/libglusterfs/src/common-utils.c
+++ b/libglusterfs/src/common-utils.c
@@ -488,7 +488,7 @@ gf_resolve_ip6(const char *hostname, uint16_t port, int family, void **dnscache,
         hints.ai_socktype = SOCK_STREAM;
 
         ret = gf_asprintf(&port_str, "%d", port);
-        if (-1 == ret) {
+        if (IS_ERROR(ret)) {
             return -1;
         }
         if ((ret = getaddrinfo(hostname, port_str, &hints, &cache->first)) !=
@@ -702,13 +702,13 @@ nprintf(struct xldump *dump, const char *fmt, ...)
     int ret = 0;
 
     ret = snprintf(header, 32, "%3d:", ++dump->lineno);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     va_start(ap, fmt);
     ret = vasprintf(&msg, fmt, ap);
     va_end(ap);
-    if (-1 == ret)
+    if (IS_ERROR(ret))
         goto out;
 
     /* NOTE: No ret value from gf_msg_plain, so unable to compute printed
@@ -1668,27 +1668,27 @@ gf_uint64_2human_readable(uint64_t n)
 
     if (n >= GF_UNIT_PB) {
         ret = gf_asprintf(&str, "%.1lfPB", ((double)n) / GF_UNIT_PB);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto err;
     } else if (n >= GF_UNIT_TB) {
         ret = gf_asprintf(&str, "%.1lfTB", ((double)n) / GF_UNIT_TB);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto err;
     } else if (n >= GF_UNIT_GB) {
         ret = gf_asprintf(&str, "%.1lfGB", ((double)n) / GF_UNIT_GB);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto err;
     } else if (n >= GF_UNIT_MB) {
         ret = gf_asprintf(&str, "%.1lfMB", ((double)n) / GF_UNIT_MB);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto err;
     } else if (n >= GF_UNIT_KB) {
         ret = gf_asprintf(&str, "%.1lfKB", ((double)n) / GF_UNIT_KB);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto err;
     } else {
         ret = gf_asprintf(&str, "%" PRIu64 "Bytes", n);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto err;
     }
     return str;
@@ -1767,13 +1767,13 @@ gf_string2bytesize_range(const char *str, uint64_t *n, uint64_t umax)
     }
 
     if (fraction) {
-        if ((max - value) < 0) {
+        if (IS_ERROR((max - value))) {
             errno = ERANGE;
             return -1;
         }
         *n = (uint64_t)value;
     } else {
-        if ((max - int_value) < 0) {
+        if (IS_ERROR((max - int_value))) {
             errno = ERANGE;
             return -1;
         }
@@ -1855,7 +1855,7 @@ gf_string2percent_or_bytesize(const char *str, double *n,
     }
 
     /* Error out if we cannot store the value in uint64 */
-    if ((UINT64_MAX - value) < 0) {
+    if (IS_ERROR((UINT64_MAX - value))) {
         errno = ERANGE;
         return -1;
     }
@@ -2092,7 +2092,7 @@ get_checksum_for_path(char *path, uint32_t *checksum, int op_version)
 
     fd = open(path, O_RDWR);
 
-    if (fd == -1) {
+    if (IS_ERROR(fd)) {
         gf_smsg(THIS->name, GF_LOG_ERROR, errno, LG_MSG_PATH_OPEN_FAILED,
                 "path=%s", path, NULL);
         goto out;
@@ -2126,7 +2126,7 @@ get_file_mtime(const char *path, time_t *stamp)
     GF_VALIDATE_OR_GOTO(THIS->name, stamp, out);
 
     ret = sys_stat(path, &f_stat);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(THIS->name, GF_LOG_ERROR, errno, LG_MSG_FILE_STAT_FAILED,
                 "path=%s", path, NULL);
         goto out;
@@ -2186,13 +2186,13 @@ gf_is_ip_in_net(const char *network, const char *ip_str)
 
     /* Convert IP address to a long */
     ret = inet_pton(family, ip_str, &ip_buf);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_smsg("common-utils", GF_LOG_ERROR, errno, LG_MSG_INET_PTON_FAILED,
                 NULL);
 
     /* Convert network IP address to a long */
     ret = inet_pton(family, net_ip, &net_ip_buf);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg("common-utils", GF_LOG_ERROR, errno, LG_MSG_INET_PTON_FAILED,
                 NULL);
         goto out;
@@ -2496,7 +2496,7 @@ valid_ipv4_address(char *address, int length, gf_boolean_t wildcard_acc)
             is_wildcard = 1;
         } else {
             value = strtol(prev, &endptr, 10);
-            if ((value > 255) || (value < 0) ||
+            if ((value > 255) || IS_ERROR(value) ||
                 (endptr != NULL && *endptr != '\0')) {
                 ret = 0;
                 goto out;
@@ -2595,7 +2595,7 @@ valid_ipv4_subnetwork(const char *address)
      */
     errno = 0;
     prefixlen = strtol(slash + 1, &endptr, 10);
-    if ((errno != 0) || (*endptr != '\0') || (prefixlen < 0) ||
+    if ((errno != 0) || (*endptr != '\0') || IS_ERROR(prefixlen) ||
         (prefixlen > IPv4_ADDR_SIZE)) {
         gf_msg_callingfn(THIS->name, GF_LOG_WARNING, 0,
                          LG_MSG_INVALID_IPV4_FORMAT,
@@ -2655,7 +2655,7 @@ valid_ipv6_address(char *address, int length, gf_boolean_t wildcard_acc)
             is_wildcard = 1;
         } else {
             value = strtol(prev, &endptr, 16);
-            if ((value > 0xffff) || (value < 0) ||
+            if ((value > 0xffff) || IS_ERROR(value) ||
                 (endptr != NULL && *endptr != '\0')) {
                 ret = 0;
                 goto out;
@@ -2956,7 +2956,8 @@ gf_array_insertionsort(void *A, int l, int r, size_t elem_size, gf_cmp cmp)
     for (i = l; i < N; i++) {
         Temp = gf_array_elem(A, i, elem_size);
         j = i - 1;
-        while (j >= 0 && (cmp(Temp, gf_array_elem(A, j, elem_size)) < 0)) {
+        while ((j >= 0) &&
+               IS_ERROR(cmp(Temp, gf_array_elem(A, j, elem_size)))) {
             gf_elem_swap(Temp, gf_array_elem(A, j, elem_size), elem_size);
             Temp = gf_array_elem(A, j, elem_size);
             j = j - 1;
@@ -3002,7 +3003,7 @@ gf_roundup_power_of_two(int32_t nr)
 {
     int32_t result = 1;
 
-    if (nr < 0) {
+    if (IS_ERROR(nr)) {
         gf_smsg("common-utils", GF_LOG_WARNING, 0, LG_MSG_NEGATIVE_NUM_PASSED,
                 NULL);
         result = -1;
@@ -3026,7 +3027,7 @@ gf_roundup_next_power_of_two(int32_t nr)
 {
     int32_t result = 1;
 
-    if (nr < 0) {
+    if (IS_ERROR(nr)) {
         gf_smsg("common-utils", GF_LOG_WARNING, 0, LG_MSG_NEGATIVE_NUM_PASSED,
                 NULL);
         result = -1;
@@ -3127,7 +3128,7 @@ get_mem_size()
     int name64[] = {CTL_HW, HW_PHYSMEM64};
 
     sysctl(name64, 2, &memsize, &len, NULL, 0);
-    if (memsize == -1)
+    if (IS_ERROR(memsize))
         sysctl(name64, 2, &memsize, &len, NULL, 0);
 #endif
     return memsize;
@@ -3250,7 +3251,7 @@ gf_get_reserved_ports()
     int32_t ret = -1;
 
     proc_fd = open(proc_file, O_RDONLY);
-    if (proc_fd == -1) {
+    if (IS_ERROR(proc_fd)) {
         /* What should be done in this case? error out from here
          * and thus stop the glusterfs process from starting or
          * continue with older method of using any of the available
@@ -3262,7 +3263,7 @@ gf_get_reserved_ports()
     }
 
     ret = sys_read(proc_fd, buffer, sizeof(buffer) - 1);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg("glusterfs", GF_LOG_WARNING, errno, LG_MSG_FILE_OP_FAILED,
                 "file=%s", proc_file, NULL);
         goto out;
@@ -3329,7 +3330,7 @@ gf_ports_reserved(char *blocked_port, unsigned char *ports, uint32_t ceiling)
         if (blocked_port[strlen(blocked_port) - 1] == '\n')
             blocked_port[strlen(blocked_port) - 1] = '\0';
         if (gf_string2int32(blocked_port, &tmp_port1) == 0) {
-            if (tmp_port1 > GF_PORT_MAX || tmp_port1 < 0) {
+            if ((tmp_port1 > GF_PORT_MAX) || IS_ERROR(tmp_port1)) {
                 gf_smsg("glusterfs-socket", GF_LOG_WARNING, 0,
                         LG_MSG_INVALID_PORT, "port=%d", tmp_port1, NULL);
                 result = _gf_true;
@@ -3356,7 +3357,7 @@ gf_ports_reserved(char *blocked_port, unsigned char *ports, uint32_t ceiling)
         if (gf_string2int32(range_port, &tmp_port1) == 0) {
             if (tmp_port1 > ceiling)
                 tmp_port1 = ceiling;
-            if (tmp_port1 < 0)
+            if (IS_ERROR(tmp_port1))
                 tmp_port1 = 0;
         }
         range_port = strtok(NULL, "-");
@@ -3370,7 +3371,7 @@ gf_ports_reserved(char *blocked_port, unsigned char *ports, uint32_t ceiling)
         if (gf_string2int32(range_port, &tmp_port2) == 0) {
             if (tmp_port2 > ceiling)
                 tmp_port2 = ceiling;
-            if (tmp_port2 < 0)
+            if (IS_ERROR(tmp_port2))
                 tmp_port2 = 0;
         }
         gf_msg_debug("glusterfs", 0, "lower: %d, higher: %d", tmp_port1,
@@ -3829,7 +3830,7 @@ gf_set_volfile_server_common(cmd_args_t *cmd_args, const char *host,
 
     ret = 0;
 out:
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         if (server) {
             GF_FREE(server->volfile_server);
             GF_FREE(server->transport);
@@ -3996,7 +3997,7 @@ gf_thread_set_vname(pthread_t thread, const char *name, va_list args)
     ret = vsnprintf(thread_name + sizeof(GF_THREAD_NAME_PREFIX) - 1,
                     sizeof(thread_name) - sizeof(GF_THREAD_NAME_PREFIX) + 1,
                     name, args);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(THIS->name, GF_LOG_WARNING, 0, LG_MSG_PTHREAD_NAMING_FAILED,
                 "name=%s", name, NULL);
         return;
@@ -4135,7 +4136,7 @@ gf_is_pid_running(int pid)
     snprintf(fname, sizeof(fname), "/proc/%d/cmdline", pid);
 
     fd = sys_open(fname, O_RDONLY, 0);
-    if (fd < 0) {
+    if (IS_ERROR(fd)) {
         return _gf_false;
     }
 
@@ -4158,7 +4159,7 @@ gf_is_service_running(char *pidfile, int *pid)
 
     fno = fileno(file);
     ret = lockf(fno, F_TEST, 0);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         running = _gf_true;
     }
 
@@ -4238,7 +4239,7 @@ gf_check_log_format(const char *value)
     else if (!strcasecmp(value, GF_LOG_FORMAT_WITH_MSG_ID))
         log_format = gf_logformat_withmsgid;
 
-    if (log_format == -1)
+    if (IS_ERROR(log_format))
         gf_smsg(THIS->name, GF_LOG_ERROR, 0, LG_MSG_INVALID_LOG,
                 "possible_values=" GF_LOG_FORMAT_NO_MSG_ID
                 "|" GF_LOG_FORMAT_WITH_MSG_ID,
@@ -4257,7 +4258,7 @@ gf_check_logger(const char *value)
     else if (!strcasecmp(value, GF_LOGGER_SYSLOG))
         logger = gf_logger_syslog;
 
-    if (logger == -1)
+    if (IS_ERROR(logger))
         gf_smsg(THIS->name, GF_LOG_ERROR, 0, LG_MSG_INVALID_LOG,
                 "possible_values=" GF_LOGGER_GLUSTER_LOG "|" GF_LOGGER_SYSLOG,
                 NULL);
@@ -4419,14 +4420,14 @@ gf_backtrace_fillframes(char *buf)
 
     /* coverity[secure_temp] mkstemp uses 0600 as the mode and is safe */
     fd = mkstemp(tmpl);
-    if (fd == -1)
+    if (IS_ERROR(fd))
         return -1;
 
     /* Calling unlink so that when the file is closed or program
      * terminates the temporary file is deleted.
      */
     ret = sys_unlink(tmpl);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(THIS->name, GF_LOG_INFO, 0, LG_MSG_FILE_DELETE_FAILED,
                 "temporary_file=%s", tmpl, NULL);
     }
@@ -4452,7 +4453,7 @@ gf_backtrace_fillframes(char *buf)
         if (ret == EOF)
             break;
         inc = gf_backtrace_append(buf, pos, callingfn[idx]);
-        if (inc == -1)
+        if (IS_ERROR(inc))
             break;
         pos += inc;
     }
@@ -4708,7 +4709,7 @@ recursive_rmdir(const char *delete_path)
     while (entry) {
         snprintf(path, PATH_MAX, "%s/%s", delete_path, entry->d_name);
         ret = sys_lstat(path, &st);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg_debug(this->name, 0,
                          "Failed to stat entry %s :"
                          " %s",
@@ -4832,7 +4833,7 @@ gf_nread(int fd, void *buf, size_t count)
         ret = sys_read(fd, buf + read_bytes, count - read_bytes);
         if (ret == 0) {
             break;
-        } else if (ret < 0) {
+        } else if (IS_ERROR(ret)) {
             if (errno == EINTR)
                 ret = 0;
             else
@@ -4853,7 +4854,7 @@ gf_nwrite(int fd, const void *buf, size_t count)
 
     for (written = 0; written != count; written += ret) {
         ret = sys_write(fd, buf + written, count - written);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             if (errno == EINTR)
                 ret = 0;
             else
@@ -5230,7 +5231,7 @@ gf_getgrouplist(const char *user, gid_t group, gid_t **groups)
     for (;;) {
         int ngroups_old = ngroups;
         ret = getgrouplist(user, group, *groups, &ngroups);
-        if (ret != -1)
+        if (ret >= 0)
             break;
 
         if (ngroups >= GF_MAX_AUX_GROUPS) {
@@ -5306,7 +5307,7 @@ gf_replace_old_iatt_in_dict(dict_t *xdata)
     }
 
     ret = dict_get_bin(xdata, DHT_IATT_IN_XDATA_KEY, (void **)&c_iatt);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         return 0;
     }
 
@@ -5338,7 +5339,7 @@ gf_replace_new_iatt_in_dict(dict_t *xdata)
     }
 
     ret = dict_get_bin(xdata, DHT_IATT_IN_XDATA_KEY, (void **)&o_iatt);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         return 0;
     }
 
@@ -5408,7 +5409,40 @@ gf_nanosleep(uint64_t nsec)
     do {
         ret = nanosleep(&req, &rem);
         req = rem;
-    } while (ret == -1 && errno == EINTR);
+    } while (IS_ERROR(ret) && errno == EINTR);
 
     return ret;
+}
+
+char *
+gf_strerror_r(int errorcode, char *str, size_t size)
+{
+    int xl_idx = (errorcode & 0x3ff00000) >> 20; /* 4k xlator-index in graph */
+    int xl_id = (errorcode & 0xfe000) >> 13;     /* 128 xlator IDs */
+    int reason = (errorcode & 0x1fff);           /* 8k reasons per xlators */
+
+    /* TODO: 1024 should be changed to macros later */
+    if (IS_ERROR(errorcode)) {
+        snprintf(str, size, "-1");
+        goto out;
+    }
+
+    if (gf_xlator_list[xl_id]) {
+        snprintf(str, size, "%s: %d %d", gf_xlator_list[xl_id], xl_idx, reason);
+    } else {
+        snprintf(str, size, "%d: %d %d", xl_id, xl_idx, reason);
+    }
+
+out:
+    str[size - 1] = '\0';
+    return str;
+}
+
+/*Thread safe conversion function*/
+char *
+gf_strerror(int errorcode)
+{
+    char *error_buffer = glusterfs_errorcode_buf_get();
+
+    return gf_strerror_r(errorcode, error_buffer, 1024);
 }

--- a/libglusterfs/src/compat.c
+++ b/libglusterfs/src/compat.c
@@ -289,8 +289,8 @@ solaris_listxattr(const char *path, char *list, size_t size)
                     }
                 }
             }
-
-            if (closedir(dirptr) == -1) {
+            ret = closedir(dirptr);
+            if (IS_ERROR(ret)) {
                 close(attrdirfd);
                 len = -1;
                 goto out;
@@ -310,6 +310,7 @@ out:
 int
 solaris_flistxattr(int fd, char *list, size_t size)
 {
+    int ret = 0;
     int attrdirfd = -1;
     ssize_t len = 0;
     DIR *dirptr = NULL;
@@ -347,7 +348,8 @@ solaris_flistxattr(int fd, char *list, size_t size)
                 }
             }
 
-            if (closedir(dirptr) == -1) {
+            ret = closedir(dirptr);
+            if (IS_ERROR(ret)) {
                 close(attrdirfd);
                 return -1;
             }
@@ -534,7 +536,7 @@ mkdtemp(char *tempstring)
         goto out;
 
     ret = mkdir(new_string, 0700);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         new_string = NULL;
 
 out:

--- a/libglusterfs/src/compat.c
+++ b/libglusterfs/src/compat.c
@@ -31,7 +31,7 @@ solaris_fsetxattr(int fd, const char *key, const char *value, size_t size,
     int ret = 0;
 
     attrfd = openat(fd, key, flags | O_CREAT | O_WRONLY | O_XATTR, 0777);
-    if (attrfd >= 0) {
+    if (IS_SUCCESS(attrfd)) {
         ftruncate(attrfd, 0);
         ret = write(attrfd, value, size);
         close(attrfd);
@@ -55,7 +55,7 @@ solaris_fgetxattr(int fd, const char *key, char *value, size_t size)
     int ret = 0;
 
     attrfd = openat(fd, key, O_RDONLY | O_XATTR);
-    if (attrfd >= 0) {
+    if (IS_SUCCESS(attrfd)) {
         if (size == 0) {
             struct stat buf;
             fstat(attrfd, &buf);
@@ -225,7 +225,7 @@ solaris_setxattr(const char *path, const char *key, const char *value,
     } else {
         attrfd = attropen(path, key, flags | O_CREAT | O_WRONLY, 0777);
     }
-    if (attrfd >= 0) {
+    if (IS_SUCCESS(attrfd)) {
         ftruncate(attrfd, 0);
         ret = write(attrfd, value, size);
         close(attrfd);
@@ -260,7 +260,7 @@ solaris_listxattr(const char *path, char *list, size_t size)
     } else {
         attrdirfd = attropen(path, ".", O_RDONLY, 0);
     }
-    if (attrdirfd >= 0) {
+    if (IS_SUCCESS(attrdirfd)) {
         newfd = dup(attrdirfd);
         dirptr = fdopendir(newfd);
         if (dirptr) {
@@ -318,7 +318,7 @@ solaris_flistxattr(int fd, char *list, size_t size)
     int newfd = -1;
 
     attrdirfd = openat(fd, ".", O_RDONLY, 0);
-    if (attrdirfd >= 0) {
+    if (IS_SUCCESS(attrdirfd)) {
         newfd = dup(attrdirfd);
         dirptr = fdopendir(newfd);
         if (dirptr) {
@@ -375,7 +375,7 @@ solaris_removexattr(const char *path, const char *key)
     } else {
         attrfd = attropen(path, ".", O_RDONLY, 0);
     }
-    if (attrfd >= 0) {
+    if (IS_SUCCESS(attrfd)) {
         ret = unlinkat(attrfd, key, 0);
         close(attrfd);
     } else {
@@ -403,7 +403,7 @@ solaris_getxattr(const char *path, const char *key, char *value, size_t size)
         attrfd = attropen(path, key, O_RDONLY, 0);
     }
 
-    if (attrfd >= 0) {
+    if (IS_SUCCESS(attrfd)) {
         if (size == 0) {
             struct stat buf;
             fstat(attrfd, &buf);

--- a/libglusterfs/src/daemon.c
+++ b/libglusterfs/src/daemon.c
@@ -25,7 +25,7 @@ os_daemon_return(int nochdir, int noclose)
 
     pid = setsid();
 
-    if (pid == -1) {
+    if (pid < 0) {
         ret = -1;
         goto out;
     }

--- a/libglusterfs/src/default-args.c
+++ b/libglusterfs/src/default-args.c
@@ -524,7 +524,7 @@ args_readv_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->vector = iov_dup(vector, count);
         args->count = count;
         args->stat = *stbuf;
@@ -560,7 +560,7 @@ args_writev_cbk_store(default_args_cbk_t *args, int32_t op_ret,
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         args->poststat = *postbuf;
     if (prebuf)
         args->prestat = *prebuf;
@@ -597,7 +597,7 @@ args_put_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         args->stat = *buf;
     if (inode)
         args->inode = inode_ref(inode);
@@ -1134,7 +1134,7 @@ args_rchecksum_cbk_store(default_args_cbk_t *args, int32_t op_ret,
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->weak_checksum = weak_checksum;
         args->strong_checksum = gf_memdup(strong_checksum,
                                           SHA256_DIGEST_LENGTH);
@@ -1569,7 +1569,7 @@ args_copy_file_range_cbk_store(default_args_cbk_t *args, int32_t op_ret,
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         if (postbuf_dst)
             args->poststat = *postbuf_dst;
         if (prebuf_dst)

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -2087,7 +2087,7 @@ _dict_modify_flag(dict_t *this, char *key, int flag, int op)
      * Using a size of 32 bytes to support max of 256
      * flags in a single key. This should be suffcient.
      */
-    GF_ASSERT(flag >= 0 && flag < DICT_MAX_FLAGS);
+    GF_ASSERT(IS_SUCCESS(flag) && flag < DICT_MAX_FLAGS);
 
     hash = (uint32_t)XXH64(key, strlen(key), 0);
     LOCK(&this->lock);

--- a/libglusterfs/src/dict.c
+++ b/libglusterfs/src/dict.c
@@ -271,7 +271,7 @@ are_dicts_equal(dict_t *one, dict_t *two,
     cmp.value_ignore = value_ignore;
     num_matches1 = dict_foreach_match(one, match, NULL, key_value_cmp, &cmp);
 
-    if (num_matches1 == -1)
+    if (IS_ERROR(num_matches1))
         return _gf_false;
 
     if ((num_matches1 == one->count) && (one->count == two->count))
@@ -394,7 +394,7 @@ dict_set_lk(dict_t *this, char *key, const int key_len, data_t *value,
 
     if (!key) {
         keylen = gf_asprintf(&key, "ref:%p", value);
-        if (-1 == keylen) {
+        if (IS_ERROR(keylen)) {
             return -1;
         }
         key_free = 1;
@@ -801,7 +801,7 @@ int_to_data(int64_t value)
     }
 
     data->len = gf_asprintf(&data->data, "%" PRId64, value);
-    if (-1 == data->len) {
+    if (IS_ERROR(data->len)) {
         gf_msg_debug("dict", 0, "asprintf failed");
         data_destroy(data);
         return NULL;
@@ -821,7 +821,7 @@ data_from_int64(int64_t value)
         return NULL;
     }
     data->len = gf_asprintf(&data->data, "%" PRId64, value);
-    if (-1 == data->len) {
+    if (IS_ERROR(data->len)) {
         gf_msg_debug("dict", 0, "asprintf failed");
         data_destroy(data);
         return NULL;
@@ -841,7 +841,7 @@ data_from_int32(int32_t value)
         return NULL;
     }
     data->len = gf_asprintf(&data->data, "%" PRId32, value);
-    if (-1 == data->len) {
+    if (IS_ERROR(data->len)) {
         gf_msg_debug("dict", 0, "asprintf failed");
         data_destroy(data);
         return NULL;
@@ -862,7 +862,7 @@ data_from_int16(int16_t value)
         return NULL;
     }
     data->len = gf_asprintf(&data->data, "%" PRId16, value);
-    if (-1 == data->len) {
+    if (IS_ERROR(data->len)) {
         gf_msg_debug("dict", 0, "asprintf failed");
         data_destroy(data);
         return NULL;
@@ -883,7 +883,7 @@ data_from_int8(int8_t value)
         return NULL;
     }
     data->len = gf_asprintf(&data->data, "%d", value);
-    if (-1 == data->len) {
+    if (IS_ERROR(data->len)) {
         gf_msg_debug("dict", 0, "asprintf failed");
         data_destroy(data);
         return NULL;
@@ -904,7 +904,7 @@ data_from_uint64(uint64_t value)
         return NULL;
     }
     data->len = gf_asprintf(&data->data, "%" PRIu64, value);
-    if (-1 == data->len) {
+    if (IS_ERROR(data->len)) {
         gf_msg_debug("dict", 0, "asprintf failed");
         data_destroy(data);
         return NULL;
@@ -926,7 +926,7 @@ data_from_double(double value)
     }
 
     data->len = gf_asprintf(&data->data, "%f", value);
-    if (data->len == -1) {
+    if (IS_ERROR(data->len)) {
         gf_msg_debug("dict", 0, "asprintf failed");
         data_destroy(data);
         return NULL;
@@ -946,7 +946,7 @@ data_from_uint32(uint32_t value)
         return NULL;
     }
     data->len = gf_asprintf(&data->data, "%" PRIu32, value);
-    if (-1 == data->len) {
+    if (IS_ERROR(data->len)) {
         gf_msg_debug("dict", 0, "asprintf failed");
         data_destroy(data);
         return NULL;
@@ -967,7 +967,7 @@ data_from_uint16(uint16_t value)
         return NULL;
     }
     data->len = gf_asprintf(&data->data, "%" PRIu16, value);
-    if (-1 == data->len) {
+    if (IS_ERROR(data->len)) {
         gf_msg_debug("dict", 0, "asprintf failed");
         data_destroy(data);
         return NULL;
@@ -1186,7 +1186,7 @@ data_to_uint16(data_t *data)
     errno = 0;
     value = strtol(data->data, NULL, 0);
 
-    if ((USHRT_MAX - value) < 0) {
+    if (IS_ERROR((USHRT_MAX - value))) {
         errno = ERANGE;
         gf_msg_callingfn("dict", GF_LOG_WARNING, errno,
                          LG_MSG_DATA_CONVERSION_ERROR,
@@ -1206,7 +1206,7 @@ data_to_uint8(data_t *data)
     errno = 0;
     uint32_t value = strtol(data->data, NULL, 0);
 
-    if ((UCHAR_MAX - (uint8_t)value) < 0) {
+    if (IS_ERROR((UCHAR_MAX - (uint8_t)value))) {
         errno = ERANGE;
         gf_msg_callingfn("dict", GF_LOG_WARNING, errno,
                          LG_MSG_DATA_CONVERSION_ERROR,
@@ -1325,7 +1325,7 @@ dict_foreach_match(dict_t *dict,
         next = pairs->next;
         if (match(dict, pairs->key, pairs->value, match_data)) {
             ret = action(dict, pairs->key, pairs->value, action_data);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 return ret;
             count++;
         }
@@ -1708,7 +1708,7 @@ dict_set_int8(dict_t *this, char *key, int8_t val)
     }
 
     ret = dict_set(this, key, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -1754,7 +1754,7 @@ dict_set_int16(dict_t *this, char *key, int16_t val)
     }
 
     ret = dict_set(this, key, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -1826,7 +1826,7 @@ dict_set_int32n(dict_t *this, char *key, const int keylen, int32_t val)
     }
 
     ret = dict_setn(this, key, keylen, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -1845,7 +1845,7 @@ dict_set_int32(dict_t *this, char *key, int32_t val)
     }
 
     ret = dict_set(this, key, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -1890,7 +1890,7 @@ dict_set_int64(dict_t *this, char *key, int64_t val)
     }
 
     ret = dict_set(this, key, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -1935,7 +1935,7 @@ dict_set_uint16(dict_t *this, char *key, uint16_t val)
     }
 
     ret = dict_set(this, key, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -1980,7 +1980,7 @@ dict_set_uint32(dict_t *this, char *key, uint32_t val)
     }
 
     ret = dict_set(this, key, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -2025,7 +2025,7 @@ dict_set_uint64(dict_t *this, char *key, uint64_t val)
     }
 
     ret = dict_set(this, key, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -2048,7 +2048,7 @@ dict_check_flag(dict_t *this, char *key, int flag)
     int ret = -ENOENT;
 
     ret = dict_get_with_ref(this, key, &data);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         return ret;
     }
 
@@ -2248,7 +2248,7 @@ dict_set_double(dict_t *this, char *key, double val)
     }
 
     ret = dict_set(this, key, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -2267,7 +2267,7 @@ dict_set_static_ptr(dict_t *this, char *key, void *ptr)
     }
 
     ret = dict_set(this, key, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -2286,7 +2286,7 @@ dict_set_dynptr(dict_t *this, char *key, void *ptr, size_t len)
     }
 
     ret = dict_set(this, key, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -2366,7 +2366,7 @@ dict_get_strn(dict_t *this, char *key, const int keylen, char **str)
         goto err;
     }
     ret = dict_get_with_refn(this, key, keylen, &data);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -2391,7 +2391,7 @@ dict_get_str(dict_t *this, char *key, char **str)
         goto err;
     }
     ret = dict_get_with_ref(this, key, &data);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -2418,7 +2418,7 @@ dict_set_str(dict_t *this, char *key, char *str)
     }
 
     ret = dict_set(this, key, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -2439,7 +2439,7 @@ dict_set_strn(dict_t *this, char *key, const int keylen, char *str)
     }
 
     ret = dict_setn(this, key, keylen, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -2460,7 +2460,7 @@ dict_set_nstrn(dict_t *this, char *key, const int keylen, char *str,
     }
 
     ret = dict_setn(this, key, keylen, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -2502,7 +2502,7 @@ dict_set_dynstrn(dict_t *this, char *key, const int keylen, char *str)
     }
 
     ret = dict_setn(this, key, keylen, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 err:
@@ -2524,7 +2524,7 @@ dict_set_option(dict_t *this, char *key, char *str)
 
     data->data_type = GF_DATA_TYPE_STR_OLD;
     ret = dict_set(this, key, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 err:
     return ret;
@@ -2548,7 +2548,7 @@ dict_add_dynstr_with_alloc(dict_t *this, char *key, char *str)
     }
 
     ret = dict_add(this, key, data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         data_destroy(data);
 
 out:
@@ -2566,7 +2566,7 @@ dict_get_bin(dict_t *this, char *key, void **bin)
     }
 
     ret = dict_get_with_ref(this, key, &data);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -2612,7 +2612,7 @@ dict_set_bin_common(dict_t *this, char *key, void *ptr, size_t size,
     data->data_type = type;
 
     ret = dict_set(this, key, data);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /* don't free data->data, let callers handle it */
         data->data = NULL;
         data_destroy(data);
@@ -2668,7 +2668,7 @@ dict_get_gfuuid(dict_t *this, char *key, uuid_t *gfid)
         goto err;
     }
     ret = dict_get_with_ref(this, key, &data);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -2701,7 +2701,7 @@ dict_get_mdata(dict_t *this, char *key, struct mdata_iatt *mdata)
         goto err;
     }
     ret = dict_get_with_ref(this, key, &data);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -2739,7 +2739,7 @@ dict_get_iatt(dict_t *this, char *key, struct iatt *iatt)
         goto err;
     }
     ret = dict_get_with_ref(this, key, &data);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -2785,7 +2785,7 @@ dict_get_str_boolean(dict_t *this, char *key, int default_val)
     int ret = 0;
 
     ret = dict_get_with_ref(this, key, &data);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (ret == -ENOENT)
             ret = default_val;
         else
@@ -2796,7 +2796,7 @@ dict_get_str_boolean(dict_t *this, char *key, int default_val)
     VALIDATE_DATA_AND_LOG(data, GF_DATA_TYPE_INT, key, -EINVAL);
 
     ret = gf_strn2boolean(data->data, data->len - 1, &boo);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 
     ret = boo;
@@ -2875,7 +2875,7 @@ dict_serialized_length_lk(dict_t *this)
     int len = DICT_HDR_LEN;
     data_pair_t *pair = this->members_list;
 
-    if (count < 0) {
+    if (IS_ERROR(count)) {
         gf_smsg("dict", GF_LOG_ERROR, EINVAL, LG_MSG_COUNT_LESS_THAN_ZERO,
                 "count=%d", count, NULL);
         goto out;
@@ -2902,7 +2902,7 @@ dict_serialized_length_lk(dict_t *this)
             goto out;
         }
 
-        if (pair->value->len < 0) {
+        if (IS_ERROR(pair->value->len)) {
             gf_smsg("dict", GF_LOG_ERROR, EINVAL,
                     LG_MSG_VALUE_LENGTH_LESS_THAN_ZERO, "len=%d",
                     pair->value->len, NULL);
@@ -2946,7 +2946,7 @@ dict_serialize_lk(dict_t *this, char *buf)
         goto out;
     }
 
-    if (count < 0) {
+    if (IS_ERROR(count)) {
         gf_smsg("dict", GF_LOG_ERROR, 0, LG_MSG_COUNT_LESS_THAN_ZERO,
                 "count=%d", count, NULL);
         goto out;
@@ -3121,7 +3121,7 @@ dict_unserialize(char *orig_buf, int32_t size, dict_t **fill)
     count = ntoh32(hostord);
     buf += DICT_HDR_LEN;
 
-    if (count < 0) {
+    if (IS_ERROR(count)) {
         gf_smsg("dict", GF_LOG_ERROR, 0, LG_MSG_COUNT_LESS_THAN_ZERO,
                 "count=%d", count, NULL);
         goto out;
@@ -3157,7 +3157,7 @@ dict_unserialize(char *orig_buf, int32_t size, dict_t **fill)
         vallen = ntoh32(hostord);
         buf += DICT_DATA_HDR_VAL_LEN;
 
-        if ((keylen < 0) || (vallen < 0)) {
+        if (IS_ERROR(keylen) || IS_ERROR(vallen)) {
             gf_msg_callingfn("dict", GF_LOG_ERROR, 0, LG_MSG_UNDERSIZED_BUF,
                              "undersized length passed "
                              "key:%d val:%d",
@@ -3194,7 +3194,7 @@ dict_unserialize(char *orig_buf, int32_t size, dict_t **fill)
         buf += vallen;
 
         ret = dict_addn(*fill, key, keylen, value);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 
@@ -3228,7 +3228,7 @@ dict_allocate_and_serialize(dict_t *this, char **buf, u_int *length)
     LOCK(&this->lock);
     {
         len = dict_serialized_length_lk(this);
-        if (len < 0) {
+        if (IS_ERROR(len)) {
             ret = len;
             goto unlock;
         }
@@ -3240,7 +3240,7 @@ dict_allocate_and_serialize(dict_t *this, char **buf, u_int *length)
         }
 
         ret = dict_serialize_lk(this, *buf);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             GF_FREE(*buf);
             *buf = NULL;
             goto unlock;
@@ -3283,7 +3283,7 @@ dict_serialize_value_with_delim_lk(dict_t *this, char *buf, int32_t *serz_len,
         goto out;
     }
 
-    if (count < 0) {
+    if (IS_ERROR(count)) {
         gf_smsg("dict", GF_LOG_ERROR, EINVAL, LG_MSG_INVALID_ARG, "count=%d",
                 count, NULL);
         goto out;
@@ -3363,7 +3363,7 @@ dict_dump_to_str(dict_t *dict, char *dump, int dumpsize, char *format)
     for (trav = dict->members_list; trav; trav = trav->next) {
         ret = snprintf(&dump[dumplen], dumpsize - dumplen, format, trav->key,
                        trav->value->data);
-        if ((ret == -1) || !ret)
+        if (IS_ERROR((ret)) || !ret)
             return ret;
 
         dumplen += ret;

--- a/libglusterfs/src/event-poll.c
+++ b/libglusterfs/src/event-poll.c
@@ -47,7 +47,7 @@ __flush_fd(int fd, int idx, int gen, void *data, int poll_in, int poll_out,
 
     do {
         ret = sys_read(fd, buf, 64);
-        if (ret == -1 && errno != EAGAIN) {
+        if (IS_ERROR(ret) && errno != EAGAIN) {
             gf_smsg("poll", GF_LOG_ERROR, errno, LG_MSG_READ_FILE_FAILED,
                     "fd=%d", fd, NULL);
         }
@@ -108,7 +108,7 @@ event_pool_new_poll(int count, int eventthreadcount)
 
     ret = pipe(event_pool->breaker);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_smsg("poll", GF_LOG_ERROR, errno, LG_MSG_PIPE_CREATE_FAILED, NULL);
         GF_FREE(event_pool->reg);
         GF_FREE(event_pool);
@@ -116,7 +116,7 @@ event_pool_new_poll(int count, int eventthreadcount)
     }
 
     ret = fcntl(event_pool->breaker[0], F_SETFL, O_NONBLOCK);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_smsg("poll", GF_LOG_ERROR, errno, LG_MSG_SET_PIPE_FAILED, NULL);
         sys_close(event_pool->breaker[0]);
         sys_close(event_pool->breaker[1]);
@@ -128,7 +128,7 @@ event_pool_new_poll(int count, int eventthreadcount)
     }
 
     ret = fcntl(event_pool->breaker[1], F_SETFL, O_NONBLOCK);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_smsg("poll", GF_LOG_ERROR, errno, LG_MSG_SET_PIPE_FAILED, NULL);
 
         sys_close(event_pool->breaker[0]);
@@ -142,7 +142,7 @@ event_pool_new_poll(int count, int eventthreadcount)
 
     ret = event_register_poll(event_pool, event_pool->breaker[0], __flush_fd,
                               NULL, 1, 0, 0);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_smsg("poll", GF_LOG_ERROR, 0, LG_MSG_REGISTER_PIPE_FAILED, NULL);
         sys_close(event_pool->breaker[0]);
         sys_close(event_pool->breaker[1]);
@@ -247,7 +247,7 @@ event_unregister_poll(struct event_pool *event_pool, int fd, int idx_hint)
     {
         idx = __event_getindex(event_pool, fd, idx_hint);
 
-        if (idx == -1) {
+        if (IS_ERROR(idx)) {
             gf_smsg("poll", GF_LOG_ERROR, 0, LG_MSG_INDEX_NOT_FOUND, "fd=%d",
                     fd, "idx_hint=%d", idx_hint, NULL);
             errno = ENOENT;
@@ -288,7 +288,7 @@ event_select_on_poll(struct event_pool *event_pool, int fd, int idx_hint,
     {
         idx = __event_getindex(event_pool, fd, idx_hint);
 
-        if (idx == -1) {
+        if (IS_ERROR(idx)) {
             gf_smsg("poll", GF_LOG_ERROR, 0, LG_MSG_INDEX_NOT_FOUND, "fd=%d",
                     fd, "idx_hint=%d", idx_hint, NULL);
             errno = ENOENT;
@@ -351,7 +351,7 @@ event_dispatch_poll_handler(struct event_pool *event_pool, struct pollfd *ufds,
     {
         idx = __event_getindex(event_pool, ufds[i].fd, i);
 
-        if (idx == -1) {
+        if (IS_ERROR(idx)) {
             gf_smsg("poll", GF_LOG_ERROR, 0, LG_MSG_INDEX_NOT_FOUND, "fd=%d",
                     ufds[i].fd, "idx_hint=%d", i, NULL);
             goto unlock;
@@ -453,7 +453,7 @@ event_dispatch_poll(struct event_pool *event_pool)
             /* timeout */
             continue;
 
-        if (ret == -1 && errno == EINTR)
+        if (IS_ERROR(ret) && errno == EINTR)
             /* sys call */
             continue;
 

--- a/libglusterfs/src/event.c
+++ b/libglusterfs/src/event.c
@@ -168,7 +168,7 @@ poller_destroy_handler(int fd, int idx, int gen, void *data, int poll_out,
 
     destroy = data;
     readfd = destroy->readfd;
-    if (readfd < 0) {
+    if (IS_ERROR(readfd)) {
         goto out;
     }
 
@@ -209,21 +209,21 @@ gf_event_dispatch_destroy(struct event_pool *event_pool)
     GF_VALIDATE_OR_GOTO("event", event_pool, out);
 
     ret = pipe(fd);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     /* Make the read end of the pipe nonblocking */
     flags = fcntl(fd[0], F_GETFL);
     flags |= O_NONBLOCK;
     ret = fcntl(fd[0], F_SETFL, flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     /* Make the write end of the pipe nonblocking */
     flags = fcntl(fd[1], F_GETFL);
     flags |= O_NONBLOCK;
     ret = fcntl(fd[1], F_SETFL, flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     data.pool = event_pool;
@@ -233,7 +233,7 @@ gf_event_dispatch_destroy(struct event_pool *event_pool)
      */
     idx = gf_event_register(event_pool, fd[0], poller_destroy_handler, &data, 1,
                             0, 0);
-    if (idx < 0)
+    if (IS_ERROR(idx))
         goto out;
 
     /* Enter the destroy mode first, set this before reconfiguring to 0
@@ -247,7 +247,7 @@ gf_event_dispatch_destroy(struct event_pool *event_pool)
     pthread_mutex_unlock(&event_pool->mutex);
 
     ret = gf_event_reconfigure_threads(event_pool, 0);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     /* Write something onto the write end of the pipe(fd[1]) so that
@@ -263,7 +263,8 @@ gf_event_dispatch_destroy(struct event_pool *event_pool)
 
         while (event_pool->activethreadcount > 0 &&
                (retry++ < (threadcount + 10))) {
-            if (sys_write(fd[1], "dummy", 6) == -1) {
+            ret = sys_write(fd[1], "dummy", 6);
+            if (IS_ERROR(ret)) {
                 break;
             }
             clock_gettime(CLOCK_REALTIME, &sleep_till);

--- a/libglusterfs/src/events.c
+++ b/libglusterfs/src/events.c
@@ -110,7 +110,7 @@ _gf_event(eventtypes_t event, const char *fmt, ...)
     ret = EVENT_SEND_OK;
 
 out:
-    if (sock >= 0) {
+    if (IS_SUCCESS(sock)) {
         sys_close(sock);
     }
 

--- a/libglusterfs/src/events.c
+++ b/libglusterfs/src/events.c
@@ -46,14 +46,14 @@ _gf_event(eventtypes_t event, const char *fmt, ...)
     /* Global context */
     ctx = this->ctx;
 
-    if (event < 0 || event >= EVENT_LAST) {
+    if (IS_ERROR(event) || event >= EVENT_LAST) {
         ret = EVENT_ERROR_INVALID_INPUTS;
         goto out;
     }
 
     /* Initialize UDP socket */
     sock = socket(AF_INET, SOCK_DGRAM, 0);
-    if (sock < 0) {
+    if (IS_ERROR(sock)) {
         ret = EVENT_ERROR_SOCKET;
         goto out;
     }
@@ -88,7 +88,7 @@ _gf_event(eventtypes_t event, const char *fmt, ...)
     ret = gf_vasprintf(&msg, fmt, arguments);
     va_end(arguments);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = EVENT_ERROR_INVALID_INPUTS;
         goto out;
     }

--- a/libglusterfs/src/fd-lk.c
+++ b/libglusterfs/src/fd-lk.c
@@ -67,7 +67,7 @@ fd_lk_ctx_unref(fd_lk_ctx_t *lk_ctx)
     GF_VALIDATE_OR_GOTO("fd-lk", lk_ctx, err);
 
     ref = GF_ATOMIC_DEC(lk_ctx->ref);
-    if (ref < 0)
+    if (IS_ERROR(ref))
         GF_ASSERT(!ref);
     if (ref == 0)
         _fd_lk_destroy_lock_list(lk_ctx);

--- a/libglusterfs/src/fd.c
+++ b/libglusterfs/src/fd.c
@@ -298,7 +298,7 @@ gf_fd_put(fdtable_t *fdtable, int32_t fd)
     if (fd == GF_ANON_FD_NO)
         return;
 
-    if (fdtable == NULL || fd < 0) {
+    if ((fdtable == NULL) || IS_ERROR(fd)) {
         gf_msg_callingfn("fd", GF_LOG_ERROR, EINVAL, LG_MSG_INVALID_ARG,
                          "invalid argument");
         return;
@@ -389,7 +389,7 @@ gf_fd_fdptr_get(fdtable_t *fdtable, int64_t fd)
 {
     fd_t *fdptr = NULL;
 
-    if (fdtable == NULL || fd < 0) {
+    if ((fdtable == NULL) || IS_ERROR(fd)) {
         gf_msg_callingfn("fd", GF_LOG_ERROR, EINVAL, LG_MSG_INVALID_ARG,
                          "invalid argument");
         errno = EINVAL;
@@ -820,7 +820,7 @@ __fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value)
 
     for (index = 0; index < fd->xl_count; index++) {
         if (!fd->_ctx[index].key) {
-            if (set_idx == -1)
+            if (IS_ERROR(set_idx))
                 set_idx = index;
             /* don't break, to check if key already exists
                further on */
@@ -831,7 +831,7 @@ __fd_ctx_set(fd_t *fd, xlator_t *xlator, uint64_t value)
         }
     }
 
-    if (set_idx == -1) {
+    if (IS_ERROR(set_idx)) {
         set_idx = fd->xl_count;
 
         new_xl_count = fd->xl_count + xlator->graph->xl_count;

--- a/libglusterfs/src/gf-dirent.c
+++ b/libglusterfs/src/gf-dirent.c
@@ -278,7 +278,7 @@ gf_fill_iatt_for_dirent(gf_dirent_t *entry, inode_t *parent, xlator_t *subvol)
     loc.parent = inode_ref(parent);
     ret = inode_path(loc.inode, entry->d_name, &path);
     loc.path = path;
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = syncop_lookup(subvol, &loc, &iatt, NULL, NULL, NULL);

--- a/libglusterfs/src/globals.c
+++ b/libglusterfs/src/globals.c
@@ -86,6 +86,13 @@ const char *gf_upcall_list[GF_UPCALL_FLAGS_MAXVALUE] = {
     [GF_UPCALL_LEASE_RECALL] = "LEASE_RECALL",
 };
 
+const char *gf_xlator_list[GF_XLATOR_MAXVALUE] = {
+    [GF_XLATOR_BACKEND] = "backend-filesystem",
+    [GF_XLATOR_POSIX] = "storage/posix",
+    [GF_XLATOR_DHT] = "cluster/distribute",
+    [GF_XLATOR_AFR] = "cluster/replicate",
+};
+
 /* THIS */
 
 /* This global ctx is a bad hack to prevent some of the libgfapi crashes.
@@ -106,6 +113,9 @@ static __thread struct syncopctx thread_syncopctx = {};
 static __thread char thread_uuid_buf[GF_UUID_BUF_SIZE] = {};
 static __thread char thread_lkowner_buf[GF_LKOWNER_BUF_SIZE] = {};
 static __thread char thread_leaseid_buf[GF_LEASE_ID_BUF_SIZE] = {};
+
+/* TODO: add macro for size */
+static __thread char thread_errorcode_buf[1024] = {};
 
 int
 gf_global_mem_acct_enable_get(void)
@@ -299,6 +309,14 @@ glusterfs_leaseid_buf_get()
     }
 
     return buf;
+}
+
+// ERRORCODE_BUFFER
+
+char *
+glusterfs_errorcode_buf_get()
+{
+    return thread_errorcode_buf;
 }
 
 char *

--- a/libglusterfs/src/glusterfs/async.h
+++ b/libglusterfs/src/glusterfs/async.h
@@ -200,7 +200,8 @@ gf_async(gf_async_t *async, xlator_t *xl, gf_async_callback_f cbk)
          * wake it so that the new item can be processed. If the queue was not
          * empty, we don't need to do anything special since the leader will
          * take care of it. */
-        if (caa_unlikely(kill(gf_async_ctrl.pid, GF_ASYNC_SIGQUEUE) < 0)) {
+        if (caa_unlikely(
+                IS_ERROR(kill(gf_async_ctrl.pid, GF_ASYNC_SIGQUEUE)))) {
             gf_async_fatal(errno, "Unable to wake leader worker.");
         };
     }

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -1167,4 +1167,9 @@ gf_d_type_from_ia_type(ia_type_t type);
 int
 gf_nanosleep(uint64_t nsec);
 
+char *
+gf_strerror_r(int errorcode, char *str, size_t size);
+char *
+gf_strerror(int errorcode);
+
 #endif /* _COMMON_UTILS_H */

--- a/libglusterfs/src/glusterfs/compat-errno.h
+++ b/libglusterfs/src/glusterfs/compat-errno.h
@@ -235,4 +235,8 @@ gf_errno_to_error(int32_t op_errno);
 int32_t
 gf_error_to_errno(int32_t error);
 
+#define SET_ERROR(xlidx, xlid, reason)                                         \
+    ((reason & 0x1fff) + ((xlid & 0x7f) << 13) + ((xlidx & 0x3ff) << 20) +     \
+     (0x80000000))
+
 #endif /* __COMPAT_ERRNO_H__ */

--- a/libglusterfs/src/glusterfs/dict.h
+++ b/libglusterfs/src/glusterfs/dict.h
@@ -58,7 +58,7 @@ typedef struct _data_pair data_pair_t;
             break;                                                             \
                                                                                \
         _ret = dict_allocate_and_serialize(from_dict, to, &len);               \
-        if (_ret < 0) {                                                        \
+        if (IS_ERROR(_ret)) {                                                  \
             gf_msg(this->name, GF_LOG_WARNING, 0, LG_MSG_DICT_SERIAL_FAILED,   \
                    "failed to get serialized dict (%s)", (#from_dict));        \
             ope = EINVAL;                                                      \
@@ -74,7 +74,7 @@ typedef struct _data_pair data_pair_t;
         GF_VALIDATE_OR_GOTO(xl->name, to, labl);                               \
                                                                                \
         ret = dict_unserialize(buff, len, &to);                                \
-        if (ret < 0) {                                                         \
+        if (IS_ERROR(ret)) {                                                   \
             gf_msg(xl->name, GF_LOG_WARNING, 0, LG_MSG_DICT_UNSERIAL_FAILED,   \
                    "failed to unserialize dictionary (%s)", (#to));            \
                                                                                \

--- a/libglusterfs/src/glusterfs/globals.h
+++ b/libglusterfs/src/glusterfs/globals.h
@@ -164,6 +164,9 @@ char *
 glusterfs_leaseid_buf_get(void);
 char *
 glusterfs_leaseid_exist(void);
+/* errorcode_buf */
+char *
+glusterfs_errorcode_buf_get(void);
 
 /* init */
 int
@@ -178,6 +181,7 @@ void
 glusterfs_ctx_tw_put(glusterfs_ctx_t *ctx);
 
 extern const char *gf_fop_list[];
+extern const char *gf_xlator_list[];
 extern const char *gf_upcall_list[];
 
 /* mem acct enable/disable */

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -43,7 +43,8 @@
 #define GF_YES 1
 #define GF_NO 0
 
-#define IS_ERROR(err) (err < 0)
+#define IS_ERROR(ret) ((ret) < 0)
+#define IS_SUCCESS(ret) ((ret) >=0)
 
 #ifndef O_LARGEFILE
 /* savannah bug #20053, patch for compiling on darwin */

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -43,6 +43,8 @@
 #define GF_YES 1
 #define GF_NO 0
 
+#define IS_ERROR(err) (err < 0)
+
 #ifndef O_LARGEFILE
 /* savannah bug #20053, patch for compiling on darwin */
 #define O_LARGEFILE 0100000 /* from bits/fcntl.h */
@@ -422,7 +424,7 @@ static const char *const FOP_PRI_STRINGS[] = {"HIGH", "NORMAL", "LOW", "LEAST"};
 static inline const char *
 fop_pri_to_string(gf_fop_pri_t pri)
 {
-    if (pri < 0)
+    if (IS_ERROR(pri))
         return "UNSPEC";
 
     if (pri >= GF_FOP_PRI_MAX)

--- a/libglusterfs/src/glusterfs/list.h
+++ b/libglusterfs/src/glusterfs/list.h
@@ -54,7 +54,7 @@ list_add_order(struct list_head *new, struct list_head *head,
     struct list_head *pos = head->prev;
 
     while (pos != head) {
-        if (IS_SUCCESS(compare(new, pos)))
+        if (compare(new, pos) >= 0)
             break;
 
         /* Iterate the list in the reverse order. This will have

--- a/libglusterfs/src/glusterfs/list.h
+++ b/libglusterfs/src/glusterfs/list.h
@@ -54,7 +54,7 @@ list_add_order(struct list_head *new, struct list_head *head,
     struct list_head *pos = head->prev;
 
     while (pos != head) {
-        if (compare(new, pos) >= 0)
+        if (IS_SUCCESS(compare(new, pos)))
             break;
 
         /* Iterate the list in the reverse order. This will have

--- a/libglusterfs/src/glusterfs/logging.h
+++ b/libglusterfs/src/glusterfs/logging.h
@@ -209,7 +209,7 @@ _gf_log_eh(const char *function, const char *fmt, ...)
 
 #define PRINT_SIZE_CHECK(ret, label, strsize)                                  \
     do {                                                                       \
-        if (ret < 0)                                                           \
+        if (IS_ERROR(ret))                                                     \
             goto label;                                                        \
         if ((strsize - ret) > 0) {                                             \
             strsize -= ret;                                                    \

--- a/libglusterfs/src/glusterfs/stack.h
+++ b/libglusterfs/src/glusterfs/stack.h
@@ -379,7 +379,7 @@ get_the_pt_fop(void *base_fop, int fop_idx)
             gf_msg("stack", GF_LOG_CRITICAL, 0, LG_MSG_FRAME_ERROR, "!frame"); \
             break;                                                             \
         }                                                                      \
-        if ((op_ret) < 0) {                                                    \
+        if (IS_ERROR((op_ret))) {                                              \
             gf_msg_debug("stack-trace", op_errno,                              \
                          "stack-address: %p, "                                 \
                          "%s returned %d error: %s",                           \
@@ -396,7 +396,7 @@ get_the_pt_fop(void *base_fop, int fop_idx)
         LOCK(&frame->root->stack_lock);                                        \
         {                                                                      \
             _parent->ref_count--;                                              \
-            if ((op_ret) < 0 && (op_errno) != frame->root->error) {            \
+            if (IS_ERROR((op_ret)) && (op_errno) != frame->root->error) {      \
                 frame->root->err_xl = frame->this;                             \
                 frame->root->error = (op_errno);                               \
             } else if ((op_ret) == 0) {                                        \
@@ -415,7 +415,7 @@ get_the_pt_fop(void *base_fop, int fop_idx)
             if (_parent->ret == NULL)                                          \
                 timespec_now(&_parent->end);                                   \
         }                                                                      \
-        if (op_ret < 0) {                                                      \
+        if (IS_ERROR(op_ret)) {                                                \
             GF_ATOMIC_INC(THIS->stats.total.metrics[frame->op].cbk);           \
             GF_ATOMIC_INC(THIS->stats.interval.metrics[frame->op].cbk);        \
         }                                                                      \

--- a/libglusterfs/src/glusterfs/statedump.h
+++ b/libglusterfs/src/glusterfs/statedump.h
@@ -48,7 +48,7 @@ _gf_proc_dump_build_key(char *key, const char *prefix, const char *fmt, ...)
         len = vsnprintf(key + len, GF_DUMP_MAX_BUF_LEN - len, fmt, ap);
         va_end(ap);
     }
-    if (len < 0) {
+    if (IS_ERROR(len)) {
         *key = 0;
     }
 }

--- a/libglusterfs/src/glusterfs/statedump.h
+++ b/libglusterfs/src/glusterfs/statedump.h
@@ -43,7 +43,7 @@ _gf_proc_dump_build_key(char *key, const char *prefix, const char *fmt, ...)
     int32_t len;
 
     len = snprintf(key, GF_DUMP_MAX_BUF_LEN, "%s.", prefix);
-    if (len >= 0) {
+    if (IS_SUCCESS(len)) {
         va_start(ap, fmt);
         len = vsnprintf(key + len, GF_DUMP_MAX_BUF_LEN - len, fmt, ap);
         va_end(ap);

--- a/libglusterfs/src/glusterfs/syncop.h
+++ b/libglusterfs/src/glusterfs/syncop.h
@@ -279,7 +279,7 @@ struct syncopctx {
  */
 #define DECODE_SYNCOP_ERR(ret)                                                 \
     do {                                                                       \
-        if (ret < 0) {                                                         \
+        if (IS_ERROR(ret)) {                                                   \
             errno = -ret;                                                      \
             ret = -1;                                                          \
         } else {                                                               \
@@ -375,7 +375,7 @@ syncop_create_frame(xlator_t *this)
         }
     } else {
         ngrps = getgroups(0, 0);
-        if (ngrps < 0) {
+        if (IS_ERROR(ngrps)) {
             STACK_DESTROY(frame->root);
             return NULL;
         }
@@ -385,7 +385,7 @@ syncop_create_frame(xlator_t *this)
             return NULL;
         }
 
-        if (getgroups(ngrps, frame->root->groups) < 0) {
+        if (IS_ERROR(getgroups(ngrps, frame->root->groups))) {
             STACK_DESTROY(frame->root);
             return NULL;
         }

--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -54,6 +54,28 @@ typedef struct _loc loc_t;
 typedef int32_t (*event_notify_fn_t)(xlator_t *this, int32_t event, void *data,
                                      ...);
 
+enum _gf_xlator_list {
+    GF_XLATOR_OLD_VERSION = 0,
+    GF_XLATOR_POSIX,
+    GF_XLATOR_AFR,
+    GF_XLATOR_DHT,
+    GF_XLATOR_EC,
+    GF_XLATOR_ACL,
+    GF_XLATOR_SELINUX,
+    GF_XLATOR_LOCKS,
+    GF_XLATOR_LEASES,
+    GF_XLATOR_INDEX,
+    GF_XLATOR_FUSE,
+    GF_XLATOR_IOT,
+    GF_XLATOR_MARKER,
+    GF_XLATOR_IO_STATS,
+    GF_XLATOR_SERVER,
+    GF_XLATOR_BACKEND = 125,
+    GF_XLATOR_EXTERNAL = 126,
+    GF_XLATOR_MAXVALUE = 127,
+};
+typedef enum _gf_xlator_list gf_xlator_list_t;
+
 #include "glusterfs/list.h"
 #include "glusterfs/gf-dirent.h"
 #include "glusterfs/stack.h"

--- a/libglusterfs/src/graph-print.c
+++ b/libglusterfs/src/graph-print.c
@@ -47,7 +47,7 @@ gpprintf(struct gf_printer *gp, const char *format, ...)
     ret = gf_vasprintf(&str, format, arg);
     va_end(arg);
 
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return ret;
 
     ret = gp->write(gp, str, ret);
@@ -60,7 +60,7 @@ gpprintf(struct gf_printer *gp, const char *format, ...)
 #define GPPRINTF(gp, fmt, ...)                                                 \
     do {                                                                       \
         ret = gpprintf(gp, fmt, ##__VA_ARGS__);                                \
-        if (ret == -1)                                                         \
+        if (IS_ERROR(ret))                                                     \
             goto out;                                                          \
         else                                                                   \
             gp->len += ret;                                                    \
@@ -114,7 +114,7 @@ glusterfs_graph_print(struct gf_printer *gp, glusterfs_graph_t *graph)
 
 out:
     len = gp->len;
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg("graph-print", GF_LOG_ERROR, 0, LG_MSG_PRINT_FAILED,
                "printing failed");
 

--- a/libglusterfs/src/graph.c
+++ b/libglusterfs/src/graph.c
@@ -719,7 +719,7 @@ _glusterfs_reachable_leaves(xlator_t *base, xlator_t *xl, dict_t *leaves)
 
         err = gf_asprintf(&strpos, "%d", pos);
 
-        if (err >= 0) {
+        if (IS_SUCCESS(err)) {
             err = dict_set_static_ptr(leaves, strpos, base);
             GF_FREE(strpos);
         }

--- a/libglusterfs/src/graph.c
+++ b/libglusterfs/src/graph.c
@@ -227,6 +227,7 @@ glusterfs_graph_insert(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
                        const char *type, const char *name,
                        gf_boolean_t autoload)
 {
+    int ret = 0;
     xlator_t *ixl = NULL;
 
     if (!ctx->master) {
@@ -254,13 +255,15 @@ glusterfs_graph_insert(glusterfs_graph_t *graph, glusterfs_ctx_t *ctx,
 
     ixl->is_autoloaded = autoload;
 
-    if (xlator_set_type(ixl, type) == -1) {
+    ret = xlator_set_type(ixl, type);
+    if (IS_ERROR(ret)) {
         gf_msg("glusterfs", GF_LOG_ERROR, 0, LG_MSG_INIT_FAILED,
                "%s (%s) initialization failed", name, type);
         return -1;
     }
 
-    if (glusterfs_xlator_link(ixl, graph->top) == -1)
+    ret = glusterfs_xlator_link(ixl, graph->top);
+    if (IS_ERROR(ret))
         goto err;
     glusterfs_graph_set_first(graph, ixl);
     graph->top = ixl;
@@ -711,7 +714,7 @@ _glusterfs_reachable_leaves(xlator_t *base, xlator_t *xl, dict_t *leaves)
 
     if (glusterfs_is_leaf(xl)) {
         pos = glusterfs_leaf_position(xl);
-        if (pos < 0)
+        if (IS_ERROR(pos))
             goto out;
 
         err = gf_asprintf(&strpos, "%d", pos);
@@ -1006,7 +1009,7 @@ gf_volfile_reconfigure(int oldvollen, FILE *newvolfile_fp, glusterfs_ctx_t *ctx,
 
         /* coverity[secure_temp] mkstemp uses 0600 as the mode and is safe */
         file_desc = mkstemp(temp_file);
-        if (file_desc < 0) {
+        if (IS_ERROR(file_desc)) {
             gf_msg("glusterfsd-mgmt", GF_LOG_ERROR, errno,
                    LG_MSG_TMPFILE_CREATE_FAILED,
                    "Unable to "
@@ -1019,7 +1022,7 @@ gf_volfile_reconfigure(int oldvollen, FILE *newvolfile_fp, glusterfs_ctx_t *ctx,
          */
         u_ret = sys_unlink(temp_file);
 
-        if (u_ret < 0) {
+        if (IS_ERROR(u_ret)) {
             gf_msg("glusterfsd-mgmt", GF_LOG_ERROR, errno,
                    LG_MSG_TMPFILE_DELETE_FAILED,
                    "Temporary file"
@@ -1240,7 +1243,7 @@ glusterfs_graph_attach(glusterfs_graph_t *orig_graph, char *path,
     }
 
     ret = sys_stat(path, &stbuf);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(THIS->name, GF_LOG_ERROR, "Unable to stat %s (%s)", path,
                strerror(errno));
         return -EINVAL;
@@ -1447,7 +1450,8 @@ glusterfs_muxsvc_setup_parent_graph(glusterfs_ctx_t *ctx, char *name,
 
     ixl->is_autoloaded = 1;
 
-    if (xlator_set_type(ixl, type) == -1) {
+    ret = xlator_set_type(ixl, type);
+    if (IS_ERROR(ret)) {
         gf_msg("glusterfs", GF_LOG_ERROR, EINVAL, LG_MSG_GRAPH_SETUP_FAILED,
                "%s (%s) set type failed", name, type);
         goto out;
@@ -1590,7 +1594,7 @@ glusterfs_svc_mux_pidfile_update(gf_volfile_t *volfile_obj,
 
     if (!volfile_obj->pidfp) {
         ret = glusterfs_svc_mux_pidfile_setup(volfile_obj, pid_file);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto out;
     }
     pidfp = volfile_obj->pidfp;
@@ -1645,14 +1649,14 @@ glusterfs_update_mux_pid(dict_t *dict, gf_volfile_t *volfile_obj)
     GF_VALIDATE_OR_GOTO("graph", volfile_obj, out);
 
     ret = dict_get_str(dict, "pidfile", &file);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("mgmt", GF_LOG_ERROR, EINVAL, LG_MSG_GRAPH_SETUP_FAILED,
                "Failed to get pidfile from dict for  volfile_id=%s",
                volfile_obj->vol_id);
     }
 
     ret = glusterfs_svc_mux_pidfile_update(volfile_obj, file, getpid());
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -1;
         gf_msg("mgmt", GF_LOG_ERROR, EINVAL, LG_MSG_GRAPH_SETUP_FAILED,
                "Failed to update "
@@ -1762,7 +1766,7 @@ glusterfs_process_svc_attach_volfp(glusterfs_ctx_t *ctx, FILE *fp,
 
     if (strcmp(ctx->cmd_args.process_name, "glustershd") == 0) {
         ret = glusterfs_update_mux_pid(dict, volfile_obj);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             GF_FREE(volfile_obj);
             goto out;
         }
@@ -1841,7 +1845,7 @@ glusterfs_mux_volfile_reconfigure(FILE *newvolfile_fp, glusterfs_ctx_t *ctx,
 
     if (!is_graph_topology_equal(oldvolfile_graph, newvolfile_graph)) {
         ret = snprintf(vol_id, sizeof(vol_id), "%s", volfile_obj->vol_id);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
         ret = glusterfs_process_svc_detach(ctx, volfile_obj);
         if (ret) {

--- a/libglusterfs/src/graph.y
+++ b/libglusterfs/src/graph.y
@@ -462,7 +462,7 @@ preprocess (FILE *srcfp, FILE *dstfp)
 
 				ret = execute_cmd (cmd, &result,
                                                    2 * cmd_buf_size);
-				if (ret < 0) {
+				if (IS_ERROR(ret)) {
 					ret = -1;
 					goto out;
 				}
@@ -568,11 +568,11 @@ glusterfs_graph_construct (FILE *fp)
 
         /* coverity[secure_temp] mkstemp uses 0600 as the mode and is safe */
         tmp_fd = mkstemp (template);
-        if (-1 == tmp_fd)
+        if (IS_ERROR(tmp_fd))
                 goto err;
 
         ret = sys_unlink (template);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
                 gf_msg ("parser", GF_LOG_WARNING, 0, LG_MSG_FILE_OP_FAILED,
                         "Unable to delete file: %s", template);
         }
@@ -582,7 +582,7 @@ glusterfs_graph_construct (FILE *fp)
                 goto err;
 
         ret = preprocess (fp, tmp_file);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
                 gf_msg ("parser", GF_LOG_ERROR, 0, LG_MSG_BACKTICK_PARSE_FAILED,
                         "parsing of backticks failed");
                 goto err;

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -1491,7 +1491,7 @@ out:
         }
     }
 
-    if (ret < 0)
+    if (IS_ERROR(ret))
         *bufp = NULL;
     return ret;
 }
@@ -1721,7 +1721,7 @@ inode_table_with_invalidator(uint32_t lru_limit, xlator_t *xl,
     INIT_LIST_HEAD(&new->invalidate);
 
     ret = gf_asprintf(&new->name, "%s/inode", xl->name);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         /* TODO: This should be ok to continue, check with avati */
         ;
     }
@@ -2030,7 +2030,7 @@ inode_needs_lookup(inode_t *inode, xlator_t *this)
         return ret;
 
     op_ret = inode_ctx_get(inode, this, &need_lookup);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         ret = _gf_true;
     } else if (need_lookup == LOOKUP_NEEDED) {
         ret = _gf_true;
@@ -2052,7 +2052,7 @@ __inode_ctx_set2(inode_t *inode, xlator_t *xlator, uint64_t *value1_p,
         return -1;
 
     set_idx = __inode_get_xl_index(inode, xlator);
-    if (set_idx == -1) {
+    if (IS_ERROR(set_idx)) {
         ret = -1;
         goto out;
         ;

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -517,7 +517,7 @@ __inode_unref(inode_t *inode, bool clear)
     --inode->ref;
 
     index = __inode_get_xl_index(inode, this);
-    if (index >= 0) {
+    if (IS_SUCCESS(index)) {
         inode->_ctx[index].xl_key = this;
         inode->_ctx[index].ref--;
     }
@@ -576,7 +576,7 @@ __inode_ref(inode_t *inode, bool is_invalidate)
     inode->ref++;
 
     index = __inode_get_xl_index(inode, this);
-    if (index >= 0) {
+    if (IS_SUCCESS(index)) {
         inode->_ctx[index].xl_key = this;
         inode->_ctx[index].ref++;
     }

--- a/libglusterfs/src/iobuf.c
+++ b/libglusterfs/src/iobuf.c
@@ -536,7 +536,7 @@ iobuf_get2(struct iobuf_pool *iobuf_pool, size_t page_size)
     }
 
     rounded_size = gf_iobuf_get_pagesize(page_size, &index);
-    if (rounded_size == -1) {
+    if (IS_ERROR(rounded_size)) {
         /* make sure to provide the requested buffer with standard
            memory allocations */
         iobuf = iobuf_get_from_stdalloc(iobuf_pool, page_size);
@@ -549,7 +549,7 @@ iobuf_get2(struct iobuf_pool *iobuf_pool, size_t page_size)
 
         iobuf_pool->request_misses++;
         return iobuf;
-    } else if (index == -1) {
+    } else if (IS_ERROR(index)) {
         gf_smsg("iobuf", GF_LOG_ERROR, 0, LG_MSG_PAGE_SIZE_EXCEEDED,
                 "page_size=%zu", page_size, NULL);
         return NULL;
@@ -613,7 +613,7 @@ iobuf_get(struct iobuf_pool *iobuf_pool)
     GF_VALIDATE_OR_GOTO("iobuf", iobuf_pool, out);
 
     index = gf_iobuf_get_arena_index(iobuf_pool->default_page_size);
-    if (index == -1) {
+    if (IS_ERROR(index)) {
         gf_smsg("iobuf", GF_LOG_ERROR, 0, LG_MSG_PAGE_SIZE_EXCEEDED,
                 "page_size=%zu", iobuf_pool->default_page_size, NULL);
         return NULL;
@@ -646,7 +646,7 @@ __iobuf_put(struct iobuf *iobuf, struct iobuf_arena *iobuf_arena)
     iobuf_pool = iobuf_arena->iobuf_pool;
 
     index = gf_iobuf_get_arena_index(iobuf_arena->page_size);
-    if (index == -1) {
+    if (IS_ERROR(index)) {
         gf_msg_debug("iobuf", 0,
                      "freeing the iobuf (%p) "
                      "allocated with standard calloc()",
@@ -923,7 +923,7 @@ iobref_merge(struct iobref *to, struct iobref *from)
 
             ret = iobref_add(to, iobuf);
 
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 break;
         }
     }

--- a/libglusterfs/src/latency.c
+++ b/libglusterfs/src/latency.c
@@ -33,7 +33,7 @@ gf_update_latency(call_frame_t *frame)
     elapsed = (end->tv_sec - begin->tv_sec) * 1e9 +
               (end->tv_nsec - begin->tv_nsec);
 
-    if (frame->op < 0 || frame->op >= GF_FOP_MAXVALUE) {
+    if (IS_ERROR(frame->op) || frame->op >= GF_FOP_MAXVALUE) {
         gf_log("[core]", GF_LOG_WARNING, "Invalid frame op value: %d",
                frame->op);
         return;

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -695,6 +695,8 @@ gf_store_save_value
 gf_store_save_items
 gf_store_unlink_tmppath
 gf_store_unlock
+gf_strerror_r
+gf_strerror
 gf_string2boolean
 gf_string2bytesize_int64
 gf_string2bytesize_uint64

--- a/libglusterfs/src/logging.c
+++ b/libglusterfs/src/logging.c
@@ -1061,7 +1061,7 @@ _gf_msg_backtrace(int stacksize, char *callstr, size_t strsize)
     ret = snprintf(callstr, strsize, "(");
     PRINT_SIZE_CHECK(ret, out, strsize);
 
-    for (IS_SUCCESS((i = size - 3); i); i--) {
+    for (i = (size - 3); i >= 0; i--) {
         ret = snprintf(callstr + savstrsize - strsize, strsize, "-->%s ",
                        callingfn[i]);
         PRINT_SIZE_CHECK(ret, out, strsize);

--- a/libglusterfs/src/logging.c
+++ b/libglusterfs/src/logging.c
@@ -1061,7 +1061,7 @@ _gf_msg_backtrace(int stacksize, char *callstr, size_t strsize)
     ret = snprintf(callstr, strsize, "(");
     PRINT_SIZE_CHECK(ret, out, strsize);
 
-    for ((i = size - 3); i >= 0; i--) {
+    for (IS_SUCCESS((i = size - 3); i); i--) {
         ret = snprintf(callstr + savstrsize - strsize, strsize, "-->%s ",
                        callingfn[i]);
         PRINT_SIZE_CHECK(ret, out, strsize);
@@ -1959,7 +1959,7 @@ _gf_msg(const char *domain, const char *file, const char *function,
     va_end(ap);
 
     /* log */
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         if (trace) {
             callstr = GF_MALLOC(GF_LOG_BACKTRACE_SIZE, gf_common_mt_char);
             if (callstr == NULL)

--- a/libglusterfs/src/logging.c
+++ b/libglusterfs/src/logging.c
@@ -311,7 +311,7 @@ gf_log_rotate(glusterfs_ctx_t *ctx)
 
         fd = sys_open(ctx->log.filename, O_CREAT | O_WRONLY | O_APPEND,
                       S_IRUSR | S_IWUSR);
-        if (fd < 0) {
+        if (IS_ERROR(fd)) {
             gf_smsg("logrotate", GF_LOG_ERROR, errno,
                     LG_MSG_OPEN_LOGFILE_FAILED, NULL);
             return;
@@ -436,10 +436,10 @@ gf_openlog(const char *ident, int option, int facility)
     int _option = option;
     int _facility = facility;
 
-    if (-1 == _option) {
+    if (IS_ERROR(_option)) {
         _option = LOG_PID | LOG_NDELAY;
     }
-    if (-1 == _facility) {
+    if (IS_ERROR(_facility)) {
         _facility = LOG_LOCAL1;
     }
 
@@ -658,7 +658,7 @@ gf_log_init(void *data, const char *file, const char *ident)
         }
 
         dupfd = dup(fileno(stderr));
-        if (dupfd == -1) {
+        if (IS_ERROR(dupfd)) {
             fprintf(stderr, "ERROR: could not dup %d (%s)\n", fileno(stderr),
                     strerror(errno));
             return -1;
@@ -701,7 +701,7 @@ gf_log_init(void *data, const char *file, const char *ident)
         }
 
         fd = sys_open(file, O_CREAT | O_WRONLY | O_APPEND, S_IRUSR | S_IWUSR);
-        if (fd < 0) {
+        if (IS_ERROR(fd)) {
             fprintf(stderr,
                     "ERROR: failed to create logfile"
                     " \"%s\" (%s)\n",
@@ -796,7 +796,7 @@ _gf_log_callingfn(const char *domain, const char *file, const char *function,
     va_start(ap, fmt);
     ret = vasprintf(&msg, fmt, ap);
     va_end(ap);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -817,7 +817,7 @@ _gf_log_callingfn(const char *domain, const char *file, const char *function,
     }
 
     ret = gettimeofday(&tv, NULL);
-    if (-1 == ret)
+    if (IS_ERROR(ret))
         goto out;
 
     gf_time_fmt(timestr, sizeof timestr, tv.tv_sec, gf_timefmt_FT);
@@ -826,7 +826,7 @@ _gf_log_callingfn(const char *domain, const char *file, const char *function,
         &logline, "[%s.%" GF_PRI_SUSECONDS "] %c [%s:%d:%s] %s %d-%s: %s\n",
         timestr, tv.tv_usec, gf_level_strings[level], basename, line, function,
         callstr, ((this->graph) ? this->graph->id : 0), domain, msg);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -931,7 +931,7 @@ _gf_msg_plain(gf_loglevel_t level, const char *fmt, ...)
     va_start(ap, fmt);
     ret = vasprintf(&msg, fmt, ap);
     va_end(ap);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -961,7 +961,7 @@ _gf_msg_vplain(gf_loglevel_t level, const char *fmt, va_list ap)
         goto out;
 
     ret = vasprintf(&msg, fmt, ap);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -1051,7 +1051,7 @@ _gf_msg_backtrace(int stacksize, char *callstr, size_t strsize)
         goto out;
 
     size = backtrace(array, ((stacksize <= 200) ? stacksize : 200));
-    if ((size - 3) < 0)
+    if (IS_ERROR((size - 3)))
         goto out;
     if (size)
         callingfn = backtrace_symbols(&array[2], size - 2);
@@ -1114,7 +1114,7 @@ _gf_msg_nomem(const char *domain, const char *file, const char *function,
     GET_FILE_NAME_TO_LOG(file, basename);
 
     ret = gettimeofday(&tv, NULL);
-    if (-1 == ret)
+    if (IS_ERROR(ret))
         goto out;
     gf_time_fmt(timestr, sizeof timestr, tv.tv_sec, gf_timefmt_FT);
 
@@ -1131,7 +1131,7 @@ _gf_msg_nomem(const char *domain, const char *file, const char *function,
         timestr, tv.tv_usec, gf_level_strings[level], (uint64_t)0, basename,
         line, function, domain, size,
         (!getrusage(RUSAGE_SELF, &r_usage) ? r_usage.ru_maxrss : 0));
-    if (-1 == wlen) {
+    if (IS_ERROR(wlen)) {
         ret = -1;
         goto out;
     }
@@ -1157,7 +1157,7 @@ _gf_msg_nomem(const char *domain, const char *file, const char *function,
             {
                 fd = ctx->log.logfile ? fileno(ctx->log.logfile)
                                       : fileno(stderr);
-                if (fd == -1) {
+                if (IS_ERROR(fd)) {
                     pthread_mutex_unlock(&ctx->log.logfile_mutex);
                     goto out;
                 }
@@ -1165,7 +1165,7 @@ _gf_msg_nomem(const char *domain, const char *file, const char *function,
                 /* write directly to the fd to prevent out of order
                  * message and stack */
                 ret = sys_write(fd, msg, wlen);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     pthread_mutex_unlock(&ctx->log.logfile_mutex);
                     goto out;
                 }
@@ -1294,7 +1294,7 @@ gf_log_glusterlog(glusterfs_ctx_t *ctx, const char *domain, const char *file,
     } else {
         ret = gf_asprintf(&footer, " \n");
     }
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -1338,7 +1338,7 @@ gf_log_glusterlog(glusterfs_ctx_t *ctx, const char *domain, const char *file,
                               domain, *appmsgstr);
         }
     }
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -1455,7 +1455,7 @@ gf_glusterlog_log_repetitions(glusterfs_ctx_t *ctx, const char *domain,
                       " [%s:%d:%s] %d-%s: %s",
                       gf_level_strings[level], msgid, file, line, function,
                       graph_id, domain, *appmsgstr);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -1474,7 +1474,7 @@ gf_glusterlog_log_repetitions(glusterfs_ctx_t *ctx, const char *domain,
                       "]",
                       errstr, refcount, timestr_oldest, oldest.tv_usec,
                       timestr_latest, latest.tv_usec);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         ret = -1;
         goto err;
     }
@@ -1959,7 +1959,7 @@ _gf_msg(const char *domain, const char *file, const char *function,
     va_end(ap);
 
     /* log */
-    if (ret != -1) {
+    if (ret >= 0) {
         if (trace) {
             callstr = GF_MALLOC(GF_LOG_BACKTRACE_SIZE, gf_common_mt_char);
             if (callstr == NULL)
@@ -1967,7 +1967,7 @@ _gf_msg(const char *domain, const char *file, const char *function,
 
             ret = _gf_msg_backtrace(GF_LOG_BACKTRACE_DEPTH, callstr,
                                     GF_LOG_BACKTRACE_SIZE);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 GF_FREE(callstr);
                 callstr = NULL;
             }
@@ -2047,7 +2047,7 @@ _gf_log(const char *domain, const char *file, const char *function, int line,
     va_start(ap, fmt);
     ret = vasprintf(&msg, fmt, ap);
     va_end(ap);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -2070,7 +2070,7 @@ _gf_log(const char *domain, const char *file, const char *function, int line,
         ctx->log.logrotate = 0;
 
         fd = sys_open(ctx->log.filename, O_CREAT | O_RDONLY, S_IRUSR | S_IWUSR);
-        if (fd < 0) {
+        if (IS_ERROR(fd)) {
             gf_smsg("logrotate", GF_LOG_ERROR, errno,
                     LG_MSG_OPEN_LOGFILE_FAILED, NULL);
             return -1;
@@ -2097,7 +2097,7 @@ _gf_log(const char *domain, const char *file, const char *function, int line,
 
 log:
     ret = gettimeofday(&tv, NULL);
-    if (-1 == ret)
+    if (IS_ERROR(ret))
         goto out;
 
     gf_time_fmt(timestr, sizeof timestr, tv.tv_sec, gf_timefmt_FT);
@@ -2106,7 +2106,7 @@ log:
         &logline, "[%s.%" GF_PRI_SUSECONDS "] %c [%s:%d:%s] %d-%s: %s\n",
         timestr, tv.tv_usec, gf_level_strings[level], basename, line, function,
         ((this->graph) ? this->graph->id : 0), domain, msg);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -2154,13 +2154,13 @@ _gf_log_eh(const char *function, const char *fmt, ...)
     va_start(ap, fmt);
     ret = vasprintf(&msg, fmt, ap);
     va_end(ap);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
     ret = gf_asprintf(&logline, "[%d] %s: %s",
                       ((this->graph) ? this->graph->id : 0), function, msg);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -2205,7 +2205,7 @@ gf_cmd_log_init(const char *filename)
 
     fd = sys_open(ctx->log.cmd_log_filename, O_CREAT | O_WRONLY | O_APPEND,
                   S_IRUSR | S_IWUSR);
-    if (fd < 0) {
+    if (IS_ERROR(fd)) {
         gf_smsg(this->name, GF_LOG_CRITICAL, errno, LG_MSG_OPEN_LOGFILE_FAILED,
                 "cmd_log_file", NULL);
         return -1;
@@ -2249,12 +2249,12 @@ gf_cmd_log(const char *domain, const char *fmt, ...)
     }
 
     ret = gettimeofday(&tv, NULL);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
     va_start(ap, fmt);
     ret = vasprintf(&msg, fmt, ap);
     va_end(ap);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -2262,7 +2262,7 @@ gf_cmd_log(const char *domain, const char *fmt, ...)
 
     ret = gf_asprintf(&logline, "[%s.%" GF_PRI_SUSECONDS "] %s : %s\n", timestr,
                       tv.tv_usec, domain, msg);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -2277,7 +2277,7 @@ gf_cmd_log(const char *domain, const char *fmt, ...)
 
         fd = sys_open(ctx->log.cmd_log_filename, O_CREAT | O_WRONLY | O_APPEND,
                       S_IRUSR | S_IWUSR);
-        if (fd < 0) {
+        if (IS_ERROR(fd)) {
             gf_smsg(THIS->name, GF_LOG_CRITICAL, errno,
                     LG_MSG_OPEN_LOGFILE_FAILED, "name=%s",
                     ctx->log.cmd_log_filename, NULL);
@@ -2363,7 +2363,7 @@ _do_slog_format(int errnum, const char *event, va_list inp, char **msg)
             /* Make separate valist and format the string */
             va_copy(valist_tmp, inp);
             ret = gf_vasprintf(&buffer, fmt, valist_tmp);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 va_end(valist_tmp);
                 goto out;
             }
@@ -2376,14 +2376,14 @@ _do_slog_format(int errnum, const char *event, va_list inp, char **msg)
             }
 
             ret = gf_asprintf(&tmp2, "%s%s{%s}", tmp1, temp_sep, buffer);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
 
             GF_FREE(buffer);
             buffer = NULL;
         } else {
             ret = gf_asprintf(&tmp2, "%s%s{%s}", tmp1, temp_sep, fmt);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
         }
 
@@ -2411,7 +2411,7 @@ _do_slog_format(int errnum, const char *event, va_list inp, char **msg)
         ret = gf_asprintf(&tmp2, "%s [%s]", event, tmp1);
     }
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     *msg = gf_strdup(tmp2);
@@ -2446,7 +2446,7 @@ _gf_smsg(const char *domain, const char *file, const char *function,
 
     va_start(valist, event);
     ret = _do_slog_format(errnum, event, valist, &msg);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     /* Pass errnum as zero since it is already formated as required */

--- a/libglusterfs/src/monitoring.c
+++ b/libglusterfs/src/monitoring.c
@@ -246,13 +246,13 @@ gf_monitor_metrics(glusterfs_ctx_t *ctx)
     }
 
     ret = gf_asprintf(&filepath, "%s/gmetrics.XXXXXX", dumppath);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         return NULL;
     }
 
     /* coverity[secure_temp] mkstemp uses 0600 as the mode and is safe */
     fd = mkstemp(filepath);
-    if (fd < 0) {
+    if (IS_ERROR(fd)) {
         gf_msg("monitoring", GF_LOG_ERROR, 0, LG_MSG_STRDUP_ERROR,
                "failed to open tmp file %s (%s)", filepath, strerror(errno));
         GF_FREE(filepath);
@@ -265,13 +265,13 @@ gf_monitor_metrics(glusterfs_ctx_t *ctx)
 
     /* This below line is used just to capture any errors with dprintf() */
     ret = dprintf(fd, "\n# End of metrics\n");
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("monitoring", GF_LOG_WARNING, 0, LG_MSG_STRDUP_ERROR,
                "dprintf() failed: %s", strerror(errno));
     }
 
     ret = sys_fsync(fd);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("monitoring", GF_LOG_WARNING, 0, LG_MSG_STRDUP_ERROR,
                "fsync() failed: %s", strerror(errno));
     }

--- a/libglusterfs/src/quota-common-utils.c
+++ b/libglusterfs/src/quota-common-utils.c
@@ -190,7 +190,7 @@ quota_conf_read_version(int fd, float *version)
     ret = 0;
 
 out:
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         *version = value;
     else
         gf_msg_callingfn("quota", GF_LOG_ERROR, 0, LG_MSG_QUOTA_CONF_ERROR,

--- a/libglusterfs/src/quota-common-utils.c
+++ b/libglusterfs/src/quota-common-utils.c
@@ -126,7 +126,7 @@ quota_dict_set_meta(dict_t *dict, char *key, const quota_meta_t *meta,
         ret = dict_set_bin(dict, key, value, sizeof(*value) - sizeof(int64_t));
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_callingfn("quota", GF_LOG_ERROR, 0, LG_MSG_DICT_SET_FAILED,
                          "dict set failed");
         GF_FREE(value);
@@ -153,7 +153,7 @@ quota_conf_read_header(int fd, char *buf)
     buf[header_len - 1] = 0;
 
 out:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_msg_callingfn("quota", GF_LOG_ERROR, 0, LG_MSG_QUOTA_CONF_ERROR,
                          "failed to read "
                          "header from a quota conf");
@@ -174,7 +174,7 @@ quota_conf_read_version(int fd, float *version)
         /* quota.conf is empty */
         value = GF_QUOTA_CONF_VERSION;
         goto out;
-    } else if (ret < 0) {
+    } else if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -226,7 +226,7 @@ quota_conf_read_gfid(int fd, void *buf, char *type, float version)
     }
 
 out:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_msg_callingfn("quota", GF_LOG_ERROR, 0, LG_MSG_QUOTA_CONF_ERROR,
                          "failed to "
                          "read gfid from a quota conf");

--- a/libglusterfs/src/rbthash.c
+++ b/libglusterfs/src/rbthash.c
@@ -127,7 +127,7 @@ rbthash_table_init(glusterfs_ctx_t *ctx, int buckets, rbt_hasher_t hfunc,
     newtab->numbuckets = buckets;
     ret = __rbthash_init_buckets(newtab, buckets);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_smsg(GF_RBTHASH, GF_LOG_ERROR, 0, LG_MSG_RBTHASH_INIT_BUCKET_FAILED,
                 NULL);
         if (newtab->pool_alloced)
@@ -143,11 +143,11 @@ rbthash_table_init(glusterfs_ctx_t *ctx, int buckets, rbt_hasher_t hfunc,
     newtab->dfunc = dfunc;
 
 free_buckets:
-    if (ret == -1)
+    if (IS_ERROR(ret))
         GF_FREE(newtab->buckets);
 
 free_newtab:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         GF_FREE(newtab);
         newtab = NULL;
     }
@@ -185,7 +185,7 @@ rbthash_init_entry(rbthash_table_t *tbl, void *data, void *key, int keylen)
 
     ret = 0;
 free_entry:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         mem_put(entry);
         entry = NULL;
     }
@@ -279,7 +279,7 @@ rbthash_insert(rbthash_table_t *tbl, void *data, void *key, int keylen)
 
     ret = rbthash_insert_entry(tbl, entry);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_smsg(GF_RBTHASH, GF_LOG_ERROR, 0, LG_MSG_RBTHASH_INSERT_FAILED,
                 NULL);
         rbthash_deinit_entry(tbl, entry);

--- a/libglusterfs/src/run.c
+++ b/libglusterfs/src/run.c
@@ -250,7 +250,7 @@ runner_redir(runner_t *runner, int fd, int tgt_fd)
     GF_ASSERT(fd > 0 && fd < 3);
 
     if ((fd > 0) && (fd < 3))
-        runner->chfd[fd] = (tgt_fd >= 0) ? tgt_fd : -2;
+        runner->chfd[fd] = (IS_SUCCESS(tgt_fd)) ? tgt_fd : -2;
 }
 
 int
@@ -274,21 +274,21 @@ runner_start(runner_t *runner)
      * possible execve(2) failures
      */
     ret = pipe(xpi);
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         ret = fcntl(xpi[1], F_SETFD, FD_CLOEXEC);
 
     for (i = 0; i < 3; i++) {
         if (runner->chfd[i] != -2)
             continue;
         ret = pipe(pi[i]);
-        if (ret >= 0) {
+        if (IS_SUCCESS(ret)) {
             runner->chio[i] = fdopen(pi[i][i ? 0 : 1], i ? "r" : "w");
             if (!runner->chio[i])
                 ret = -1;
         }
     }
 
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         runner->chpid = fork();
     switch (runner->chpid) {
         case -1:
@@ -324,13 +324,13 @@ runner_start(runner_t *runner)
                 }
             }
 
-            if (ret >= 0) {
+            if (IS_SUCCESS(ret)) {
                 int fdv[4] = {0, 1, 2, xpi[1]};
 
                 ret = close_fds_except(fdv, sizeof(fdv) / sizeof(*fdv));
             }
 
-            if (ret >= 0) {
+            if (IS_SUCCESS(ret)) {
                 /* save child from inheriting our signal handling */
                 sigemptyset(&set);
                 sigprocmask(SIG_SETMASK, &set, NULL);

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -691,7 +691,7 @@ gf_proc_dump_parse_set_option(char *key, char *value)
             ret = -1;
         else {
             ret = sys_write(gf_dump_fd, buf, len);
-            if (ret >= 0)
+            if (IS_SUCCESS(ret))
                 ret = -1;
         }
         goto out;

--- a/libglusterfs/src/statedump.c
+++ b/libglusterfs/src/statedump.c
@@ -60,7 +60,7 @@ gf_proc_dump_open(char *tmpname)
     mode_t mask = umask(S_IRWXG | S_IRWXO);
     dump_fd = mkstemp(tmpname);
     umask(mask);
-    if (dump_fd < 0)
+    if (IS_ERROR(dump_fd))
         return -1;
 
     gf_dump_fd = dump_fd;
@@ -687,7 +687,7 @@ gf_proc_dump_parse_set_option(char *key, char *value)
                        "[Warning]:None of the options "
                        "matched key : %s\n",
                        key);
-        if (len < 0)
+        if (IS_ERROR(len))
             ret = -1;
         else {
             ret = sys_write(gf_dump_fd, buf, len);
@@ -833,7 +833,7 @@ gf_proc_dump_info(int signum, glusterfs_ctx_t *ctx)
         snprintf(brick_name, sizeof(brick_name), "glusterdump");
 
     ret = gf_proc_dump_options_init();
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = snprintf(
@@ -843,7 +843,7 @@ gf_proc_dump_info(int signum, glusterfs_ctx_t *ctx)
              : ((ctx->statedump_path != NULL) ? ctx->statedump_path
                                               : DEFAULT_VAR_RUN_DIRECTORY)),
         brick_name, getpid(), (uint64_t)time(NULL));
-    if ((ret < 0) || (ret >= sizeof(path))) {
+    if (IS_ERROR(ret) || (ret >= sizeof(path))) {
         goto out;
     }
 
@@ -855,7 +855,7 @@ gf_proc_dump_info(int signum, glusterfs_ctx_t *ctx)
                                               : DEFAULT_VAR_RUN_DIRECTORY)));
 
     ret = gf_proc_dump_open(tmp_dump_name);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     // continue even though gettimeofday() has failed

--- a/libglusterfs/src/store.c
+++ b/libglusterfs/src/store.c
@@ -107,7 +107,7 @@ gf_store_sync_direntry(char *path)
 
     ret = 0;
 out:
-    if (dirfd >= 0) {
+    if (IS_SUCCESS(dirfd)) {
         ret = sys_close(dirfd);
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, errno, LG_MSG_DIR_OP_FAILED,
@@ -148,7 +148,7 @@ gf_store_rename_tmppath(gf_store_handle_t *shandle)
 
     ret = gf_store_sync_direntry(tmppath);
 out:
-    if (shandle && shandle->tmp_fd >= 0) {
+    if (IS_SUCCESS(shandle && shandle->tmp_fd)) {
         sys_close(shandle->tmp_fd);
         shandle->tmp_fd = -1;
     }
@@ -175,7 +175,7 @@ gf_store_unlink_tmppath(gf_store_handle_t *shandle)
         ret = 0;
     }
 out:
-    if (shandle && shandle->tmp_fd >= 0) {
+    if (IS_SUCCESS(shandle && shandle->tmp_fd)) {
         sys_close(shandle->tmp_fd);
         shandle->tmp_fd = -1;
     }
@@ -261,7 +261,7 @@ gf_store_retrieve_value(gf_store_handle_t *handle, char *key, char **value)
     if (!handle->read) {
         int duped_fd = dup(handle->fd);
 
-        if (duped_fd >= 0)
+        if (IS_SUCCESS(duped_fd))
             handle->read = fdopen(duped_fd, "r");
         if (!handle->read) {
             if (duped_fd != -1)
@@ -437,7 +437,7 @@ gf_store_handle_new(const char *path, gf_store_handle_t **handle)
 
     ret = 0;
 out:
-    if (fd >= 0)
+    if (IS_SUCCESS(fd))
         sys_close(fd);
 
     if (ret) {

--- a/libglusterfs/src/store.c
+++ b/libglusterfs/src/store.c
@@ -24,7 +24,7 @@ gf_store_mkdir(char *path)
 
     ret = mkdir_p(path, 0755, _gf_true);
 
-    if ((-1 == ret) && (EEXIST != errno)) {
+    if ((IS_ERROR(ret) && (EEXIST != errno))) {
         gf_msg("", GF_LOG_ERROR, errno, LG_MSG_DIR_OP_FAILED,
                "mkdir()"
                " failed on path %s.",
@@ -67,7 +67,7 @@ gf_store_mkstemp(gf_store_handle_t *shandle)
 
     snprintf(tmppath, sizeof(tmppath), "%s.tmp", shandle->path);
     shandle->tmp_fd = open(tmppath, O_RDWR | O_CREAT | O_TRUNC, 0600);
-    if (shandle->tmp_fd < 0) {
+    if (IS_ERROR(shandle->tmp_fd)) {
         gf_msg("", GF_LOG_ERROR, errno, LG_MSG_FILE_OP_FAILED,
                "Failed to open %s.", tmppath);
     }
@@ -92,7 +92,7 @@ gf_store_sync_direntry(char *path)
 
     pdir = dirname(dir);
     dirfd = open(pdir, O_RDONLY);
-    if (dirfd == -1) {
+    if (IS_ERROR(dirfd)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, LG_MSG_DIR_OP_FAILED,
                "Failed to open directory %s.", pdir);
         goto out;
@@ -253,7 +253,7 @@ gf_store_retrieve_value(gf_store_handle_t *handle, char *key, char **value)
         /* handle->fd is valid already, kept open for lockf() */
         sys_lseek(handle->fd, 0, SEEK_SET);
 
-    if (handle->fd == -1) {
+    if (IS_ERROR(handle->fd)) {
         gf_msg("", GF_LOG_ERROR, errno, LG_MSG_FILE_OP_FAILED,
                "Unable to open file %s", handle->path);
         goto out;
@@ -276,7 +276,7 @@ gf_store_retrieve_value(gf_store_handle_t *handle, char *key, char **value)
     do {
         ret = gf_store_read_and_tokenize(handle->read, &iter_key, &iter_val,
                                          &store_errno);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg_trace("", 0,
                          "error while reading key '%s': "
                          "%s",
@@ -320,7 +320,7 @@ gf_store_save_value(int fd, char *key, char *value)
     GF_ASSERT(value);
 
     dup_fd = dup(fd);
-    if (dup_fd == -1)
+    if (IS_ERROR(dup_fd))
         goto out;
 
     fp = fdopen(dup_fd, "a+");
@@ -332,7 +332,7 @@ gf_store_save_value(int fd, char *key, char *value)
     }
 
     ret = fprintf(fp, "%s=%s\n", key, value);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(THIS->name, GF_LOG_WARNING, errno, LG_MSG_FILE_OP_FAILED,
                "Unable to store key: %s, value: %s.", key, value);
         ret = -1;
@@ -367,7 +367,7 @@ gf_store_save_items(int fd, char *items)
     GF_ASSERT(items);
 
     dup_fd = dup(fd);
-    if (dup_fd == -1)
+    if (IS_ERROR(dup_fd))
         goto out;
 
     fp = fdopen(dup_fd, "a+");
@@ -379,7 +379,7 @@ gf_store_save_items(int fd, char *items)
     }
 
     ret = fputs(items, fp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(THIS->name, GF_LOG_WARNING, errno, LG_MSG_FILE_OP_FAILED,
                "Unable to store items: %s", items);
         ret = -1;
@@ -420,7 +420,7 @@ gf_store_handle_new(const char *path, gf_store_handle_t **handle)
         goto out;
 
     fd = open(path, O_RDWR | O_CREAT | O_APPEND, 0600);
-    if (fd < 0) {
+    if (IS_ERROR(fd)) {
         gf_msg("", GF_LOG_ERROR, errno, LG_MSG_FILE_OP_FAILED,
                "Failed to open file: %s.", path);
         goto out;
@@ -587,7 +587,7 @@ gf_store_iter_get_next(gf_store_iter_t *iter, char **key, char **value,
 
     ret = gf_store_read_and_tokenize(iter->file, &iter_key, &iter_val,
                                      &store_errno);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -700,7 +700,7 @@ gf_store_lock(gf_store_handle_t *sh)
     GF_ASSERT(sh->locked == F_ULOCK);
 
     sh->fd = open(sh->path, O_RDWR);
-    if (sh->fd == -1) {
+    if (IS_ERROR(sh->fd)) {
         gf_msg("", GF_LOG_ERROR, errno, LG_MSG_FILE_OP_FAILED,
                "Failed to open '%s'", sh->path);
         return -1;
@@ -726,7 +726,7 @@ gf_store_unlock(gf_store_handle_t *sh)
     sh->locked = F_ULOCK;
 
     /* does not matter if this fails, locks are released on close anyway */
-    if (lockf(sh->fd, F_ULOCK, 0) == -1)
+    if (IS_ERROR(lockf(sh->fd, F_ULOCK, 0)))
         gf_msg("", GF_LOG_ERROR, errno, LG_MSG_UNLOCK_FAILED,
                "Failed to release lock on '%s'", sh->path);
 

--- a/libglusterfs/src/strfd.c
+++ b/libglusterfs/src/strfd.c
@@ -33,7 +33,7 @@ strvprintf(strfd_t *strfd, const char *fmt, va_list ap)
 
     size = vasprintf(&str, fmt, ap);
 
-    if (size < 0)
+    if (IS_ERROR(size))
         return size;
 
     if (!strfd->alloc_size) {

--- a/libglusterfs/src/syncop-utils.c
+++ b/libglusterfs/src/syncop-utils.c
@@ -105,7 +105,7 @@ syncop_ftw(xlator_t *subvol, loc_t *loc, int pid, void *data,
 
     while ((ret = syncop_readdirp(subvol, fd, 131072, offset, &entries, NULL,
                                   NULL))) {
-        if (ret < 0)
+        if (IS_ERROR(ret))
             break;
 
         if (ret > 0) {
@@ -185,7 +185,7 @@ syncop_ftw_throttle(xlator_t *subvol, loc_t *loc, int pid, void *data,
 
     while ((ret = syncop_readdirp(subvol, fd, 131072, offset, &entries, NULL,
                                   NULL))) {
-        if (ret < 0)
+        if (IS_ERROR(ret))
             break;
 
         if (ret > 0) {
@@ -317,7 +317,7 @@ _run_dir_scan_task(call_frame_t *frame, xlator_t *subvol, loc_t *parent,
     ret = synctask_new(subvol->ctx->env, _dir_scan_job_fn, _dir_scan_job_fn_cbk,
                        frame, scan_data);
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_dirent_entry_free(entry);
         _scan_data_destroy(scan_data);
         pthread_mutex_lock(mut);
@@ -379,7 +379,7 @@ syncop_mt_dir_scan(call_frame_t *frame, xlator_t *subvol, loc_t *loc, int pid,
 
     while ((ret = syncop_readdir(subvol, fd, 131072, offset, &entries, xdata,
                                  NULL))) {
-        if (ret < 0)
+        if (IS_ERROR(ret))
             break;
 
         if (ret > 0) {
@@ -474,7 +474,7 @@ syncop_dir_scan(xlator_t *subvol, loc_t *loc, int pid, void *data,
 
     while ((ret = syncop_readdir(subvol, fd, 131072, offset, &entries, NULL,
                                  NULL))) {
-        if (ret < 0)
+        if (IS_ERROR(ret))
             break;
 
         if (ret > 0) {
@@ -521,7 +521,7 @@ syncop_is_subvol_local(xlator_t *this, loc_t *loc, gf_boolean_t *is_local)
     *is_local = _gf_false;
 
     ret = syncop_getxattr(this, loc, &xattr, GF_XATTR_PATHINFO_KEY, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -1;
         goto out;
     }
@@ -583,7 +583,7 @@ syncop_gfid_to_path_hard(inode_table_t *itable, xlator_t *subvol, uuid_t gfid,
         ret = syncop_getxattr(subvol, &loc, &xattr, GFID2PATH_VIRT_XATTR_KEY,
                               NULL, NULL);
 
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     /*
@@ -655,7 +655,7 @@ syncop_inode_find(xlator_t *this, xlator_t *subvol, uuid_t gfid,
     gf_uuid_copy(loc.gfid, gfid);
 
     ret = syncop_lookup(subvol, &loc, &iatt, NULL, xdata, rsp_dict);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     *inode = inode_link(loc.inode, NULL, NULL, &iatt);

--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -1169,7 +1169,7 @@ syncop_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         list_for_each_entry(entry, &entries->list, list)
         {
             tmp = entry_copy(entry);
@@ -1239,7 +1239,7 @@ syncop_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         list_for_each_entry(entry, &entries->list, list)
         {
             tmp = entry_copy(entry);
@@ -1536,7 +1536,7 @@ syncop_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         args->xattr = dict_ref(dict);
 
     __wake(args);
@@ -1804,7 +1804,7 @@ syncop_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (args->op_ret >= 0) {
+    if (IS_SUCCESS(args->op_ret)) {
         if (iobref)
             args->iobref = iobref_ref(iobref);
         args->vector = iov_dup(vector, count);
@@ -1874,7 +1874,7 @@ syncop_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *prebuf;
         args->iatt2 = *postbuf;
     }
@@ -2230,7 +2230,7 @@ syncop_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *prebuf;
         args->iatt2 = *postbuf;
     }
@@ -2301,7 +2301,7 @@ syncop_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *prebuf;
         args->iatt2 = *postbuf;
     }
@@ -2504,7 +2504,7 @@ syncop_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if ((op_ret >= 0) && path)
+    if (IS_SUCCESS((op_ret)) && path)
         args->buffer = gf_strdup(path);
 
     __wake(args);
@@ -3350,7 +3350,7 @@ syncop_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *stbuf;
         args->iatt2 = *prebuf_dst;
         args->iatt3 = *postbuf_dst;

--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -240,7 +240,7 @@ synctask_yield(struct synctask *task)
     if (task->state != SYNCTASK_DONE) {
         task->state = SYNCTASK_SUSPEND;
     }
-    if (swapcontext(&task->ctx, &task->proc->sched) < 0) {
+    if (IS_ERROR(swapcontext(&task->ctx, &task->proc->sched))) {
         gf_msg("syncop", GF_LOG_ERROR, errno, LG_MSG_SWAPCONTEXT_FAILED,
                "swapcontext failed");
     }
@@ -389,7 +389,7 @@ synctask_create(struct syncenv *env, size_t stacksize, synctask_fn_t fn,
     INIT_LIST_HEAD(&newtask->all_tasks);
     INIT_LIST_HEAD(&newtask->waitq);
 
-    if (getcontext(&newtask->ctx) < 0) {
+    if (IS_ERROR(getcontext(&newtask->ctx))) {
         gf_msg("syncop", GF_LOG_ERROR, errno, LG_MSG_GETCONTEXT_FAILED,
                "getcontext failed");
         goto err;
@@ -555,7 +555,7 @@ synctask_switchto(struct synctask *task)
     task->ctx.uc_flags &= ~_UC_TLSBASE;
 #endif
 
-    if (swapcontext(&task->proc->sched, &task->ctx) < 0) {
+    if (IS_ERROR(swapcontext(&task->proc->sched, &task->ctx))) {
         gf_msg("syncop", GF_LOG_ERROR, errno, LG_MSG_SWAPCONTEXT_FAILED,
                "swapcontext failed");
     }
@@ -691,7 +691,7 @@ syncenv_new(size_t stacksize, int procmin, int procmax)
     int ret = 0;
     int i = 0;
 
-    if (!procmin || procmin < 0)
+    if (!procmin || IS_ERROR(procmin))
         procmin = SYNCENV_PROC_MIN;
     if (!procmax || procmax > SYNCENV_PROC_MAX)
         procmax = SYNCENV_PROC_MAX;
@@ -1144,7 +1144,7 @@ syncop_lookup(xlator_t *subvol, loc_t *loc, struct iatt *iatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1214,7 +1214,7 @@ syncop_readdirp(xlator_t *subvol, fd_t *fd, size_t size, off_t off,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1284,7 +1284,7 @@ syncop_readdir(xlator_t *subvol, fd_t *fd, size_t size, off_t off,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1323,7 +1323,7 @@ syncop_opendir(xlator_t *subvol, loc_t *loc, fd_t *fd, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1362,7 +1362,7 @@ syncop_fsyncdir(xlator_t *subvol, fd_t *fd, int datasync, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1401,7 +1401,7 @@ syncop_removexattr(xlator_t *subvol, loc_t *loc, const char *name,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1440,7 +1440,7 @@ syncop_fremovexattr(xlator_t *subvol, fd_t *fd, const char *name,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1479,7 +1479,7 @@ syncop_setxattr(xlator_t *subvol, loc_t *loc, dict_t *dict, int32_t flags,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1518,7 +1518,7 @@ syncop_fsetxattr(xlator_t *subvol, fd_t *fd, dict_t *dict, int32_t flags,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1565,7 +1565,7 @@ syncop_listxattr(xlator_t *subvol, loc_t *loc, dict_t **dict, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1591,7 +1591,7 @@ syncop_getxattr(xlator_t *subvol, loc_t *loc, dict_t **dict, const char *key,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1617,7 +1617,7 @@ syncop_fgetxattr(xlator_t *subvol, fd_t *fd, dict_t **dict, const char *key,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1665,7 +1665,7 @@ syncop_statfs(xlator_t *subvol, loc_t *loc, struct statvfs *buf,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1716,7 +1716,7 @@ syncop_setattr(xlator_t *subvol, loc_t *loc, struct iatt *iatt, int valid,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1743,7 +1743,7 @@ syncop_fsetattr(xlator_t *subvol, fd_t *fd, struct iatt *iatt, int valid,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1782,7 +1782,7 @@ syncop_open(xlator_t *subvol, loc_t *loc, int32_t flags, fd_t *fd,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1837,7 +1837,7 @@ syncop_readv(xlator_t *subvol, fd_t *fd, size_t size, off_t off, uint32_t flags,
     if (iatt)
         *iatt = args.iatt1;
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         goto out;
 
     if (vector)
@@ -1855,7 +1855,7 @@ syncop_readv(xlator_t *subvol, fd_t *fd, size_t size, off_t off, uint32_t flags,
         iobref_unref(args.iobref);
 
 out:
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1907,7 +1907,7 @@ syncop_writev(xlator_t *subvol, fd_t *fd, const struct iovec *vector,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1935,7 +1935,7 @@ syncop_write(xlator_t *subvol, fd_t *fd, const char *buf, int size,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -1990,7 +1990,7 @@ syncop_create(xlator_t *subvol, loc_t *loc, int32_t flags, mode_t mode,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2040,7 +2040,7 @@ syncop_put(xlator_t *subvol, loc_t *loc, mode_t mode, mode_t umask,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2080,7 +2080,7 @@ syncop_unlink(xlator_t *subvol, loc_t *loc, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2120,7 +2120,7 @@ syncop_rmdir(xlator_t *subvol, loc_t *loc, int flags, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2167,7 +2167,7 @@ syncop_link(xlator_t *subvol, loc_t *oldloc, loc_t *newloc, struct iatt *iatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
     return args.op_ret;
@@ -2210,7 +2210,7 @@ syncop_rename(xlator_t *subvol, loc_t *oldloc, loc_t *newloc, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
     return args.op_ret;
@@ -2261,7 +2261,7 @@ syncop_ftruncate(xlator_t *subvol, fd_t *fd, off_t offset, struct iatt *preiatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2282,7 +2282,7 @@ syncop_truncate(xlator_t *subvol, loc_t *loc, off_t offset, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2332,7 +2332,7 @@ syncop_fsync(xlator_t *subvol, fd_t *fd, int dataonly, struct iatt *preiatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2368,7 +2368,7 @@ syncop_flush(xlator_t *subvol, fd_t *fd, dict_t *xdata_in, dict_t **xdata_out)
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2414,7 +2414,7 @@ syncop_fstat(xlator_t *subvol, fd_t *fd, struct iatt *stbuf, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2438,7 +2438,7 @@ syncop_stat(xlator_t *subvol, loc_t *loc, struct iatt *stbuf, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2485,7 +2485,7 @@ syncop_symlink(xlator_t *subvol, loc_t *loc, const char *newpath,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2504,7 +2504,7 @@ syncop_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if ((op_ret != -1) && path)
+    if ((op_ret >= 0) && path)
         args->buffer = gf_strdup(path);
 
     __wake(args);
@@ -2533,7 +2533,7 @@ syncop_readlink(xlator_t *subvol, loc_t *loc, char **buffer, size_t size,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2580,7 +2580,7 @@ syncop_mknod(xlator_t *subvol, loc_t *loc, mode_t mode, dev_t rdev,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2627,7 +2627,7 @@ syncop_mkdir(xlator_t *subvol, loc_t *loc, mode_t mode, struct iatt *iatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2681,7 +2681,7 @@ syncop_access(xlator_t *subvol, loc_t *loc, int32_t mask, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_errno;
 }
@@ -2721,7 +2721,7 @@ syncop_fallocate(xlator_t *subvol, fd_t *fd, int32_t keep_size, off_t offset,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2761,7 +2761,7 @@ syncop_discard(xlator_t *subvol, fd_t *fd, off_t offset, size_t len,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2801,7 +2801,7 @@ syncop_zerofill(xlator_t *subvol, fd_t *fd, off_t offset, off_t len,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2846,7 +2846,7 @@ syncop_ipc(xlator_t *subvol, int32_t op, dict_t *xdata_in, dict_t **xdata_out)
         }
     }
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2884,7 +2884,7 @@ syncop_seek(xlator_t *subvol, fd_t *fd, off_t offset, gf_seek_what_t what,
     if (*off)
         *off = args.offset;
 
-    if (args.op_ret == -1)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2935,7 +2935,7 @@ syncop_lease(xlator_t *subvol, loc_t *loc, struct gf_lease *lease,
         }
     }
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -2978,7 +2978,7 @@ syncop_lk(xlator_t *subvol, fd_t *fd, int cmd, struct gf_flock *flock,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_ret;
 }
@@ -3017,7 +3017,7 @@ syncop_inodelk(xlator_t *subvol, const char *volume, loc_t *loc, int32_t cmd,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
     return args.op_ret;
@@ -3056,7 +3056,7 @@ syncop_entrylk(xlator_t *subvol, const char *volume, loc_t *loc,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
     return args.op_ret;
@@ -3105,7 +3105,7 @@ syncop_xattrop(xlator_t *subvol, loc_t *loc, gf_xattrop_flags_t flags,
     else if (args.dict_out)
         dict_unref(args.dict_out);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
     return args.op_ret;
@@ -3133,7 +3133,7 @@ syncop_fxattrop(xlator_t *subvol, fd_t *fd, gf_xattrop_flags_t flags,
     else if (args.dict_out)
         dict_unref(args.dict_out);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
     return args.op_ret;
@@ -3210,7 +3210,7 @@ syncop_getactivelk(xlator_t *subvol, loc_t *loc,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
     return args.op_ret;
@@ -3252,7 +3252,7 @@ syncop_setactivelk(xlator_t *subvol, loc_t *loc,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
     return args.op_ret;

--- a/libglusterfs/src/syscall.c
+++ b/libglusterfs/src/syscall.c
@@ -118,7 +118,7 @@ sys_openat(int dirfd, const char *pathname, int flags, int mode)
 #ifdef __FreeBSD__
     /* On FreeBSD S_ISVTX flag is ignored for an open() with O_CREAT set.
      * We need to force the flag using fchmod(). */
-    if ((fd >= 0) && ((flags & O_CREAT) != 0) && ((mode & S_ISVTX) != 0)) {
+    if (IS_SUCCESS((fd)) && ((flags & O_CREAT) != 0) && ((mode & S_ISVTX) != 0)) {
         sys_fchmod(fd, mode);
         /* TODO: It's unlikely that fchmod could fail here. However,
                  if it fails we cannot always restore the old state
@@ -440,7 +440,7 @@ sys_close(int fd)
 {
     int ret = -1;
 
-    if (fd >= 0)
+    if (IS_SUCCESS(fd))
         ret = close(fd);
 
     return FS_RET_CHECK0(ret, errno);
@@ -761,7 +761,7 @@ sys_socket(int domain, int type, int protocol)
     int fd = -1;
 
     fd = socket(domain, type, protocol);
-    if (fd >= 0)
+    if (IS_SUCCESS(fd))
         fcntl(fd, F_SETFD, FD_CLOEXEC);
     return fd;
 #endif

--- a/libglusterfs/src/trie.c
+++ b/libglusterfs/src/trie.c
@@ -144,7 +144,7 @@ trienode_walk(trienode_t *node, int (*fn)(trienode_t *node, void *data),
             continue;
 
         cret = trienode_walk(trav, fn, data, eowonly);
-        if (cret < 0) {
+        if (IS_ERROR(cret)) {
             ret = cret;
             goto out;
         }

--- a/libglusterfs/src/xlator.c
+++ b/libglusterfs/src/xlator.c
@@ -196,7 +196,7 @@ xlator_volopt_dynload(char *xlator_type, void **dl_handle,
         ret = gf_asprintf(&name, "%s/%s.so", XLATORDIR, xlator_type);
     else
         ret = gf_asprintf(&name, "%s/%s.so", XLATORPARENTDIR, xlator_type);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -359,7 +359,7 @@ xlator_dynload(xlator_t *xl)
     INIT_LIST_HEAD(&xl->volume_options);
 
     ret = gf_asprintf(&name, "%s/%s.so", XLATORDIR, xl->type);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -376,7 +376,7 @@ xlator_dynload(xlator_t *xl)
     xl->dlhandle = handle;
 
     ret = xlator_dynload_apis(xl);
-    if (-1 == ret)
+    if (IS_ERROR(ret))
         goto out;
 
     fill_defaults(xl);
@@ -1116,7 +1116,7 @@ loc_touchup(loc_t *loc, const char *name)
             gf_uuid_copy(loc->gfid, loc->inode->gfid);
     }
 
-    if (ret < 0 || !path) {
+    if (IS_ERROR(ret) || !path) {
         ret = -ENOMEM;
         goto out;
     }
@@ -1161,7 +1161,7 @@ loc_copy_overload_parent(loc_t *dst, loc_t *src, inode_t *parent)
 
     ret = 0;
 out:
-    if (ret == -1)
+    if (IS_ERROR(ret))
         loc_wipe(dst);
 
 err:
@@ -1205,7 +1205,7 @@ loc_copy(loc_t *dst, loc_t *src)
 
     ret = 0;
 out:
-    if (ret == -1)
+    if (IS_ERROR(ret))
         loc_wipe(dst);
 
 err:
@@ -1240,7 +1240,7 @@ loc_build_child(loc_t *child, loc_t *parent, char *name)
     else
         ret = gf_asprintf((char **)&child->path, "%s/%s", parent->path, name);
 
-    if (ret < 0 || !child->path) {
+    if (IS_ERROR(ret) || !child->path) {
         ret = -1;
         goto out;
     }
@@ -1258,7 +1258,7 @@ loc_build_child(loc_t *child, loc_t *parent, char *name)
     ret = 0;
 
 out:
-    if ((ret < 0) && child)
+    if (IS_ERROR(ret) && child)
         loc_wipe(child);
 
     return ret;
@@ -1342,7 +1342,7 @@ is_gf_log_command(xlator_t *this, const char *name, char *value, size_t size)
     }
 
     log_level = glusterd_check_log_level(key);
-    if (log_level == -1) {
+    if (IS_ERROR(log_level)) {
         ret = EOPNOTSUPP;
         goto out;
     }
@@ -1410,7 +1410,7 @@ glusterd_check_log_level(const char *value)
         log_level = GF_LOG_NONE;
     }
 
-    if (log_level == -1)
+    if (IS_ERROR(log_level))
         gf_smsg(THIS->name, GF_LOG_ERROR, 0, LG_MSG_INVALID_INIT, NULL);
 
     return log_level;

--- a/rpc/rpc-lib/src/auth-glusterfs.c
+++ b/rpc/rpc-lib/src/auth-glusterfs.c
@@ -59,7 +59,7 @@ auth_glusterfs_authenticate(rpcsvc_request_t *req, void *priv)
         return ret;
 
     ret = xdr_to_glusterfs_auth(req->cred.authdata, &au);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log("", GF_LOG_WARNING, "failed to decode glusterfs credentials");
         ret = RPCSVC_AUTH_REJECT;
         goto err;
@@ -167,7 +167,7 @@ auth_glusterfs_v2_authenticate(rpcsvc_request_t *req, void *priv)
         return ret;
 
     ret = xdr_to_glusterfs_auth_v2(req->cred.authdata, &au);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log("", GF_LOG_WARNING, "failed to decode glusterfs credentials");
         ret = RPCSVC_AUTH_REJECT;
         goto err;
@@ -295,7 +295,7 @@ auth_glusterfs_v3_authenticate(rpcsvc_request_t *req, void *priv)
         return ret;
 
     ret = xdr_to_glusterfs_auth_v3(req->cred.authdata, &au);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log("", GF_LOG_WARNING, "failed to decode glusterfs credentials");
         ret = RPCSVC_AUTH_REJECT;
         goto err;

--- a/rpc/rpc-lib/src/auth-unix.c
+++ b/rpc/rpc-lib/src/auth-unix.c
@@ -31,7 +31,7 @@ auth_unix_authenticate(rpcsvc_request_t *req, void *priv)
     req->auxgids = req->auxgidsmall;
     ret = xdr_to_auth_unix_cred(req->cred.authdata, req->cred.datalen, &aup,
                                 machname, req->auxgids);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log("", GF_LOG_WARNING, "failed to decode unix credentials");
         ret = RPCSVC_AUTH_REJECT;
         goto err;

--- a/rpc/rpc-lib/src/mgmt-pmap.c
+++ b/rpc/rpc-lib/src/mgmt-pmap.c
@@ -37,21 +37,21 @@ mgmt_pmap_signout_cbk(struct rpc_req *req, struct iovec *iov, int count,
     call_frame_t *frame = NULL;
 
     frame = myframe;
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_pmap_signout_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(THIS->name, GF_LOG_ERROR, "XDR decoding failed");
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
         goto out;
     }
 
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_log(THIS->name, GF_LOG_ERROR,
                "failed to register the port with glusterd");
         goto out;
@@ -128,7 +128,7 @@ rpc_clnt_mgmt_pmap_signout(glusterfs_ctx_t *ctx, char *brickname)
 
     /* Create the xdr payload */
     ret = xdr_serialize_generic(iov, &req, (xdrproc_t)xdr_pmap_signout_req);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(THIS->name, GF_LOG_WARNING, "failed to create XDR payload");
         goto out;
     }

--- a/rpc/rpc-lib/src/rpc-clnt-ping.c
+++ b/rpc/rpc-lib/src/rpc-clnt-ping.c
@@ -198,7 +198,7 @@ rpc_clnt_ping_cbk(struct rpc_req *req, struct iovec *iov, int count,
     pthread_mutex_lock(&conn->lock);
     {
         unref = rpc_clnt_remove_ping_timer_locked(local->rpc);
-        if (req->rpc_status == -1) {
+        if (IS_ERROR(req->rpc_status)) {
             conn->ping_started = 0;
             pthread_mutex_unlock(&conn->lock);
             if (unref) {

--- a/rpc/rpc-lib/src/rpc-clnt-ping.c
+++ b/rpc/rpc-lib/src/rpc-clnt-ping.c
@@ -304,7 +304,7 @@ rpc_clnt_start_ping(void *rpc_ptr)
         unref = rpc_clnt_remove_ping_timer_locked(rpc);
 
         if (conn->saved_frames) {
-            GF_ASSERT(conn->saved_frames->count >= 0);
+            GF_ASSERT(IS_SUCCESS(conn->saved_frames->count));
             /* treat the case where conn->saved_frames is NULL
                as no pending frames */
             frame_count = conn->saved_frames->count;

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -1013,7 +1013,7 @@ rpc_clnt_connection_init(struct rpc_clnt *clnt, glusterfs_ctx_t *ctx,
     }
 
     ret = dict_get_int32(options, "frame-timeout", &conn->frame_timeout);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         gf_log(name, GF_LOG_INFO, "setting frame-timeout to %d",
                conn->frame_timeout);
     } else {
@@ -1023,7 +1023,7 @@ rpc_clnt_connection_init(struct rpc_clnt *clnt, glusterfs_ctx_t *ctx,
     conn->rpc_clnt = clnt;
 
     ret = dict_get_int32(options, "ping-timeout", &conn->ping_timeout);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         gf_log(name, GF_LOG_DEBUG, "setting ping-timeout to %d",
                conn->ping_timeout);
     } else {
@@ -1713,7 +1713,7 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
                    "ProgVers: %d, Proc: %d) to rpc-transport (%s)",
                    cframe->root->unique, rpcreq->xid, rpcreq->prog->progname,
                    rpcreq->prog->progver, rpcreq->procnum, conn->name);
-        } else if ((ret >= 0) && frame) {
+        } else if (IS_SUCCESS((ret)) && frame) {
             /* Save the frame in queue */
             __save_frame(rpc, frame, rpcreq);
 

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -434,7 +434,7 @@ rpc_clnt_fill_request_info(struct rpc_clnt *clnt, rpc_request_info_t *info)
     }
     pthread_mutex_unlock(&clnt->conn.lock);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(clnt->conn.name, GF_LOG_CRITICAL,
                "cannot lookup the saved "
                "frame corresponding to xid (%d)",
@@ -690,7 +690,7 @@ rpc_clnt_handle_cbk(struct rpc_clnt *clnt, rpc_transport_pollin_t *msg)
 
     clnt = rpc_clnt_ref(clnt);
     ret = xdr_to_rpc_call(msgbuf, msglen, &rpcmsg, &progmsg, NULL, NULL);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(clnt->conn.name, GF_LOG_WARNING, "RPC call decoding failed");
         goto out;
     }
@@ -911,7 +911,7 @@ rpc_clnt_notify(rpc_transport_t *trans, void *mydata,
                 clnt_mydata = clnt->mydata;
                 clnt->mydata = NULL;
                 ret = clnt->notifyfn(clnt, clnt_mydata, RPC_CLNT_DESTROY, NULL);
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     gf_log(trans->name, GF_LOG_WARNING,
                            "client notify handler returned error "
                            "while handling RPC_CLNT_DESTROY");
@@ -1051,7 +1051,7 @@ rpc_clnt_connection_init(struct rpc_clnt *clnt, glusterfs_ctx_t *ctx,
     pthread_mutex_unlock(&conn->lock);
 
     ret = rpc_transport_register_notify(conn->trans, rpc_clnt_notify, conn);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(name, GF_LOG_WARNING, "registering notify failed");
         goto out;
     }
@@ -1123,7 +1123,7 @@ rpc_clnt_new(dict_t *options, xlator_t *owner, char *name,
     }
 
     ret = rpc_clnt_connection_init(rpc, ctx, options, name);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         pthread_mutex_destroy(&rpc->lock);
         mem_pool_destroy(rpc->reqpool);
         mem_pool_destroy(rpc->saved_frames_pool);
@@ -1405,7 +1405,7 @@ rpc_clnt_fill_request(struct rpc_clnt *clnt, int prognum, int progver,
         request->rm_call.cb_cred.oa_length = 0;
     } else {
         ret = xdr_serialize_glusterfs_auth(clnt, fr, auth_data);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_log("rpc-clnt", GF_LOG_WARNING,
                    "cannot encode auth credentials");
             goto out;
@@ -1436,7 +1436,7 @@ rpc_clnt_record_build_header(char *recordstart, size_t rlen,
     size_t fraglen = 0;
 
     ret = rpc_request_to_xdr(request, recordstart, rlen, &requesthdr);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log("rpc-clnt", GF_LOG_DEBUG, "Failed to create RPC request");
         goto out;
     }
@@ -1488,7 +1488,7 @@ rpc_clnt_record_build_record(struct rpc_clnt *clnt, call_frame_t *fr,
     ret = rpc_clnt_fill_request(clnt, prognum, progver, procnum, xid, fr,
                                 &request, auth_data);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(clnt->conn.name, GF_LOG_WARNING,
                "cannot build a rpc-request xid (%" PRIu64 ")", xid);
         goto out;
@@ -1595,7 +1595,7 @@ rpcclnt_cbk_program_register(struct rpc_clnt *clnt,
            program->prognum, program->progver);
 
 out:
-    if (ret == -1 && clnt) {
+    if (IS_ERROR(ret) && clnt) {
         gf_log(clnt->conn.name, GF_LOG_ERROR,
                "Program registration failed:"
                " %s, Num: %d, Ver: %d",
@@ -1694,7 +1694,7 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
             if (rpc->disabled)
                 goto unlock;
             ret = rpc_transport_connect(conn->trans, conn->config.remote_port);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_log(conn->name,
                        (errno == EINPROGRESS) ? GF_LOG_DEBUG : GF_LOG_WARNING,
                        "error returned while attempting to "
@@ -1705,7 +1705,7 @@ rpc_clnt_submit(struct rpc_clnt *rpc, rpc_clnt_prog_t *prog, int procnum,
         }
 
         ret = rpc_transport_submit_request(conn->trans, &req);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_log(conn->name, GF_LOG_WARNING,
                    "failed to submit rpc-request "
                    "(unique: %" PRIu64
@@ -1741,7 +1741,7 @@ unlock:
     if (need_unref)
         rpc_clnt_unref(rpc);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -1757,7 +1757,7 @@ out:
         iobref_unref(iobref);
     }
 
-    if (frame && (ret == -1)) {
+    if (frame && IS_ERROR(ret)) {
         if (rpcreq) {
             rpcreq->rpc_status = -1;
             cbkfn(rpcreq, NULL, 0, frame);

--- a/rpc/rpc-lib/src/rpc-clnt.c
+++ b/rpc/rpc-lib/src/rpc-clnt.c
@@ -697,12 +697,9 @@ rpc_clnt_handle_cbk(struct rpc_clnt *clnt, rpc_transport_pollin_t *msg)
 
     gf_log(clnt->conn.name, GF_LOG_TRACE,
            "receivd rpc message (XID: 0x%" GF_PRI_RPC_XID
-           ", "
-           "Ver: %" GF_PRI_RPC_VERSION ", Program: %" GF_PRI_RPC_PROG_ID
-           ", "
-           "ProgVers: %" GF_PRI_RPC_PROG_VERS ", Proc: %" GF_PRI_RPC_PROC
-           ") "
-           "from rpc-transport (%s)",
+           ", Ver: %" GF_PRI_RPC_VERSION ", Program: %" GF_PRI_RPC_PROG_ID
+           ", ProgVers: %" GF_PRI_RPC_PROG_VERS ", Proc: %" GF_PRI_RPC_PROC
+           ") from rpc-transport (%s)",
            rpc_call_xid(&rpcmsg), rpc_call_rpcvers(&rpcmsg),
            rpc_call_program(&rpcmsg), rpc_call_progver(&rpcmsg),
            rpc_call_progproc(&rpcmsg), clnt->conn.name);

--- a/rpc/rpc-lib/src/rpc-drc.c
+++ b/rpc/rpc-lib/src/rpc-drc.c
@@ -679,7 +679,7 @@ rpcsvc_drc_init(rpcsvc_t *svc, dict_t *options)
     /* Toggle DRC on/off, when more drc types(persistent/cluster)
      * are added, we shouldn't treat this as boolean. */
     ret = dict_get_str_boolean(options, "nfs.drc", _gf_false);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_INFO, "drc user options need second look");
         ret = _gf_false;
     }
@@ -754,7 +754,7 @@ rpcsvc_drc_init(rpcsvc_t *svc, dict_t *options)
     UNLOCK(&drc->lock);
     gf_log(GF_RPCSVC, GF_LOG_DEBUG, "drc init successful");
 post_unlock:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         if (drc->mempool) {
             mem_pool_destroy(drc->mempool);
             drc->mempool = NULL;
@@ -829,7 +829,7 @@ rpcsvc_drc_reconfigure(rpcsvc_t *svc, dict_t *options)
      *         ACTION: rpcsvc_drc_deinit()
      */
     ret = dict_get_str_boolean(options, "nfs.drc", _gf_false);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         ret = _gf_false;
 
     enable_drc = ret;

--- a/rpc/rpc-lib/src/rpc-transport.c
+++ b/rpc/rpc-lib/src/rpc-transport.c
@@ -196,9 +196,9 @@ rpc_transport_load(glusterfs_ctx_t *ctx, dict_t *options, char *trans_name)
 
     /* Backward compatibility */
     ret = dict_get_str_sizen(options, "transport-type", &type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = dict_set_str_sizen(options, "transport-type", "socket");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_log("dict", GF_LOG_DEBUG, "setting transport-type failed");
         else
             gf_log("rpc-transport", GF_LOG_DEBUG,
@@ -225,11 +225,11 @@ rpc_transport_load(glusterfs_ctx_t *ctx, dict_t *options, char *trans_name)
                 ret = dict_set_str_sizen(options, "transport.address-family",
                                          "inet-sdp");
 
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 gf_log("dict", GF_LOG_DEBUG, "setting address-family failed");
 
             ret = dict_set_str_sizen(options, "transport-type", "socket");
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 gf_log("dict", GF_LOG_DEBUG, "setting transport-type failed");
         }
     }
@@ -242,7 +242,7 @@ rpc_transport_load(glusterfs_ctx_t *ctx, dict_t *options, char *trans_name)
         ret = dict_get_str_sizen(options, "bind-insecure", &type);
     if (ret == 0) {
         ret = gf_string2boolean(type, &bind_insecure);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log("rcp-transport", GF_LOG_WARNING,
                    "bind-insecure option %s is not a"
                    " valid bool option",
@@ -259,7 +259,7 @@ rpc_transport_load(glusterfs_ctx_t *ctx, dict_t *options, char *trans_name)
     }
 
     ret = dict_get_str_sizen(options, "transport-type", &type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log("rpc-transport", GF_LOG_ERROR,
                "'option transport-type <xx>' missing in volume '%s'",
                trans_name);
@@ -267,7 +267,7 @@ rpc_transport_load(glusterfs_ctx_t *ctx, dict_t *options, char *trans_name)
     }
 
     ret = gf_asprintf(&name, "%s/%s.so", RPC_TRANSPORTDIR, type);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         goto fail;
     }
 

--- a/rpc/rpc-lib/src/rpcsvc-auth.c
+++ b/rpc/rpc-lib/src/rpcsvc-auth.c
@@ -53,7 +53,7 @@ rpcsvc_auth_add_initers(rpcsvc_t *svc)
     ret = rpcsvc_auth_add_initer(
         &svc->authschemes, "auth-glusterfs",
         (rpcsvc_auth_initer_t)rpcsvc_auth_glusterfs_init);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "Failed to add AUTH_GLUSTERFS");
         goto err;
     }
@@ -61,7 +61,7 @@ rpcsvc_auth_add_initers(rpcsvc_t *svc)
     ret = rpcsvc_auth_add_initer(
         &svc->authschemes, "auth-glusterfs-v2",
         (rpcsvc_auth_initer_t)rpcsvc_auth_glusterfs_v2_init);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "Failed to add AUTH_GLUSTERFS-v2");
         goto err;
     }
@@ -69,21 +69,21 @@ rpcsvc_auth_add_initers(rpcsvc_t *svc)
     ret = rpcsvc_auth_add_initer(
         &svc->authschemes, "auth-glusterfs-v3",
         (rpcsvc_auth_initer_t)rpcsvc_auth_glusterfs_v3_init);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "Failed to add AUTH_GLUSTERFS-v3");
         goto err;
     }
 
     ret = rpcsvc_auth_add_initer(&svc->authschemes, "auth-unix",
                                  (rpcsvc_auth_initer_t)rpcsvc_auth_unix_init);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "Failed to add AUTH_UNIX");
         goto err;
     }
 
     ret = rpcsvc_auth_add_initer(&svc->authschemes, "auth-null",
                                  (rpcsvc_auth_initer_t)rpcsvc_auth_null_init);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "Failed to add AUTH_NULL");
         goto err;
     }
@@ -168,7 +168,7 @@ rpcsvc_auth_init_auths(rpcsvc_t *svc, dict_t *options)
     list_for_each_entry_safe(auth, tmp, &svc->authschemes, authlist)
     {
         ret = rpcsvc_auth_init_auth(svc, options, auth);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto err;
     }
 
@@ -188,7 +188,7 @@ rpcsvc_set_addr_namelookup(rpcsvc_t *svc, dict_t *options)
 
     /* By default it's disabled */
     ret = dict_get_str_boolean(options, addrlookup_key, _gf_false);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         svc->addr_namelookup = _gf_false;
     } else {
         svc->addr_namelookup = ret;
@@ -227,7 +227,7 @@ rpcsvc_set_allow_insecure(rpcsvc_t *svc, dict_t *options)
          * configuration params for allow insecure,  eg: gf_auth
          */
         ret = dict_set_str(options, "rpc-auth-allow-insecure", "on");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_log("rpc-auth", GF_LOG_DEBUG,
                    "dict_set failed for 'allow-insecure'");
     }
@@ -246,7 +246,7 @@ rpcsvc_set_root_squash(rpcsvc_t *svc, dict_t *options)
     GF_ASSERT(options);
 
     ret = dict_get_str_boolean(options, "root-squash", 0);
-    if (ret != -1)
+    if (ret >= 0)
         svc->root_squash = ret;
     else
         svc->root_squash = _gf_false;
@@ -284,7 +284,7 @@ rpcsvc_set_all_squash(rpcsvc_t *svc, dict_t *options)
     GF_ASSERT(options);
 
     ret = dict_get_str_boolean(options, "all-squash", 0);
-    if (ret != -1)
+    if (ret >= 0)
         svc->all_squash = ret;
     else
         svc->all_squash = _gf_false;
@@ -323,13 +323,13 @@ rpcsvc_auth_init(rpcsvc_t *svc, dict_t *options)
     (void)rpcsvc_set_all_squash(svc, options);
     (void)rpcsvc_set_addr_namelookup(svc, options);
     ret = rpcsvc_auth_add_initers(svc);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "Failed to add initers");
         goto out;
     }
 
     ret = rpcsvc_auth_init_auths(svc, options);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "Failed to init auth schemes");
         goto out;
     }
@@ -511,7 +511,7 @@ rpcsvc_auth_array(rpcsvc_t *svc, char *volname, int *autharr, int arrlen)
             break;
 
         result = gf_asprintf(&srchstr, "rpc-auth.%s.%s", auth->name, volname);
-        if (result == -1) {
+        if (IS_ERROR(result)) {
             count = -1;
             goto err;
         }

--- a/rpc/rpc-lib/src/rpcsvc-auth.c
+++ b/rpc/rpc-lib/src/rpcsvc-auth.c
@@ -246,7 +246,7 @@ rpcsvc_set_root_squash(rpcsvc_t *svc, dict_t *options)
     GF_ASSERT(options);
 
     ret = dict_get_str_boolean(options, "root-squash", 0);
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         svc->root_squash = ret;
     else
         svc->root_squash = _gf_false;
@@ -284,7 +284,7 @@ rpcsvc_set_all_squash(rpcsvc_t *svc, dict_t *options)
     GF_ASSERT(options);
 
     ret = dict_get_str_boolean(options, "all-squash", 0);
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         svc->all_squash = ret;
     else
         svc->all_squash = _gf_false;

--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -539,13 +539,9 @@ rpcsvc_request_create(rpcsvc_t *svc, rpc_transport_t *trans,
     rpcsvc_request_init(svc, trans, &rpcmsg, progmsg, msg, req);
 
     gf_log(GF_RPCSVC, GF_LOG_TRACE,
-           "received rpc-message "
-           "(XID: 0x%" GF_PRI_RPC_XID ", Ver: %" GF_PRI_RPC_VERSION
-           ", Program: %" GF_PRI_RPC_PROG_ID
-           ", "
-           "ProgVers: %" GF_PRI_RPC_PROG_VERS ", Proc: %" GF_PRI_RPC_PROC
-           ") "
-           "from rpc-transport (%s)",
+           "received rpc-message (XID: 0x%" GF_PRI_RPC_XID ", Ver: %" GF_PRI_RPC_VERSION
+           ", Program: %" GF_PRI_RPC_PROG_ID ", ProgVers: %" GF_PRI_RPC_PROG_VERS ", Proc: %" GF_PRI_RPC_PROC
+           ") from rpc-transport (%s)",
            rpc_call_xid(&rpcmsg), rpc_call_rpcvers(&rpcmsg),
            rpc_call_program(&rpcmsg), rpc_call_progver(&rpcmsg),
            rpc_call_progproc(&rpcmsg), trans->name);
@@ -561,13 +557,9 @@ rpcsvc_request_create(rpcsvc_t *svc, rpc_transport_t *trans,
         /* LOG- TODO: print rpc version, also print the peerinfo
            from transport */
         gf_log(GF_RPCSVC, GF_LOG_ERROR,
-               "RPC version not supported "
-               "(XID: 0x%" GF_PRI_RPC_XID ", Ver: %" GF_PRI_RPC_VERSION
-               ", Program: %" GF_PRI_RPC_PROG_ID
-               ", "
-               "ProgVers: %" GF_PRI_RPC_PROG_VERS ", Proc: %" GF_PRI_RPC_PROC
-               ") "
-               "from trans (%s)",
+               "RPC version not supported (XID: 0x%" GF_PRI_RPC_XID ", Ver: %" GF_PRI_RPC_VERSION
+               ", Program: %" GF_PRI_RPC_PROG_ID ", ProgVers: %" GF_PRI_RPC_PROG_VERS ", Proc: %" GF_PRI_RPC_PROC
+               ") from trans (%s)",
                rpc_call_xid(&rpcmsg), rpc_call_rpcvers(&rpcmsg),
                rpc_call_program(&rpcmsg), rpc_call_progver(&rpcmsg),
                rpc_call_progproc(&rpcmsg), trans->name);
@@ -583,13 +575,9 @@ rpcsvc_request_create(rpcsvc_t *svc, rpc_transport_t *trans,
          */
         rpcsvc_request_seterr(req, AUTH_ERROR);
         gf_log(GF_RPCSVC, GF_LOG_ERROR,
-               "auth failed on request. "
-               "(XID: 0x%" GF_PRI_RPC_XID ", Ver: %" GF_PRI_RPC_VERSION
-               ", Program: %" GF_PRI_RPC_PROG_ID
-               ", "
-               "ProgVers: %" GF_PRI_RPC_PROG_VERS ", Proc: %" GF_PRI_RPC_PROC
-               ") "
-               "from trans (%s)",
+               "auth failed on request. (XID: 0x%" GF_PRI_RPC_XID ", Ver: %" GF_PRI_RPC_VERSION
+               ", Program: %" GF_PRI_RPC_PROG_ID ", ProgVers: %" GF_PRI_RPC_PROG_VERS ", Proc: %" GF_PRI_RPC_PROC
+               ") from trans (%s)",
                rpc_call_xid(&rpcmsg), rpc_call_rpcvers(&rpcmsg),
                rpc_call_program(&rpcmsg), rpc_call_progver(&rpcmsg),
                rpc_call_progproc(&rpcmsg), trans->name);

--- a/rpc/rpc-lib/src/rpcsvc.c
+++ b/rpc/rpc-lib/src/rpcsvc.c
@@ -188,7 +188,7 @@ rpcsvc_get_program_vector_sizer(rpcsvc_t *svc, uint32_t prognum,
 
     if (found) {
         /* Make sure the requested procnum is supported by RPC prog */
-        if ((procnum < 0) || (procnum >= program->numactors)) {
+        if (IS_ERROR((procnum)) || (procnum >= program->numactors)) {
             gf_log(GF_RPCSVC, GF_LOG_ERROR,
                    "RPC procedure %d not available for Program %s", procnum,
                    program->progname);
@@ -343,7 +343,7 @@ rpcsvc_program_actor(rpcsvc_request_t *req)
         goto err;
     }
 
-    if ((req->procnum < 0) || (req->procnum >= program->numactors)) {
+    if (IS_ERROR((req->procnum)) || (req->procnum >= program->numactors)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR,
                "RPC Program procedure not"
                " available for procedure %d in %s for  %s",
@@ -527,7 +527,7 @@ rpcsvc_request_create(rpcsvc_t *svc, rpc_transport_t *trans,
     ret = xdr_to_rpc_call(msgbuf, msglen, &rpcmsg, &progmsg, req->cred.authdata,
                           req->verf.authdata);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_WARNING, "RPC call decoding failed");
         rpcsvc_request_seterr(req, GARBAGE_ARGS);
         req->trans = rpc_transport_ref(trans);
@@ -604,7 +604,7 @@ rpcsvc_request_create(rpcsvc_t *svc, rpc_transport_t *trans,
     req->reply = NULL;
     ret = 0;
 err:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         ret = rpcsvc_error_reply(req);
         if (ret)
             gf_log("rpcsvc", GF_LOG_WARNING, "failed to queue error reply");
@@ -840,7 +840,7 @@ rpcsvc_handle_rpc_call(rpcsvc_t *svc, rpc_transport_t *trans,
                         value = (void *)num;
                         ret = pthread_setspecific(req->prog->req_queue_key,
                                                   value);
-                        if (ret < 0) {
+                        if (IS_ERROR(ret)) {
                             gf_log(GF_RPCSVC, GF_LOG_WARNING,
                                    "setting request queue in TLS failed");
                             rpcsvc_toggle_queue_status(
@@ -855,7 +855,7 @@ rpcsvc_handle_rpc_call(rpcsvc_t *svc, rpc_transport_t *trans,
                 pthread_mutex_unlock(&req->prog->thr_lock);
             }
 
-            if (num == -1)
+            if (IS_ERROR(num))
                 goto noqueue;
 
             num = ((unsigned long)value) - 1;
@@ -878,7 +878,7 @@ rpcsvc_handle_rpc_call(rpcsvc_t *svc, rpc_transport_t *trans,
                         "spawning a request handler thread for queue %d failed",
                         (int)num);
                     ret = pthread_setspecific(req->prog->req_queue_key, 0);
-                    if (ret < 0) {
+                    if (IS_ERROR(ret)) {
                         gf_log(GF_RPCSVC, GF_LOG_WARNING,
                                "resetting request queue in TLS failed");
                     }
@@ -1059,7 +1059,7 @@ rpcsvc_record_build_header(char *recordstart, size_t rlen, struct rpc_msg reply,
      * encode the RPC reply structure into the buffer given to us.
      */
     ret = rpc_reply_to_xdr(&reply, recordstart, rlen, &replyhdr);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_WARNING, "Failed to create RPC reply");
         goto err;
     }
@@ -1141,7 +1141,7 @@ rpcsvc_callback_build_header(char *recordstart, size_t rlen,
     size_t fraglen = 0;
 
     ret = rpc_request_to_xdr(request, recordstart, rlen, &requesthdr);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log("rpcsvc", GF_LOG_WARNING, "Failed to create RPC request");
         goto out;
     }
@@ -1189,7 +1189,7 @@ rpcsvc_callback_build_record(rpcsvc_t *rpc, int prognum, int progver,
     /* Fill the rpc structure and XDR it into the buffer got above. */
     ret = rpcsvc_fill_callback(prognum, progver, procnum, payload, xid,
                                &request);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log("rpcsvc", GF_LOG_WARNING,
                "cannot build a rpc-request "
                "xid (%lu)",
@@ -1258,7 +1258,7 @@ rpcsvc_request_submit(rpcsvc_t *rpc, rpc_transport_t *trans,
     iov.iov_len = iobuf_pagesize(iobuf);
 
     ret = xdr_serialize_generic(iov, req, xdrproc);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(THIS->name, GF_LOG_WARNING, "failed to create XDR payload");
         goto out;
     }
@@ -1339,7 +1339,7 @@ rpcsvc_callback_submit(rpcsvc_t *rpc, rpc_transport_t *trans,
     req.msg.iobref = iobref;
 
     ret = rpc_transport_submit_request(trans, &req);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log("rpcsvc", GF_LOG_WARNING, "transmission of rpc-request failed");
         goto out;
     }
@@ -1560,7 +1560,7 @@ rpcsvc_submit_generic(rpcsvc_request_t *req, struct iovec *proghdr,
         ret = rpcsvc_cache_reply(req, iobref, &recordhdr, 1, proghdr, hdrcount,
                                  payload, payloadcount);
         UNLOCK(&drc->lock);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(GF_RPCSVC, GF_LOG_ERROR, "failed to cache reply");
         }
     }
@@ -1569,7 +1569,7 @@ rpcsvc_submit_generic(rpcsvc_request_t *req, struct iovec *proghdr,
                                   payload, payloadcount, iobref,
                                   req->trans_private);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR,
                "failed to submit message "
                "(XID: 0x%x, Program: %s, ProgVers: %d, Proc: %d) to "
@@ -1642,7 +1642,7 @@ rpcsvc_program_register_rpcbind6(rpcsvc_program_t *newprog, uint32_t port)
     }
 
     err = sprintf(addr_buf, "::.%d.%d", port >> 8 & 0xff, port & 0xff);
-    if (err < 0) {
+    if (IS_ERROR(err)) {
         err = -1;
         goto out;
     }
@@ -1812,7 +1812,7 @@ rpcsvc_get_listener(rpcsvc_t *svc, uint16_t port, rpc_transport_t *trans)
             }
 
             listener_port = rpcsvc_get_listener_port(listener);
-            if (listener_port == -1) {
+            if (IS_ERROR(listener_port)) {
                 gf_log(GF_RPCSVC, GF_LOG_ERROR, "invalid port for listener %s",
                        listener->trans->name);
                 continue;
@@ -1874,7 +1874,7 @@ rpcsvc_program_unregister(rpcsvc_t *svc, rpcsvc_program_t *program)
     pthread_rwlock_unlock(&svc->rpclock);
 
     ret = rpcsvc_program_unregister_portmap(program);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR,
                "portmap unregistration of"
                " program failed");
@@ -1882,7 +1882,7 @@ rpcsvc_program_unregister(rpcsvc_t *svc, rpcsvc_program_t *program)
     }
 #ifdef IPV6_DEFAULT
     ret = rpcsvc_program_unregister_rpcbind6(program);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR,
                "rpcbind (ipv6)"
                " unregistration of program failed");
@@ -1912,7 +1912,7 @@ out:
     if (prog)
         GF_FREE(prog);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         if (program) {
             gf_log(GF_RPCSVC, GF_LOG_ERROR,
                    "Program "
@@ -1993,13 +1993,13 @@ rpcsvc_create_listener(rpcsvc_t *svc, dict_t *options, char *name)
     }
 
     ret = rpc_transport_listen(trans);
-    if (ret == -EADDRINUSE || ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_WARNING, "listening on transport failed");
         goto out;
     }
 
     ret = rpc_transport_register_notify(trans, rpcsvc_notify, svc);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_WARNING, "registering notify failed");
         goto out;
     }
@@ -2064,12 +2064,12 @@ rpcsvc_create_listeners(rpcsvc_t *svc, dict_t *options, char *name)
         }
 
         ret = gf_asprintf(&transport_name, "%s.%s", tmp, name);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
         ret = dict_set_dynstr(options, "transport-type", tmp);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -2088,7 +2088,7 @@ rpcsvc_create_listeners(rpcsvc_t *svc, dict_t *options, char *name)
     }
 
     ret = dict_set_dynstr(options, "transport-type", transport_type);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -2348,7 +2348,7 @@ rpcsvc_program_register(rpcsvc_t *svc, rpcsvc_program_t *program,
            newprog->progport);
 
 out:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR,
                "Program registration failed:"
                " %s, Num: %d, Ver: %d, Port: %d",
@@ -2432,7 +2432,7 @@ rpcsvc_ping(rpcsvc_request_t *req)
     iov.iov_len = ping_rsp_len;
 
     ret = xdr_serialize_generic(iov, &rsp, (xdrproc_t)xdr_gf_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = RPCSVC_ACTOR_ERROR;
     } else {
         rsp.op_ret = 0;
@@ -2462,7 +2462,7 @@ rpcsvc_dump(rpcsvc_request_t *req)
         goto sendrsp;
 
     ret = build_prog_details(req, &rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto sendrsp;
     }
@@ -2479,7 +2479,7 @@ sendrsp:
     iov.iov_len = dump_rsp_len;
 
     ret = xdr_serialize_generic(iov, &rsp, (xdrproc_t)xdr_gf_dump_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = RPCSVC_ACTOR_ERROR;
     } else {
         rpcsvc_submit_generic(req, &iov, 1, NULL, 0, NULL);
@@ -2505,7 +2505,7 @@ rpcsvc_init_options(rpcsvc_t *svc, dict_t *options)
     svc->register_portmap = _gf_true;
     if (dict_get(options, "rpc.register-with-portmap")) {
         ret = dict_get_str(options, "rpc.register-with-portmap", &optstr);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(GF_RPCSVC, GF_LOG_ERROR,
                    "Failed to parse "
                    "dict");
@@ -2513,7 +2513,7 @@ rpcsvc_init_options(rpcsvc_t *svc, dict_t *options)
         }
 
         ret = gf_string2boolean(optstr, &svc->register_portmap);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(GF_RPCSVC, GF_LOG_ERROR,
                    "Failed to parse bool "
                    "string");
@@ -2552,7 +2552,7 @@ rpcsvc_reconfigure_options(rpcsvc_t *svc, dict_t *options)
     while (volentry) {
         ret = gf_asprintf(&srchkey, "rpc-auth.addr.%s.allow",
                           volentry->xlator->name);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_log(GF_RPCSVC, GF_LOG_ERROR, "asprintf failed");
             return (-1);
         }
@@ -2569,7 +2569,7 @@ rpcsvc_reconfigure_options(rpcsvc_t *svc, dict_t *options)
         dict_del(svc->options, srchkey);
         if (!dict_get_str(options, srchkey, &keyval)) {
             ret = dict_set_dynstr_with_alloc(svc->options, srchkey, keyval);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_log(GF_RPCSVC, GF_LOG_ERROR, "dict_set_str error");
                 GF_FREE(srchkey);
                 return (-1);
@@ -2585,7 +2585,7 @@ rpcsvc_reconfigure_options(rpcsvc_t *svc, dict_t *options)
     while (volentry) {
         ret = gf_asprintf(&srchkey, "rpc-auth.addr.%s.reject",
                           volentry->xlator->name);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_log(GF_RPCSVC, GF_LOG_ERROR, "asprintf failed");
             return (-1);
         }
@@ -2601,7 +2601,7 @@ rpcsvc_reconfigure_options(rpcsvc_t *svc, dict_t *options)
         dict_del(svc->options, srchkey);
         if (!dict_get_str(options, srchkey, &keyval)) {
             ret = dict_set_dynstr_with_alloc(svc->options, srchkey, keyval);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_log(GF_RPCSVC, GF_LOG_ERROR, "dict_set_str error");
                 GF_FREE(srchkey);
                 return (-1);
@@ -2681,7 +2681,7 @@ rpcsvc_set_outstanding_rpc_limit(rpcsvc_t *svc, dict_t *options, int defvalue)
 
     /* Fetch the rpc.outstanding-rpc-limit from dict. */
     ret = dict_get_int32(options, rpclimkey, &rpclim);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /* Fall back to default for FAILURE */
         rpclim = defvalue;
     }
@@ -2806,7 +2806,7 @@ rpcsvc_init(xlator_t *xl, glusterfs_ctx_t *ctx, dict_t *options,
     INIT_LIST_HEAD(&svc->programs);
 
     ret = rpcsvc_init_options(svc, options);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "Failed to init options");
         goto free_svc;
     }
@@ -2823,7 +2823,7 @@ rpcsvc_init(xlator_t *xl, glusterfs_ctx_t *ctx, dict_t *options,
     }
 
     ret = rpcsvc_auth_init(svc, options);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR,
                "Failed to init "
                "authentication");
@@ -2846,7 +2846,7 @@ rpcsvc_init(xlator_t *xl, glusterfs_ctx_t *ctx, dict_t *options,
 
     ret = 0;
 free_svc:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         GF_FREE(svc);
         svc = NULL;
     }
@@ -2868,7 +2868,7 @@ rpcsvc_transport_peer_check_search(dict_t *options, char *pattern, char *ip,
         return -1;
 
     ret = dict_get_str(options, pattern, &addrstr);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -1;
         goto err;
     }
@@ -2933,7 +2933,7 @@ rpcsvc_transport_peer_check_allow(dict_t *options, char *volname, char *ip,
         return ret;
 
     ret = gf_asprintf(&srchstr, "rpc-auth.addr.%s.allow", volname);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "asprintf failed");
         ret = RPCSVC_AUTH_DONTCARE;
         goto out;
@@ -2961,7 +2961,7 @@ rpcsvc_transport_peer_check_reject(dict_t *options, char *volname, char *ip,
         return ret;
 
     ret = gf_asprintf(&srchstr, "rpc-auth.addr.%s.reject", volname);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "asprintf failed");
         ret = RPCSVC_AUTH_REJECT;
         goto out;
@@ -3023,18 +3023,18 @@ rpcsvc_auth_check(rpcsvc_t *svc, char *volname, char *ipaddr)
      * assume no one is allowed mounts, and thus, we reject mounts.
      */
     ret = gf_asprintf(&srchstr, "rpc-auth.addr.%s.allow", volname);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "asprintf failed");
         return RPCSVC_AUTH_REJECT;
     }
 
     ret = dict_get_str(options, srchstr, &allow_str);
     GF_FREE(srchstr);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return RPCSVC_AUTH_REJECT;
 
     ret = gf_asprintf(&srchstr, "rpc-auth.addr.%s.reject", volname);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "asprintf failed");
         return RPCSVC_AUTH_REJECT;
     }
@@ -3103,7 +3103,7 @@ rpcsvc_transport_privport_check(rpcsvc_t *svc, char *volname, uint16_t port)
 
     /* Disabled by default */
     ret = gf_asprintf(&srchstr, "rpc-auth.ports.%s.insecure", volname);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "asprintf failed");
         ret = RPCSVC_AUTH_REJECT;
         goto err;
@@ -3153,7 +3153,7 @@ rpcsvc_volume_allowed(dict_t *options, char *volname)
         return NULL;
 
     ret = gf_asprintf(&srchstr, "rpc-auth.addr.%s.allow", volname);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "asprintf failed");
         goto out;
     }

--- a/rpc/rpc-transport/socket/src/name.c
+++ b/rpc/rpc-transport/socket/src/name.c
@@ -75,7 +75,7 @@ loop:
         if (ret == 0)
             break;
 
-        if (ret == -1 && errno == EACCES)
+        if (IS_ERROR(ret) && errno == EACCES)
             break;
 
         port--;
@@ -118,7 +118,7 @@ af_unix_client_bind(rpc_transport_t *this, struct sockaddr *sockaddr,
         addr = (struct sockaddr_un *)sockaddr;
         strcpy(addr->sun_path, path);
         ret = bind(sock, (struct sockaddr *)addr, sockaddr_len);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_log(this->name, GF_LOG_ERROR,
                    "cannot bind to unix-domain socket %d (%s)", sock,
                    strerror(errno));
@@ -260,7 +260,7 @@ af_inet_client_get_remote_sockaddr(rpc_transport_t *this,
        non blocking dns techniques */
     ret = gf_resolve_ip6(remote_host, remote_port, sockaddr->sa_family,
                          &this->dnscache, &addr_info);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_ERROR, "DNS resolution failed on host %s",
                remote_host);
         goto err;
@@ -456,7 +456,7 @@ client_bind(rpc_transport_t *this, struct sockaddr *sockaddr,
             if (!this->bind_insecure) {
                 ret = af_inet_bind_to_port_lt_ceiling(
                     sock, sockaddr, *sockaddr_len, GF_CLIENT_PORT_CEILING);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     gf_log(this->name, GF_LOG_DEBUG,
                            "cannot bind inet socket (%d) "
                            "to port less than %d (%s)",
@@ -466,7 +466,7 @@ client_bind(rpc_transport_t *this, struct sockaddr *sockaddr,
             } else {
                 ret = af_inet_bind_to_port_lt_ceiling(
                     sock, sockaddr, *sockaddr_len, GF_IANA_PRIV_PORTS_START);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     gf_log(this->name, GF_LOG_DEBUG,
                            "failed while binding to less than "
                            "%d (%s)",
@@ -605,7 +605,7 @@ socket_server_get_local_sockaddr(rpc_transport_t *this, struct sockaddr *addr,
     GF_VALIDATE_OR_GOTO("socket", addr_len, err);
 
     ret = server_fill_address_family(this, &addr->sa_family);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -724,7 +724,7 @@ get_transport_identifiers(rpc_transport_t *this)
             ret = fill_inet6_inet_identifiers(this, &this->myinfo.sockaddr,
                                               this->myinfo.sockaddr_len,
                                               this->myinfo.identifier);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 gf_log(this->name, GF_LOG_ERROR,
                        "cannot fill inet/inet6 identifier for server");
                 goto err;
@@ -733,7 +733,7 @@ get_transport_identifiers(rpc_transport_t *this)
             ret = fill_inet6_inet_identifiers(this, &this->peerinfo.sockaddr,
                                               this->peerinfo.sockaddr_len,
                                               this->peerinfo.identifier);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 gf_log(this->name, GF_LOG_ERROR,
                        "cannot fill inet/inet6 identifier for client");
                 goto err;

--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -1345,7 +1345,7 @@ socket_event_poll_err(rpc_transport_t *this, int gen, int idx)
 
     pthread_mutex_lock(&priv->out_lock);
     {
-        if (IS_SUCCESS((priv->gen == gen) && (priv->idx == idx) && (priv->sock))) {
+        if ((priv->gen == gen) && (priv->idx == idx) && IS_SUCCESS(priv->sock)) {
             __socket_ioq_flush(priv);
             __socket_reset(this);
             socket_closed = _gf_true;
@@ -2535,7 +2535,7 @@ socket_event_poll_in(rpc_transport_t *this, gf_boolean_t notify_handled)
         pthread_mutex_unlock(&priv->notify.lock);
     }
 
-    if (IS_SUCCESS(notify_handled && (ret)))
+    if (notify_handled && IS_SUCCESS(ret))
         gf_event_handled(ctx->event_pool, priv->sock, priv->idx, priv->gen);
 
     if (pollin) {
@@ -2951,7 +2951,7 @@ socket_event_handler(int fd, int idx, int gen, void *data, int poll_in,
                          this->name, "disconnecting from");
 
         /* Logging has happened already in earlier cases */
-        gf_log(IS_SUCCESS("transport", ((ret)) ? GF_LOG_INFO : GF_LOG_DEBUG),
+        gf_log("transport", (IS_SUCCESS(ret) ? GF_LOG_INFO : GF_LOG_DEBUG),
                "EPOLLERR - disconnecting (sock:%d) (%s)", priv->sock,
                (priv->use_ssl ? "SSL" : "non-SSL"));
 

--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -876,7 +876,7 @@ __socket_disconnect(rpc_transport_t *this)
     gf_log(this->name, GF_LOG_TRACE, "disconnecting %p, sock=%d", this,
            priv->sock);
 
-    if (priv->sock >= 0) {
+    if (IS_SUCCESS(priv->sock)) {
         gf_log_callingfn(this->name, GF_LOG_TRACE,
                          "tearing down socket connection");
         ret = __socket_teardown_connection(this);
@@ -919,7 +919,7 @@ __socket_server_bind(rpc_transport_t *this)
         memcpy(&unix_addr, SA(&this->myinfo.sockaddr),
                this->myinfo.sockaddr_len);
         reuse_check_sock = sys_socket(AF_UNIX, SOCK_STREAM, 0);
-        if (reuse_check_sock >= 0) {
+        if (IS_SUCCESS(reuse_check_sock)) {
             ret = connect(reuse_check_sock, SA(&unix_addr),
                           this->myinfo.sockaddr_len);
             if ((ret != 0) && (ECONNREFUSED == errno)) {
@@ -999,7 +999,7 @@ __socket_nonblock(int fd)
 
     flags = fcntl(fd, F_GETFL);
 
-    if (flags >= 0)
+    if (IS_SUCCESS(flags))
         ret = fcntl(fd, F_SETFL, flags | O_NONBLOCK);
 
     return ret;
@@ -1345,7 +1345,7 @@ socket_event_poll_err(rpc_transport_t *this, int gen, int idx)
 
     pthread_mutex_lock(&priv->out_lock);
     {
-        if ((priv->gen == gen) && (priv->idx == idx) && (priv->sock >= 0)) {
+        if (IS_SUCCESS((priv->gen == gen) && (priv->idx == idx) && (priv->sock))) {
             __socket_ioq_flush(priv);
             __socket_reset(this);
             socket_closed = _gf_true;
@@ -2535,7 +2535,7 @@ socket_event_poll_in(rpc_transport_t *this, gf_boolean_t notify_handled)
         pthread_mutex_unlock(&priv->notify.lock);
     }
 
-    if (notify_handled && (ret >= 0))
+    if (IS_SUCCESS(notify_handled && (ret)))
         gf_event_handled(ctx->event_pool, priv->sock, priv->idx, priv->gen);
 
     if (pollin) {
@@ -2951,7 +2951,7 @@ socket_event_handler(int fd, int idx, int gen, void *data, int poll_in,
                          this->name, "disconnecting from");
 
         /* Logging has happened already in earlier cases */
-        gf_log("transport", ((ret >= 0) ? GF_LOG_INFO : GF_LOG_DEBUG),
+        gf_log(IS_SUCCESS("transport", ((ret)) ? GF_LOG_INFO : GF_LOG_DEBUG),
                "EPOLLERR - disconnecting (sock:%d) (%s)", priv->sock,
                (priv->use_ssl ? "SSL" : "non-SSL"));
 
@@ -3188,7 +3188,7 @@ socket_server_event_handler(int fd, int idx, int gen, void *data, int poll_in,
              */
             ret = rpc_transport_notify(this, RPC_TRANSPORT_ACCEPT, new_trans);
 
-            if (ret >= 0) {
+            if (IS_SUCCESS(ret)) {
                 new_priv->idx = gf_event_register(
                     ctx->event_pool, new_sock, socket_event_handler, new_trans,
                     1, 0, new_trans->notify_poller_death);
@@ -3304,7 +3304,7 @@ connect_loop(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 
     for (;;) {
         ret = connect(sockfd, addr, addrlen);
-        if (ret >= 0) {
+        if (IS_SUCCESS(ret)) {
             break;
         }
         if ((errno != ENOENT) || (++connect_fails >= 5)) {
@@ -3353,7 +3353,7 @@ socket_connect(rpc_transport_t *this, int port)
 
     pthread_mutex_lock(&priv->out_lock);
     {
-        if (priv->sock >= 0) {
+        if (IS_SUCCESS(priv->sock)) {
             gf_log_callingfn(this->name, GF_LOG_TRACE,
                              "connect () called on transport "
                              "already connected");
@@ -3639,7 +3639,7 @@ socket_listen(rpc_transport_t *this)
     }
     pthread_mutex_unlock(&priv->out_lock);
 
-    if (sock >= 0) {
+    if (IS_SUCCESS(sock)) {
         gf_log_callingfn(this->name, GF_LOG_DEBUG, "already listening");
         return ret;
     }
@@ -3652,7 +3652,7 @@ socket_listen(rpc_transport_t *this)
 
     pthread_mutex_lock(&priv->out_lock);
     {
-        if (priv->sock >= 0) {
+        if (IS_SUCCESS(priv->sock)) {
             gf_log(this->name, GF_LOG_DEBUG, "already listening");
             goto unlock;
         }
@@ -4586,7 +4586,7 @@ fini(rpc_transport_t *this)
 
     priv = this->private;
     if (priv) {
-        if (priv->sock >= 0) {
+        if (IS_SUCCESS(priv->sock)) {
             pthread_mutex_lock(&priv->out_lock);
             {
                 __socket_ioq_flush(priv);

--- a/rpc/rpc-transport/socket/src/socket.c
+++ b/rpc/rpc-transport/socket/src/socket.c
@@ -166,7 +166,7 @@ ssl_setup_connection_params(rpc_transport_t *this);
                                                                                \
         ret = __socket_readv(this, in->pending_vector, 1, &in->pending_vector, \
                              &in->pending_count, &bytes_read);                 \
-        if (ret < 0)                                                           \
+        if (IS_ERROR(ret))                                                     \
             break;                                                             \
         __socket_proto_update_priv_after_read(priv, ret, bytes_read);          \
     }
@@ -249,7 +249,7 @@ ssl_do(rpc_transport_t *this, void *buf, size_t len, SSL_trinary_func *func)
     priv = this->private;
 
     if (buf) {
-        if (priv->connected == -1) {
+        if (IS_ERROR(priv->connected)) {
             /*
              * Fields in the SSL structure (especially
              * the BIO pointers) are not valid at this
@@ -363,7 +363,7 @@ ssl_setup_connection_prefix(rpc_transport_t *this, gf_boolean_t server)
 
     priv = this->private;
 
-    if (ssl_setup_connection_params(this) < 0) {
+    if (IS_ERROR(ssl_setup_connection_params(this))) {
         gf_log(this->name, GF_LOG_TRACE,
                "+ ssl_setup_connection_params() failed!");
         goto done;
@@ -659,7 +659,7 @@ __does_socket_rwv_error_need_logging(socket_private_t *priv, int write)
 {
     int read = !write;
 
-    if (priv->connected == -1) /* Didn't even connect, of course it fails */
+    if (IS_ERROR(priv->connected)) /* Didn't even connect, of course it fails */
         return _gf_false;
 
     if (read && (priv->read_fail_log == _gf_false))
@@ -725,7 +725,7 @@ __socket_rwv(rpc_transport_t *this, struct iovec *vector, int count,
                 ret = sys_writev(sock, opvector, IOV_MIN(opcount));
             }
 
-            if ((ret == 0) || ((ret < 0) && (errno == EAGAIN))) {
+            if ((ret == 0) || (IS_ERROR(ret) && (errno == EAGAIN))) {
                 /* done for now */
                 break;
             } else if (ret > 0)
@@ -740,7 +740,7 @@ __socket_rwv(rpc_transport_t *this, struct iovec *vector, int count,
                 errno = ENODATA;
                 ret = -1;
             }
-            if ((ret < 0) && (errno == EAGAIN)) {
+            if (IS_ERROR(ret) && (errno == EAGAIN)) {
                 /* done for now */
                 break;
             } else if (ret > 0)
@@ -756,7 +756,7 @@ __socket_rwv(rpc_transport_t *this, struct iovec *vector, int count,
             errno = ENOTCONN;
             break;
         }
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             if (errno == EINTR)
                 continue;
 
@@ -1073,7 +1073,7 @@ __socket_keepalive(int fd, int family, int keepaliveintvl, int keepaliveidle,
     }
 
 #if defined(TCP_USER_TIMEOUT)
-    if (timeout_ms < 0)
+    if (IS_ERROR(timeout_ms))
         goto done;
     ret = setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &timeout_ms,
                      sizeof(timeout_ms));
@@ -1380,7 +1380,7 @@ socket_event_poll_out(rpc_transport_t *this)
         if (priv->connected == 1) {
             ret = __socket_ioq_churn(this);
 
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_log(this->name, GF_LOG_TRACE,
                        "__socket_ioq_churn returned -1; "
                        "disconnecting socket");
@@ -1438,7 +1438,7 @@ __socket_read_simple_msg(rpc_transport_t *this)
                                      &bytes_read);
             }
 
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_log(this->name, GF_LOG_WARNING,
                        "reading from socket failed. Error (%s), "
                        "peer (%s)",
@@ -1627,8 +1627,8 @@ __socket_read_vectored_request(rpc_transport_t *this,
 
             remaining_size = RPC_FRAGSIZE(in->fraghdr) - frag->bytes_read;
 
-            if ((ret < 0) || ((ret == 0) && (remaining_size == 0) &&
-                              RPC_LASTFRAG(in->fraghdr))) {
+            if (IS_ERROR(ret) || ((ret == 0) && (remaining_size == 0) &&
+                                  RPC_LASTFRAG(in->fraghdr))) {
                 request->vector_state = SP_STATE_VECTORED_REQUEST_INIT;
                 in->payload_vector.iov_len = ((unsigned long)frag->fragcurrent -
                                               (unsigned long)
@@ -1701,8 +1701,8 @@ __socket_read_request(rpc_transport_t *this)
 
             remaining_size = RPC_FRAGSIZE(in->fraghdr) - frag->bytes_read;
 
-            if ((ret < 0) || ((ret == 0) && (remaining_size == 0) &&
-                              (RPC_LASTFRAG(in->fraghdr)))) {
+            if (IS_ERROR(ret) || ((ret == 0) && (remaining_size == 0) &&
+                                  (RPC_LASTFRAG(in->fraghdr)))) {
                 request->header_state = SP_STATE_REQUEST_HEADER_INIT;
             }
 
@@ -1809,7 +1809,7 @@ __socket_read_accepted_successful_reply(rpc_transport_t *this)
 
                 ret = iobref_add(in->iobref, iobuf);
                 iobuf_unref(iobuf);
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     goto out;
                 }
 
@@ -1828,8 +1828,8 @@ __socket_read_accepted_successful_reply(rpc_transport_t *this)
             /* now read the entire remaining msg into new iobuf */
             ret = __socket_read_simple_msg(this);
             remaining_size = RPC_FRAGSIZE(in->fraghdr) - frag->bytes_read;
-            if ((ret < 0) || ((ret == 0) && (remaining_size == 0) &&
-                              RPC_LASTFRAG(in->fraghdr))) {
+            if (IS_ERROR(ret) || ((ret == 0) && (remaining_size == 0) &&
+                                  RPC_LASTFRAG(in->fraghdr))) {
                 frag->call_body.reply.accepted_success_state =
                     SP_STATE_ACCEPTED_SUCCESS_REPLY_INIT;
             }
@@ -1939,7 +1939,7 @@ __socket_read_accepted_successful_reply_v2(rpc_transport_t *this)
 
                 ret = iobref_add(in->iobref, iobuf);
                 iobuf_unref(iobuf);
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     goto out;
                 }
 
@@ -1958,8 +1958,8 @@ __socket_read_accepted_successful_reply_v2(rpc_transport_t *this)
             /* now read the entire remaining msg into new iobuf */
             ret = __socket_read_simple_msg(this);
             remaining_size = RPC_FRAGSIZE(in->fraghdr) - frag->bytes_read;
-            if ((ret < 0) || ((ret == 0) && (remaining_size == 0) &&
-                              RPC_LASTFRAG(in->fraghdr))) {
+            if (IS_ERROR(ret) || ((ret == 0) && (remaining_size == 0) &&
+                                  RPC_LASTFRAG(in->fraghdr))) {
                 frag->call_body.reply.accepted_success_state =
                     SP_STATE_ACCEPTED_SUCCESS_REPLY_INIT;
             }
@@ -2055,8 +2055,8 @@ __socket_read_accepted_reply(rpc_transport_t *this)
 
             remaining_size = RPC_FRAGSIZE(in->fraghdr) - frag->bytes_read;
 
-            if ((ret < 0) || ((ret == 0) && (remaining_size == 0) &&
-                              (RPC_LASTFRAG(in->fraghdr)))) {
+            if (IS_ERROR(ret) || ((ret == 0) && (remaining_size == 0) &&
+                                  (RPC_LASTFRAG(in->fraghdr)))) {
                 frag->call_body.reply
                     .accepted_state = SP_STATE_ACCEPTED_REPLY_INIT;
             }
@@ -2117,8 +2117,8 @@ __socket_read_vectored_reply(rpc_transport_t *this)
 
             remaining_size = RPC_FRAGSIZE(in->fraghdr) - frag->bytes_read;
 
-            if ((ret < 0) || ((ret == 0) && (remaining_size == 0) &&
-                              (RPC_LASTFRAG(in->fraghdr)))) {
+            if (IS_ERROR(ret) || ((ret == 0) && (remaining_size == 0) &&
+                                  (RPC_LASTFRAG(in->fraghdr)))) {
                 frag->call_body.reply
                     .status_state = SP_STATE_VECTORED_REPLY_STATUS_INIT;
                 in->payload_vector.iov_len = (unsigned long)frag->fragcurrent -
@@ -2181,7 +2181,7 @@ __socket_read_reply(rpc_transport_t *this)
         /* Transition back to externally visible state. */
         frag->state = SP_STATE_READ_MSGTYPE;
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(this->name, GF_LOG_WARNING,
                    "notify for event MAP_XID failed for %s",
                    this->peerinfo.identifier);
@@ -2256,8 +2256,8 @@ __socket_read_frag(rpc_transport_t *this)
 
             remaining_size = RPC_FRAGSIZE(in->fraghdr) - frag->bytes_read;
 
-            if ((ret < 0) || ((ret == 0) && (remaining_size == 0) &&
-                              (RPC_LASTFRAG(in->fraghdr)))) {
+            if (IS_ERROR(ret) || ((ret == 0) && (remaining_size == 0) &&
+                                  (RPC_LASTFRAG(in->fraghdr)))) {
                 /* frag->state = SP_STATE_NADA; */
                 frag->state = SP_STATE_RPCFRAG_INIT;
             }
@@ -2340,7 +2340,7 @@ __socket_proto_state_machine(rpc_transport_t *this,
                 ret = __socket_readv(this, in->pending_vector, 1,
                                      &in->pending_vector, &in->pending_count,
                                      NULL);
-                if (ret < 0)
+                if (IS_ERROR(ret))
                     goto out;
 
                 if (ret > 0) {
@@ -2397,7 +2397,7 @@ __socket_proto_state_machine(rpc_transport_t *this,
             case SP_STATE_READING_FRAG:
                 ret = __socket_read_frag(this);
 
-                if ((ret < 0) ||
+                if (IS_ERROR(ret) ||
                     (frag->bytes_read != RPC_FRAGSIZE(in->fraghdr))) {
                     goto out;
                 }
@@ -2565,10 +2565,10 @@ socket_connect_finish(rpc_transport_t *this)
 
         ret = __socket_connect_finish(priv->sock);
 
-        if ((ret < 0) && (errno == EINPROGRESS))
+        if (IS_ERROR(ret) && (errno == EINPROGRESS))
             ret = 1;
 
-        if ((ret < 0) && (errno != EINPROGRESS)) {
+        if (IS_ERROR(ret) && (errno != EINPROGRESS)) {
             if (!priv->connect_finish_log) {
                 gf_log(this->name, GF_LOG_ERROR,
                        "connection to %s failed (%s); "
@@ -2668,7 +2668,7 @@ ssl_handle_server_connection_attempt(rpc_transport_t *this)
 
     if (!priv->ssl_context_created) {
         ret = ssl_setup_connection_prefix(this, _gf_true);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(this->name, GF_LOG_TRACE,
                    "> ssl_setup_connection_prefix() failed!");
             ret = -1;
@@ -2722,7 +2722,7 @@ ssl_handle_client_connection_attempt(rpc_transport_t *this)
     } else {
         if (!priv->ssl_context_created) {
             ret = ssl_setup_connection_prefix(this, _gf_false);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_log(this->name, GF_LOG_TRACE,
                        "> ssl_setup_connection_prefix() "
                        "failed!");
@@ -2939,7 +2939,7 @@ socket_event_handler(int fd, int idx, int gen, void *data, int poll_in,
         notify_handled = _gf_true;
     }
 
-    if ((ret < 0) || poll_err) {
+    if (IS_ERROR(ret) || poll_err) {
         struct sockaddr *sa = SA(&this->peerinfo.sockaddr);
 
         if (priv->is_server &&
@@ -3024,7 +3024,7 @@ socket_server_event_handler(int fd, int idx, int gen, void *data, int poll_in,
 
         gf_event_handled(ctx->event_pool, fd, idx, gen);
 
-        if (new_sock < 0) {
+        if (IS_ERROR(new_sock)) {
             gf_log(this->name, GF_LOG_WARNING, "accept on %d failed (%s)",
                    priv->sock, strerror(errno));
             goto out;
@@ -3192,7 +3192,7 @@ socket_server_event_handler(int fd, int idx, int gen, void *data, int poll_in,
                 new_priv->idx = gf_event_register(
                     ctx->event_pool, new_sock, socket_event_handler, new_trans,
                     1, 0, new_trans->notify_poller_death);
-                if (new_priv->idx == -1) {
+                if (IS_ERROR(new_priv->idx)) {
                     ret = -1;
                     gf_log(this->name, GF_LOG_ERROR,
                            "failed to register the socket "
@@ -3226,7 +3226,7 @@ socket_server_event_handler(int fd, int idx, int gen, void *data, int poll_in,
             rpc_transport_unref(new_trans);
         }
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(this->name, GF_LOG_WARNING, "closing newly accepted socket");
             sys_close(new_sock);
             /* this unref is to actually cause the destruction of
@@ -3367,7 +3367,7 @@ socket_connect(rpc_transport_t *this, int port)
 
         ret = socket_client_get_remote_sockaddr(this, &sock_union.sa,
                                                 &sockaddr_len, &sa_family);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             /* logged inside client_get_remote_sockaddr */
             goto unlock;
         }
@@ -3386,7 +3386,7 @@ socket_connect(rpc_transport_t *this, int port)
         this->peerinfo.sockaddr_len = sockaddr_len;
 
         priv->sock = sys_socket(sa_family, SOCK_STREAM, 0);
-        if (priv->sock < 0) {
+        if (IS_ERROR(priv->sock)) {
             gf_log(this->name, GF_LOG_ERROR, "socket creation failed (%s)",
                    strerror(errno));
             ret = -1;
@@ -3420,8 +3420,9 @@ socket_connect(rpc_transport_t *this, int port)
          */
 #ifdef IPV6_DEFAULT
         int disable_v6only = 0;
-        if (setsockopt(priv->sock, IPPROTO_IPV6, IPV6_V6ONLY,
-                       (void *)&disable_v6only, sizeof(disable_v6only)) < 0) {
+        if (IS_ERROR(setsockopt(priv->sock, IPPROTO_IPV6, IPV6_V6ONLY,
+                                (void *)&disable_v6only,
+                                sizeof(disable_v6only)))) {
             gf_log(this->name, GF_LOG_WARNING,
                    "Error disabling sockopt IPV6_V6ONLY: \"%s\"",
                    strerror(errno));
@@ -3465,7 +3466,7 @@ socket_connect(rpc_transport_t *this, int port)
 
         ret = client_bind(this, SA(&this->myinfo.sockaddr),
                           &this->myinfo.sockaddr_len, priv->sock);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(this->name, GF_LOG_WARNING, "client bind failed: %s",
                    strerror(errno));
             goto handler;
@@ -3547,7 +3548,7 @@ socket_connect(rpc_transport_t *this, int port)
         }
 
     handler:
-        if (ret < 0 && !connect_attempted) {
+        if (IS_ERROR(ret) && !connect_attempted) {
             /* Ignore error from connect. epoll events
                should be handled in the socket handler.  shutdown(2)
                will result in EPOLLERR, so cleanup is done in
@@ -3567,7 +3568,7 @@ socket_connect(rpc_transport_t *this, int port)
         priv->idx = gf_event_register(ctx->event_pool, priv->sock,
                                       socket_event_handler, this, 1, 1,
                                       this->notify_poller_death);
-        if (priv->idx == -1) {
+        if (IS_ERROR(priv->idx)) {
             gf_log("", GF_LOG_WARNING,
                    "failed to register the event; "
                    "closing socket %d",
@@ -3584,7 +3585,7 @@ socket_connect(rpc_transport_t *this, int port)
 
 err:
     /* if sock >= 0, then cleanup is done from the event handler */
-    if ((ret < 0) && (sock < 0)) {
+    if (IS_ERROR(ret) && IS_ERROR(sock)) {
         /* Cleaup requires to send notification to upper layer which
            intern holds the big_lock. There can be dead-lock situation
            if big_lock is already held by the current thread.
@@ -3645,7 +3646,7 @@ socket_listen(rpc_transport_t *this)
 
     ret = socket_server_get_local_sockaddr(this, SA(&sockaddr), &sockaddr_len,
                                            &sa_family);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         return ret;
     }
 
@@ -3661,7 +3662,7 @@ socket_listen(rpc_transport_t *this)
 
         priv->sock = sys_socket(sa_family, SOCK_STREAM, 0);
 
-        if (priv->sock < 0) {
+        if (IS_ERROR(priv->sock)) {
             gf_log(this->name, GF_LOG_ERROR, "socket creation failed (%s)",
                    strerror(errno));
             goto unlock;
@@ -3713,7 +3714,7 @@ socket_listen(rpc_transport_t *this)
         /* coverity[SLEEP] */
         ret = __socket_server_bind(this);
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             /* logged inside __socket_server_bind() */
             gf_log(this->name, GF_LOG_ERROR,
                    "__socket_server_bind failed;"
@@ -3745,7 +3746,7 @@ socket_listen(rpc_transport_t *this)
                                       socket_server_event_handler, this, 1, 0,
                                       this->notify_poller_death);
 
-        if (priv->idx == -1) {
+        if (IS_ERROR(priv->idx)) {
             gf_log(this->name, GF_LOG_WARNING,
                    "could not register socket %d with events; "
                    "closing socket",
@@ -4637,7 +4638,7 @@ init(rpc_transport_t *this)
 
     ret = socket_init(this);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_DEBUG, "socket_init() failed");
     }
 

--- a/rpc/xdr/src/glusterfs3.h
+++ b/rpc/xdr/src/glusterfs3.h
@@ -459,7 +459,7 @@ gf_proto_inodelk_contention_to_upcall(struct gfs4_inodelk_contention_req *lc,
     ret = 0;
 
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -op_errno;
     }
 
@@ -495,7 +495,7 @@ gf_proto_inodelk_contention_from_upcall(xlator_t *this,
     ret = 0;
 
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -op_errno;
     }
 
@@ -537,7 +537,7 @@ gf_proto_entrylk_contention_to_upcall(struct gfs4_entrylk_contention_req *lc,
     ret = 0;
 
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -op_errno;
     }
 
@@ -577,7 +577,7 @@ gf_proto_entrylk_contention_from_upcall(xlator_t *this,
     ret = 0;
 
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -op_errno;
     }
 
@@ -826,7 +826,7 @@ xdr_to_dict(gfx_dict *dict, dict_t **to)
     if (!to || !dict)
         goto out;
 
-    if (dict->count < 0) {
+    if (IS_ERROR(dict->count)) {
         /* indicates NULL dict was passed for encoding */
         ret = 0;
         goto out;

--- a/tests/basic/fencing/fence-basic.c
+++ b/tests/basic/fencing/fence-basic.c
@@ -123,7 +123,7 @@ test(glfs_t *fs1, glfs_t *fs2, char *fname)
 
     /* write should fail */
     ret = glfs_write(fd2, buf, 10, 0);
-    if (ret != -1) {
+    if (ret >= 0) {
         LOG_ERR("glfs_write", errno);
         ret = -1;
         goto out;
@@ -138,7 +138,7 @@ test(glfs_t *fs1, glfs_t *fs2, char *fname)
 
     /* write should succeed from client 2 */
     ret = glfs_write(fd2, buf, 10, 0);
-    if (ret == -1) {
+    if (ret < 0) {
         LOG_ERR("glfs_write", errno);
         goto out;
     }

--- a/tests/basic/fops-sanity.c
+++ b/tests/basic/fops-sanity.c
@@ -1004,7 +1004,7 @@ generic_open_read_write(char *filename, int flag, mode_t mode)
     }
 
     ret = read(fd, rstring, strlen(wstring));
-    if (ret < 0 && flag != (O_CREAT | O_WRONLY) && flag != O_WRONLY &&
+    if (IS_ERROR(ret) && flag != (O_CREAT | O_WRONLY) && flag != O_WRONLY &&
         flag != (O_TRUNC | O_WRONLY)) {
         close(fd);
         unlink(filename);

--- a/tests/basic/gfapi/gfapi-statx-basic.c
+++ b/tests/basic/gfapi/gfapi-statx-basic.c
@@ -99,7 +99,7 @@ main(int argc, char *argv[])
     /* TEST 1: Invalid mask to statx */
     mask = 0xfafadbdb;
     ret = glfs_statx(fs, filename, mask, NULL);
-    if (ret == 0 || ((ret == -1) && (errno != EINVAL))) {
+    if (ret == 0 || ((ret < 0) && (errno != EINVAL))) {
         fprintf(stderr,
                 "Invalid args passed, but error returned is"
                 " incorrect (ret - %d, errno - %d)\n",

--- a/tests/basic/gfapi/glfs-copy-file-range.c
+++ b/tests/basic/gfapi/glfs-copy-file-range.c
@@ -157,7 +157,7 @@ main(int argc, char **argv)
     do {
         ret = glfs_copy_file_range(glfd_in, NULL, glfd_out, NULL, len, 0,
                                    &stat_src, &prestat_dst, &poststat_dst);
-        if (ret == -1) {
+        if (ret < 0) {
             fprintf(stderr, "copy_file_range failed with %s\n",
                     strerror(errno));
             ret = -errno;

--- a/tests/basic/playground/template-xlator-sanity.t
+++ b/tests/basic/playground/template-xlator-sanity.t
@@ -32,7 +32,7 @@ TEST generate_statedump $pid
 kill -USR2 $pid
 
 # Handle SIGHUP and reconfigure
-sed -i -e '/s/dummy 13/dummy 42/g' $B0/template.vol
+sed -i -e 's/dummy 13/dummy 42/g' $B0/template.vol
 kill -HUP $pid
 
 # for calling 'fini()'

--- a/tests/basic/quota.c
+++ b/tests/basic/quota.c
@@ -47,7 +47,7 @@ file_write(char *filename, int bs, int count)
     fd = open(filename, O_RDWR | O_CREAT | O_SYNC, 0600);
     while (i < count) {
         ret = nwrite(fd, buf, bs);
-        if (ret == -1) {
+        if (ret < 0) {
             close(fd);
             goto out;
         }

--- a/tests/basic/rpc-coverage.t
+++ b/tests/basic/rpc-coverage.t
@@ -22,4 +22,5 @@ EXPECT 'Started' volinfo_field $V0 'Status';
 TEST $GFS -s $H0 --volfile-id $V0 $M1;
 
 TEST $(dirname $0)/rpc-coverage.sh $M1
+
 cleanup;

--- a/tests/bugs/replicate/bug-1250170-fsync.c
+++ b/tests/bugs/replicate/bug-1250170-fsync.c
@@ -42,7 +42,7 @@ main(int argc, char **argv)
 
     for (i = 0; i < loop_count; i++) {
         ret = write(fd, buffer, buf_size);
-        if (ret == -1) {
+        if (ret < 0) {
             perror("write");
             return ret;
         } else {

--- a/tests/utils/arequal-checksum.c
+++ b/tests/utils/arequal-checksum.c
@@ -277,7 +277,7 @@ checksum_md5(const char *path, const struct stat *sb)
     }
 
     this_data_checksum = strtoull(strvalue, NULL, 16);
-    if (-1 == this_data_checksum) {
+    if (IS_ERROR(this_data_checksum)) {
         fprintf(stderr, "%s: %s\n", strvalue, strerror(errno));
         goto out;
     }
@@ -289,7 +289,7 @@ checksum_md5(const char *path, const struct stat *sb)
     }
 
     this_data_checksum = strtoull(strvalue, NULL, 16);
-    if (-1 == this_data_checksum) {
+    if (IS_ERROR(this_data_checksum)) {
         fprintf(stderr, "%s: %s\n", strvalue, strerror(errno));
         goto out;
     }

--- a/tools/setgfid2path/src/main.c
+++ b/tools/setgfid2path/src/main.c
@@ -104,7 +104,7 @@ main(int argc, char **argv)
 
     /* Set the Xattr, ignore if same key xattr already exists */
     ret = sys_lsetxattr(file_path, key, val, strlen(val), XATTR_CREATE);
-    if (ret == -1) {
+    if (ret < 0) {
         if (errno == EEXIST) {
             printf("Xattr already exists, ignoring..\n");
             ret = 0;

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -5785,7 +5785,7 @@ find_best_down_child(xlator_t *this)
     priv = this->private;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (IS_SUCCESS(!priv->child_up[i] && priv->child_latency[i]) &&
+        if (!priv->child_up[i] && IS_SUCCESS(priv->child_latency[i]) &&
             priv->child_latency[i] < best_latency) {
             best_child = i;
             best_latency = priv->child_latency[i];
@@ -5810,7 +5810,7 @@ find_worst_up_child(xlator_t *this)
     priv = this->private;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (IS_SUCCESS(priv->child_up[i] && priv->child_latency[i]) &&
+        if (priv->child_up[i] && IS_SUCCESS(priv->child_latency[i]) &&
             priv->child_latency[i] > worst_latency) {
             worst_child = i;
             worst_latency = priv->child_latency[i];

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -79,7 +79,7 @@ afr_dom_lock_acquire_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local->cont.lk.dom_lock_op_ret[i] = op_ret;
     local->cont.lk.dom_lock_op_errno[i] = op_errno;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_LK_HEAL_DOM,
                "%s: Failed to acquire %s on %s",
                uuid_utoa(local->fd->inode->gfid), AFR_LK_HEAL_DOM,
@@ -163,7 +163,7 @@ afr_dom_lock_release_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     afr_private_t *priv = this->private;
     int i = (long)cookie;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_LK_HEAL_DOM,
                "%s: Failed to release %s on %s", local->loc.path,
                AFR_LK_HEAL_DOM, priv->children[i]->name);
@@ -931,7 +931,7 @@ afr_is_symmetric_error(call_frame_t *frame, xlator_t *this)
     for (i = 0; i < priv->child_count; i++) {
         if (!local->replies[i].valid)
             continue;
-        if (local->replies[i].op_ret != -1) {
+        if (local->replies[i].op_ret >= 0) {
             /* Operation succeeded on at least one subvol,
                so it is not a failed-everywhere situation.
             */
@@ -1004,7 +1004,7 @@ __afr_inode_read_subvol_get_small(inode_t *inode, xlator_t *this,
     priv = this->private;
 
     ret = __afr_inode_ctx_get(this, inode, &ctx);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return ret;
 
     val = ctx->read_subvol;
@@ -1088,7 +1088,7 @@ __afr_inode_split_brain_choice_get(inode_t *inode, xlator_t *this,
     int ret = -1;
 
     ret = __afr_inode_ctx_get(this, inode, &ctx);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return ret;
 
     *spb_choice = ctx->spb_choice;
@@ -1163,7 +1163,7 @@ afr_inode_get_readable(call_frame_t *frame, inode_t *inode, xlator_t *this,
 
     ret = afr_inode_read_subvol_get(inode, this, data, metadata,
                                     &event_generation);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         return -EIO;
 
     data_count = AFR_COUNT(data, priv->child_count);
@@ -1322,7 +1322,7 @@ afr_spb_choice_timeout_cancel(xlator_t *this, inode_t *inode)
     LOCK(&inode->lock);
     {
         ret = __afr_inode_ctx_get(this, inode, &ctx);
-        if (ret < 0 || !ctx) {
+        if (IS_ERROR(ret) || !ctx) {
             UNLOCK(&inode->lock);
             gf_msg(this->name, GF_LOG_WARNING, 0,
                    AFR_MSG_SPLIT_BRAIN_CHOICE_ERROR,
@@ -1433,7 +1433,7 @@ afr_set_split_brain_choice(int ret, call_frame_t *frame, void *opaque)
          * ctx->spb_choice is -1
          */
         if (ctx->timer) {
-            if (ctx->spb_choice == -1) {
+            if (IS_ERROR(ctx->spb_choice)) {
                 if (!gf_timer_call_cancel(this->ctx, ctx->timer)) {
                     ctx->timer = NULL;
                     timer_cancelled = _gf_true;
@@ -1448,7 +1448,7 @@ afr_set_split_brain_choice(int ret, call_frame_t *frame, void *opaque)
             }
             goto reset_timer;
         } else {
-            if (ctx->spb_choice == -1)
+            if (IS_ERROR(ctx->spb_choice))
                 goto unlock;
             goto set_timer;
         }
@@ -1585,7 +1585,7 @@ afr_readables_fill(call_frame_t *frame, xlator_t *this, inode_t *inode,
 
     for (i = 0; i < priv->child_count; i++) {
         if (replies) { /* Lookup */
-            if (!replies[i].valid || replies[i].op_ret == -1 ||
+            if (!replies[i].valid || IS_ERROR(replies[i].op_ret) ||
                 (replies[i].xdata &&
                  dict_get_sizen(replies[i].xdata, GLUSTERFS_BAD_INODE))) {
                 data_readable[i] = 0;
@@ -1746,7 +1746,7 @@ afr_txn_refresh_done(call_frame_t *frame, xlator_t *this, int err)
         }
         read_subvol = afr_sh_get_fav_by_policy(this, local->replies, inode,
                                                NULL);
-        if (read_subvol == -1) {
+        if (IS_ERROR(read_subvol)) {
             err = EIO;
             goto refresh_done;
         }
@@ -1852,7 +1852,7 @@ afr_inode_refresh_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local->replies[call_child].valid = 1;
     local->replies[call_child].op_ret = op_ret;
     local->replies[call_child].op_errno = op_errno;
-    if (op_ret != -1) {
+    if (op_ret >= 0) {
         local->replies[call_child].poststat = *buf;
         if (par)
             local->replies[call_child].postparent = *par;
@@ -2073,7 +2073,7 @@ afr_xattr_req_prepare(xlator_t *this, dict_t *xattr_req)
     for (i = 0; i < priv->child_count; i++) {
         ret = dict_set_uint64(xattr_req, priv->pending_key[i],
                               AFR_NUM_CHANGE_LOGS * sizeof(int));
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg(this->name, GF_LOG_WARNING, -ret, AFR_MSG_DICT_SET_FAILED,
                    "Unable to set dict value for %s", priv->pending_key[i]);
         /* 3 = data+metadata+entry */
@@ -2112,20 +2112,20 @@ afr_lookup_xattr_req_prepare(afr_local_t *local, xlator_t *this,
     ret = afr_xattr_req_prepare(this, local->xattr_req);
 
     ret = dict_set_uint64(local->xattr_req, GLUSTERFS_INODELK_COUNT, 0);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, -ret, AFR_MSG_DICT_SET_FAILED,
                "%s: Unable to set dict value for %s", loc->path,
                GLUSTERFS_INODELK_COUNT);
     }
     ret = dict_set_uint64(local->xattr_req, GLUSTERFS_ENTRYLK_COUNT, 0);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, -ret, AFR_MSG_DICT_SET_FAILED,
                "%s: Unable to set dict value for %s", loc->path,
                GLUSTERFS_ENTRYLK_COUNT);
     }
 
     ret = dict_set_uint32(local->xattr_req, GLUSTERFS_PARENT_ENTRYLK, 0);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, -ret, AFR_MSG_DICT_SET_FAILED,
                "%s: Unable to set dict value for %s", loc->path,
                GLUSTERFS_PARENT_ENTRYLK);
@@ -2498,7 +2498,7 @@ afr_handle_inconsistent_fop(call_frame_t *frame, int32_t *op_ret,
     if (!frame || !frame->this || !frame->local || !frame->this->private)
         return;
 
-    if (*op_ret < 0)
+    if (IS_ERROR(*op_ret))
         return;
 
     /* Failing inodelk/entrylk/lk here is not a good idea because we
@@ -2750,10 +2750,10 @@ afr_get_parent_read_subvol(xlator_t *this, inode_t *parent,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret < 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
-        if (par_read_subvol_iter == -1) {
+        if (IS_ERROR(par_read_subvol_iter)) {
             par_read_subvol_iter = i;
             continue;
         }
@@ -2769,7 +2769,7 @@ afr_get_parent_read_subvol(xlator_t *this, inode_t *parent,
      * So it is okay to send an arbitrary subvolume (0 in this case)
      * as parent read subvol.
      */
-    if (par_read_subvol_iter == -1)
+    if (IS_ERROR(par_read_subvol_iter))
         par_read_subvol_iter = 0;
 
     return par_read_subvol_iter;
@@ -2851,9 +2851,7 @@ afr_attempt_readsubvol_set(call_frame_t *frame, xlator_t *this,
         local->op_ret = -1;
         local->op_errno = ENOTCONN;
         gf_msg(this->name, GF_LOG_WARNING, 0, AFR_MSG_READ_SUBVOL_ERROR,
-               "no read "
-               "subvols for %s",
-               local->loc.path);
+               "no read subvols for %s", local->loc.path);
     }
     if (*read_subvol >= 0)
         dict_del_sizen(local->replies[*read_subvol].xdata, GF_CONTENT_KEY);
@@ -2920,7 +2918,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
         if (!replies[i].valid)
             continue;
 
-        if (locked_entry && replies[i].op_ret == -1 &&
+        if (locked_entry && IS_ERROR(replies[i].op_ret) &&
             replies[i].op_errno == ENOENT) {
             /* Second, check entry is still
                "underway" in creation */
@@ -2929,7 +2927,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
             goto error;
         }
 
-        if (replies[i].op_ret == -1)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         if (read_subvol == -1 || !readable[read_subvol]) {
@@ -2940,7 +2938,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
         }
     }
 
-    if (read_subvol == -1)
+    if (IS_ERROR(read_subvol))
         goto error;
     /* We now have a read_subvol, which is readable[] (if there
        were any). Next we look for GFID mismatches. We don't
@@ -2948,7 +2946,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
        readable[] but the mismatching GFID subvol is not.
     */
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1) {
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret)) {
             continue;
         }
 
@@ -2995,7 +2993,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
         ret = afr_replies_interpret(frame, this, local->inode, NULL);
         read_subvol = afr_read_subvol_decide(local->inode, this, &args,
                                              readable);
-        if (read_subvol == -1)
+        if (IS_ERROR(read_subvol))
             goto cant_interpret;
         if (ret) {
             afr_inode_need_refresh_set(local->inode, this);
@@ -3005,7 +3003,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
     cant_interpret:
         afr_attempt_readsubvol_set(frame, this, success_replies, readable,
                                    &read_subvol);
-        if (read_subvol == -1) {
+        if (IS_ERROR(read_subvol)) {
             goto error;
         }
     }
@@ -3176,12 +3174,12 @@ afr_lookup_sh_metadata_wrap(void *opaque)
     replies = local->replies;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         first = i;
         break;
     }
-    if (first == -1)
+    if (IS_ERROR(first))
         goto out;
 
     if (afr_selfheal_metadata_by_stbuf(this, &replies[first].poststat))
@@ -3279,9 +3277,9 @@ afr_can_start_metadata_self_heal(call_frame_t *frame, xlator_t *this)
         return _gf_false;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
-        if (first == -1) {
+        if (IS_ERROR(first)) {
             first = i;
             stbuf = replies[i].poststat;
             continue;
@@ -3413,7 +3411,7 @@ afr_lookup_entry_heal(call_frame_t *frame, xlator_t *this)
 
     ret = afr_inode_read_subvol_get(local->loc.parent, this, par_readables,
                                     NULL, NULL);
-    if (ret < 0 || AFR_COUNT(par_readables, priv->child_count) == 0) {
+    if (IS_ERROR(ret) || AFR_COUNT(par_readables, priv->child_count) == 0) {
         /* In this case set par_readables to all 1 so that name_heal
          * need checks at the end of this function will flag missing
          * entry when name state mismatches*/
@@ -3438,11 +3436,11 @@ afr_lookup_entry_heal(call_frame_t *frame, xlator_t *this)
         }
 
         /*gfid is missing, needs heal*/
-        if ((replies[i].op_ret == -1) && (replies[i].op_errno == ENODATA)) {
+        if (IS_ERROR(replies[i].op_ret) && (replies[i].op_errno == ENODATA)) {
             goto name_heal;
         }
 
-        if (first == -1) {
+        if (IS_ERROR(first)) {
             first = i;
             continue;
         }
@@ -3472,7 +3470,7 @@ afr_lookup_entry_heal(call_frame_t *frame, xlator_t *this)
         for (i = 0; i < priv->child_count; i++) {
             if (!replies[i].valid)
                 continue;
-            if (par_readables[i] && replies[i].op_ret < 0 &&
+            if (par_readables[i] && IS_ERROR(replies[i].op_ret) &&
                 replies[i].op_errno != ENOTCONN) {
                 goto name_heal;
             }
@@ -3532,7 +3530,7 @@ afr_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     } else {
         local->replies[child_index].need_heal = need_heal;
     }
-    if (op_ret != -1) {
+    if (op_ret >= 0) {
         local->replies[child_index].poststat = *buf;
         local->replies[child_index].postparent = *postparent;
         if (xdata)
@@ -3567,7 +3565,7 @@ afr_discover_unwind(call_frame_t *frame, xlator_t *this)
     if (AFR_COUNT(success_replies, priv->child_count) > 0)
         local->op_ret = 0;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         local->op_ret = -1;
         local->op_errno = afr_final_errno(frame->local, this->private);
         goto error;
@@ -3587,7 +3585,7 @@ afr_discover_unwind(call_frame_t *frame, xlator_t *this)
 unwind:
     afr_attempt_readsubvol_set(frame, this, success_replies, data_readable,
                                &read_subvol);
-    if (read_subvol == -1)
+    if (IS_ERROR(read_subvol))
         goto error;
 
     if (AFR_IS_ARBITER_BRICK(priv, read_subvol) && local->op_ret == 0) {
@@ -3715,7 +3713,7 @@ afr_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     local->replies[child_index].valid = 1;
     local->replies[child_index].op_ret = op_ret;
     local->replies[child_index].op_errno = op_errno;
-    if (op_ret != -1) {
+    if (op_ret >= 0) {
         local->replies[child_index].poststat = *buf;
         local->replies[child_index].postparent = *postparent;
         if (xdata)
@@ -3860,7 +3858,7 @@ afr_lookup_do(call_frame_t *frame, xlator_t *this, int err)
     local = frame->local;
     priv = this->private;
 
-    if (err < 0) {
+    if (IS_ERROR(err)) {
         local->op_errno = err;
         goto out;
     }
@@ -4016,7 +4014,7 @@ afr_cleanup_fd_ctx(xlator_t *this, fd_t *fd)
     int ret = 0;
 
     ret = fd_ctx_get(fd, this, &ctx);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     fd_ctx = (afr_fd_ctx_t *)(long)ctx;
@@ -4046,13 +4044,13 @@ __afr_fd_ctx_get(fd_t *fd, xlator_t *this)
 
     ret = __fd_ctx_get(fd, this, &ctx);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = __afr_fd_ctx_set(this, fd);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = __fd_ctx_get(fd, this, &ctx);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 
@@ -4139,7 +4137,7 @@ afr_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret != -1) {
+        if (op_ret >= 0) {
             local->op_ret = op_ret;
             if (!local->xdata_rsp && xdata)
                 local->xdata_rsp = dict_ref(xdata);
@@ -4342,7 +4340,7 @@ afr_serialized_lock_wind(call_frame_t *frame, xlator_t *this);
 static gf_boolean_t
 afr_is_conflicting_lock_present(int32_t op_ret, int32_t op_errno)
 {
-    if (op_ret == -1 && op_errno == EAGAIN)
+    if (IS_ERROR(op_ret) && op_errno == EAGAIN)
         return _gf_true;
     return _gf_false;
 }
@@ -4489,7 +4487,7 @@ afr_unlock_partial_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     priv = this->private;
 
-    if (op_ret < 0 && op_errno != ENOTCONN) {
+    if (IS_ERROR(op_ret) && op_errno != ENOTCONN) {
         if (local->fd)
             gf_uuid_copy(gfid, local->fd->inode->gfid);
         else
@@ -4549,7 +4547,7 @@ afr_unlock_locks_and_proceed(call_frame_t *frame, xlator_t *this,
         if (!local->replies[i].valid)
             continue;
 
-        if (local->replies[i].op_ret == -1)
+        if (IS_ERROR(local->replies[i].op_ret))
             continue;
 
         afr_fop_lock_wind(frame, this, i, afr_unlock_partial_lock_cbk);
@@ -4585,10 +4583,10 @@ afr_fop_lock_done(call_frame_t *frame, xlator_t *this)
             success[i] = 1;
         }
 
-        if (local->op_ret == -1 && local->op_errno == EAGAIN)
+        if (IS_ERROR(local->op_ret) && local->op_errno == EAGAIN)
             continue;
 
-        if ((local->replies[i].op_ret == -1) &&
+        if (IS_ERROR(local->replies[i].op_ret) &&
             (local->replies[i].op_errno == EAGAIN)) {
             local->op_ret = -1;
             local->op_errno = EAGAIN;
@@ -5007,7 +5005,7 @@ afr_lk_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0 && op_errno != ENOTCONN && op_errno != EBADFD) {
+    if (IS_ERROR(op_ret) && (op_errno != ENOTCONN) && (op_errno != EBADFD)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_UNLOCK_FAIL,
                "gfid=%s: unlock failed on subvolume %s "
                "with lock owner %s",
@@ -5078,7 +5076,7 @@ afr_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     child_index = (long)cookie;
 
     afr_common_lock_cbk(frame, cookie, this, op_ret, op_errno, xdata);
-    if (op_ret < 0 && op_errno == EAGAIN) {
+    if (IS_ERROR(op_ret) && op_errno == EAGAIN) {
         local->op_ret = -1;
         local->op_errno = EAGAIN;
 
@@ -5108,7 +5106,7 @@ afr_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
         afr_lk_unlock(frame, this);
     } else {
-        if (local->op_ret < 0)
+        if (IS_ERROR(local->op_ret))
             local->op_errno = afr_final_errno(local, priv);
 
         AFR_STACK_UNWIND(lk, frame, local->op_ret, local->op_errno,
@@ -5154,7 +5152,7 @@ afr_lk_txn_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     afr_private_t *priv = this->private;
     int child_index = (long)cookie;
 
-    if (op_ret < 0 && op_errno != ENOTCONN && op_errno != EBADFD) {
+    if (IS_ERROR(op_ret) && op_errno != ENOTCONN && op_errno != EBADFD) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_UNLOCK_FAIL,
                "gfid=%s: unlock failed on subvolume %s "
                "with lock owner %s",
@@ -5369,7 +5367,7 @@ afr_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     child_index = (long)cookie;
 
     afr_common_lock_cbk(frame, cookie, this, op_ret, op_errno, xdata);
-    if (op_ret < 0 && op_errno == EAGAIN) {
+    if (IS_ERROR(op_ret) && op_errno == EAGAIN) {
         local->op_ret = -1;
         local->op_errno = EAGAIN;
 
@@ -5397,7 +5395,7 @@ afr_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
         afr_lease_unlock(frame, this);
     } else {
-        if (local->op_ret < 0)
+        if (IS_ERROR(local->op_ret))
             local->op_errno = afr_final_errno(local, priv);
         AFR_STACK_UNWIND(lease, frame, local->op_ret, local->op_errno,
                          &local->cont.lease.ret_lease, NULL);
@@ -5477,7 +5475,7 @@ afr_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     for (i = 0; i < priv->child_count; i++) {
         if (!local->replies[i].valid)
             continue;
-        if (local->replies[i].op_ret < 0 &&
+        if (IS_ERROR(local->replies[i].op_ret) &&
             local->replies[i].op_errno != ENOTCONN) {
             local->op_ret = local->replies[i].op_ret;
             local->op_errno = local->replies[i].op_errno;
@@ -5538,7 +5536,7 @@ afr_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
 
     if (xdata) {
         for (i = 0; i < priv->child_count; i++) {
-            if (dict_set_int8(xdata, priv->pending_key[i], 0) < 0)
+            if (IS_ERROR(dict_set_int8(xdata, priv->pending_key[i], 0)))
                 goto err;
         }
     }
@@ -5556,7 +5554,7 @@ afr_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
     return 0;
 
 err:
-    if (op_errno == -1)
+    if (IS_ERROR(op_errno))
         op_errno = errno;
     AFR_STACK_UNWIND(ipc, frame, -1, op_errno, NULL);
 
@@ -5940,10 +5938,10 @@ __afr_handle_child_up_event(xlator_t *this, xlator_t *child_xlator,
     if (!priv->halo_enabled)
         goto out;
 
-    if (child_latency_msec < 0) {
+    if (IS_ERROR(child_latency_msec)) {
         /*set to INT64_MAX-1 so that it is found for best_down_child*/
         priv->halo_child_up[idx] = 1;
-        if (priv->child_latency[idx] < 0) {
+        if (IS_ERROR(priv->child_latency[idx])) {
             priv->child_latency[idx] = AFR_HALO_MAX_LATENCY;
         }
     }
@@ -5973,7 +5971,7 @@ __afr_handle_child_up_event(xlator_t *this, xlator_t *child_xlator,
 
     if (up_children > priv->halo_max_replicas && !priv->shd.iamshd) {
         worst_up_child = find_worst_up_child(this);
-        if (worst_up_child < 0) {
+        if (IS_ERROR(worst_up_child)) {
             worst_up_child = idx;
         }
         priv->child_up[worst_up_child] = 0;
@@ -6032,7 +6030,7 @@ __afr_handle_child_down_event(xlator_t *this, xlator_t *child_xlator, int idx,
      * want to set the child_latency to < 0 to indicate
      * the child is really disconnected.
      */
-    if (child_latency_msec < 0) {
+    if (IS_ERROR(child_latency_msec)) {
         priv->child_latency[idx] = child_latency_msec;
         priv->halo_child_up[idx] = 0;
     }
@@ -6222,7 +6220,7 @@ afr_notify(xlator_t *this, int32_t event, void *data, void *data2)
      * which triggers afr self-heals if any.
      */
     idx = afr_find_child_index(this, child_xlator);
-    if (idx < 0) {
+    if (IS_ERROR(idx)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_INVALID_CHILD_UP,
                "Received child_up from invalid subvolume");
         goto out;
@@ -6545,7 +6543,7 @@ afr_transaction_local_init(afr_local_t *local, xlator_t *this)
     INIT_LIST_HEAD(&local->ta_waitq);
     INIT_LIST_HEAD(&local->ta_onwireq);
     ret = afr_internal_lock_init(&local->internal_lock, priv->child_count);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = -ENOMEM;
@@ -6658,7 +6656,7 @@ afr_mark_pending_changelog(afr_private_t *priv, unsigned char *pending,
             changelog[i][d_idx] = hton32(1);
     }
     ret = afr_set_pending_dict(priv, xattr, changelog);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         afr_matrix_cleanup(changelog, priv->child_count);
         return NULL;
     }
@@ -6920,7 +6918,7 @@ afr_get_heal_info(call_frame_t *frame, xlator_t *this, loc_t *loc)
 
     if (ret == -EIO) {
         ret = gf_asprintf(&status, "split-brain%s", substr ? substr : "");
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
         dict = afr_set_heal_info(status);
@@ -6930,7 +6928,7 @@ afr_get_heal_info(call_frame_t *frame, xlator_t *this, loc_t *loc)
         }
     } else if (ret == -EAGAIN) {
         ret = gf_asprintf(&status, "possibly-healing%s", substr ? substr : "");
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
         dict = afr_set_heal_info(status);
@@ -6956,7 +6954,7 @@ afr_get_heal_info(call_frame_t *frame, xlator_t *this, loc_t *loc)
             }
         } else {
             ret = gf_asprintf(&status, "heal%s", substr ? substr : "");
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 goto out;
             }
             dict = afr_set_heal_info(status);
@@ -6965,7 +6963,7 @@ afr_get_heal_info(call_frame_t *frame, xlator_t *this, loc_t *loc)
                 goto out;
             }
         }
-    } else if (ret < 0) {
+    } else if (IS_ERROR(ret)) {
         /* Apart from above checked -ve ret values, there are
          * other possible ret values like ENOTCONN
          * (returned when number of valid replies received are
@@ -6975,7 +6973,7 @@ afr_get_heal_info(call_frame_t *frame, xlator_t *this, loc_t *loc)
          */
         if (data_selfheal || entry_selfheal || metadata_selfheal) {
             ret = gf_asprintf(&status, "heal%s", substr ? substr : "");
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 goto out;
             }
             dict = afr_set_heal_info(status);
@@ -7153,7 +7151,7 @@ afr_get_split_brain_status(void *opaque)
                           (d_spb) ? "yes" : "no", (m_spb) ? "yes" : "no",
                           choices);
 
-        if (-1 == ret) {
+        if (IS_ERROR(ret)) {
             op_errno = ENOMEM;
             goto out;
         }
@@ -7225,7 +7223,7 @@ afr_heal_splitbrain_file(call_frame_t *frame, xlator_t *this, loc_t *loc)
             /* 'sh-fail-msg' has been set in the dict during self-heal.*/
             dict_copy(local->xdata_rsp, dict);
             ret = 0;
-        } else if (ret < 0) {
+        } else if (IS_ERROR(ret)) {
             op_errno = -ret;
             ret = -1;
         }
@@ -7556,7 +7554,7 @@ afr_set_inode_local(xlator_t *this, afr_local_t *local, inode_t *inode)
         ret = __afr_inode_ctx_get(this, local->inode, &local->inode_ctx);
     }
     UNLOCK(&local->inode->lock);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_callingfn(
             this->name, GF_LOG_ERROR, ENOMEM, AFR_MSG_INODE_CTX_GET_FAILED,
             "Error getting inode ctx %s", uuid_utoa(local->inode->gfid));
@@ -7619,7 +7617,7 @@ afr_ta_post_op_lock(xlator_t *this, loc_t *loc)
             cmd = F_SETLK;
             gf_uuid_generate(gfid);
             flock1.l_start = gfid_to_ino(gfid);
-            if (flock1.l_start < 0)
+            if (IS_ERROR(flock1.l_start))
                 flock1.l_start = -flock1.l_start;
             flock1.l_len = 1;
         }

--- a/xlators/cluster/afr/src/afr-dir-read.c
+++ b/xlators/cluster/afr/src/afr-dir-read.c
@@ -44,7 +44,7 @@ afr_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             fd_ctx->opened_on[child_index] = AFR_FD_NOT_OPENED;
         } else {
@@ -195,7 +195,7 @@ afr_readdir_transform_entries(gf_dirent_t *subvol_entries, int subvol,
 
         if (entry->inode) {
             ret = afr_validate_read_subvol(entry->inode, this, subvol);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 inode_unref(entry->inode);
                 entry->inode = NULL;
                 continue;
@@ -216,7 +216,7 @@ afr_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0 && !local->cont.readdir.offset) {
+    if (IS_ERROR(op_ret) && !local->cont.readdir.offset) {
         /* failover only if this was first readdir, detected
            by offset == 0 */
         local->op_ret = op_ret;
@@ -301,7 +301,7 @@ afr_do_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     subvol = fd_ctx->readdir_subvol;
 
-    if (offset == 0 || subvol == -1) {
+    if (offset == 0 || IS_ERROR(subvol)) {
         /* First readdir has option of failing over and selecting
            an appropriate read subvolume */
         afr_read_txn(frame, this, fd->inode, afr_readdir_wind,

--- a/xlators/cluster/afr/src/afr-dir-read.c
+++ b/xlators/cluster/afr/src/afr-dir-read.c
@@ -226,7 +226,7 @@ afr_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         return 0;
     }
 
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         afr_readdir_transform_entries(subvol_entries, (long)cookie, &entries,
                                       local->fd);
 

--- a/xlators/cluster/afr/src/afr-dir-write.c
+++ b/xlators/cluster/afr/src/afr-dir-write.c
@@ -86,7 +86,7 @@ __afr_dir_write_finalize(call_frame_t *frame, xlator_t *this)
     for (i = 0; i < priv->child_count; i++) {
         if (!local->replies[i].valid)
             continue;
-        if (local->replies[i].op_ret == -1)
+        if (IS_ERROR(local->replies[i].op_ret))
             continue;
         gf_uuid_copy(args.gfid, local->replies[i].poststat.ia_gfid);
         args.ia_type = local->replies[i].poststat.ia_type;
@@ -117,7 +117,7 @@ __afr_dir_write_finalize(call_frame_t *frame, xlator_t *this)
     for (i = 0; i < priv->child_count; i++) {
         if (!local->replies[i].valid)
             continue;
-        if (local->replies[i].op_ret < 0) {
+        if (IS_ERROR(local->replies[i].op_ret)) {
             if (local->inode)
                 afr_inode_need_refresh_set(local->inode, this);
             if (local->parent)
@@ -127,7 +127,7 @@ __afr_dir_write_finalize(call_frame_t *frame, xlator_t *this)
             continue;
         }
 
-        if (local->op_ret == -1) {
+        if (IS_ERROR(local->op_ret)) {
             local->op_ret = local->replies[i].op_ret;
             local->op_errno = local->replies[i].op_errno;
 
@@ -349,7 +349,7 @@ afr_mark_entry_pending_changelog(call_frame_t *frame, xlator_t *this)
     local = frame->local;
     priv = this->private;
 
-    if (local->op_ret < 0)
+    if (IS_ERROR(local->op_ret))
         return;
 
     if (local->op != GF_FOP_CREATE && local->op != GF_FOP_MKNOD &&
@@ -474,7 +474,7 @@ afr_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     local->transaction.main_frame = frame;
     local->transaction.basename = AFR_BASENAME(loc->path);
     ret = afr_transaction(transaction_frame, this, AFR_ENTRY_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -583,7 +583,7 @@ afr_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     local->transaction.main_frame = frame;
     local->transaction.basename = AFR_BASENAME(loc->path);
     ret = afr_transaction(transaction_frame, this, AFR_ENTRY_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -697,7 +697,7 @@ afr_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     local->transaction.main_frame = frame;
     local->transaction.basename = AFR_BASENAME(loc->path);
     ret = afr_transaction(transaction_frame, this, AFR_ENTRY_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -804,7 +804,7 @@ afr_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     local->transaction.main_frame = frame;
     local->transaction.basename = AFR_BASENAME(newloc->path);
     ret = afr_transaction(transaction_frame, this, AFR_ENTRY_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -911,7 +911,7 @@ afr_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
     local->transaction.main_frame = frame;
     local->transaction.basename = AFR_BASENAME(loc->path);
     ret = afr_transaction(transaction_frame, this, AFR_ENTRY_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -1030,7 +1030,7 @@ afr_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     local->transaction.new_basename = AFR_BASENAME(newloc->path);
     ret = afr_transaction(transaction_frame, this,
                           AFR_ENTRY_RENAME_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -1134,7 +1134,7 @@ afr_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     local->transaction.main_frame = frame;
     local->transaction.basename = AFR_BASENAME(loc->path);
     ret = afr_transaction(transaction_frame, this, AFR_ENTRY_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -1237,7 +1237,7 @@ afr_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
     local->transaction.main_frame = frame;
     local->transaction.basename = AFR_BASENAME(loc->path);
     ret = afr_transaction(transaction_frame, this, AFR_ENTRY_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }

--- a/xlators/cluster/afr/src/afr-dir-write.c
+++ b/xlators/cluster/afr/src/afr-dir-write.c
@@ -186,7 +186,7 @@ __afr_dir_write_fill(call_frame_t *frame, xlator_t *this, int child_index,
     if (xdata)
         local->replies[child_index].xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         if (poststat)
             local->replies[child_index].poststat = *poststat;
         if (preparent)

--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -68,7 +68,7 @@ afr_handle_quota_size(call_frame_t *frame, xlator_t *this)
     readable_cnt = AFR_COUNT(readable, priv->child_count);
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         if (readable_cnt && !readable[i])
             continue;
@@ -76,9 +76,9 @@ afr_handle_quota_size(call_frame_t *frame, xlator_t *this)
             continue;
         ret = quota_dict_get_meta(replies[i].xdata, QUOTA_SIZE_KEY,
                                   SLEN(QUOTA_SIZE_KEY), &size);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             continue;
-        if (read_subvol == -1)
+        if (IS_ERROR(read_subvol))
             read_subvol = i;
         if (size.size > max_size.size ||
             (size.file_count + size.dir_count) >
@@ -98,7 +98,7 @@ afr_handle_quota_size(call_frame_t *frame, xlator_t *this)
         return read_subvol;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         if (readable_cnt && !readable[i])
             continue;
@@ -121,7 +121,7 @@ afr_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
 
@@ -143,7 +143,7 @@ afr_access_wind(call_frame_t *frame, xlator_t *this, int subvol)
     priv = this->private;
     local = frame->local;
 
-    if (subvol == -1) {
+    if (IS_ERROR(subvol)) {
         AFR_STACK_UNWIND(access, frame, local->op_ret, local->op_errno, 0);
         return 0;
     }
@@ -194,7 +194,7 @@ afr_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
 
@@ -216,7 +216,7 @@ afr_stat_wind(call_frame_t *frame, xlator_t *this, int subvol)
     priv = this->private;
     local = frame->local;
 
-    if (subvol == -1) {
+    if (IS_ERROR(subvol)) {
         AFR_STACK_UNWIND(stat, frame, local->op_ret, local->op_errno, 0, 0);
         return 0;
     }
@@ -263,7 +263,7 @@ afr_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
 
@@ -285,7 +285,7 @@ afr_fstat_wind(call_frame_t *frame, xlator_t *this, int subvol)
     priv = this->private;
     local = frame->local;
 
-    if (subvol == -1) {
+    if (IS_ERROR(subvol)) {
         AFR_STACK_UNWIND(fstat, frame, local->op_ret, local->op_errno, 0, 0);
         return 0;
     }
@@ -336,7 +336,7 @@ afr_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = -1;
         local->op_errno = op_errno;
 
@@ -357,7 +357,7 @@ afr_readlink_wind(call_frame_t *frame, xlator_t *this, int subvol)
     local = frame->local;
     priv = this->private;
 
-    if (subvol == -1) {
+    if (IS_ERROR(subvol)) {
         AFR_STACK_UNWIND(readlink, frame, local->op_ret, local->op_errno, 0, 0,
                          0);
         return 0;
@@ -465,7 +465,7 @@ afr_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0 && !afr_getxattr_ignorable_errnos(op_errno)) {
+    if (IS_ERROR(op_ret) && !afr_getxattr_ignorable_errnos(op_errno)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
 
@@ -490,7 +490,7 @@ afr_getxattr_wind(call_frame_t *frame, xlator_t *this, int subvol)
     local = frame->local;
     priv = this->private;
 
-    if (subvol == -1) {
+    if (IS_ERROR(subvol)) {
         AFR_STACK_UNWIND(getxattr, frame, local->op_ret, local->op_errno, NULL,
                          NULL);
         return 0;
@@ -543,7 +543,7 @@ afr_fgetxattr_clrlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     LOCK(&frame->lock);
     {
         callcnt = --local->call_count;
-        if (op_ret == -1)
+        if (IS_ERROR(op_ret))
             local->replies[cky].op_errno = op_errno;
 
         if (!local->dict)
@@ -576,7 +576,7 @@ unlock:
             op_errno = ENOMEM;
             goto unwind;
         }
-        if (serz_len == -1)
+        if (IS_ERROR(serz_len))
             snprintf(lk_summary, sizeof(lk_summary), "No locks cleared.");
         ret = dict_set_dynstrn(xattr, local->cont.getxattr.name, keylen,
                                gf_strdup(lk_summary));
@@ -631,7 +631,7 @@ afr_getxattr_clrlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     LOCK(&frame->lock);
     {
         callcnt = --local->call_count;
-        if (op_ret == -1)
+        if (IS_ERROR(op_ret))
             local->replies[cky].op_errno = op_errno;
 
         if (!local->dict)
@@ -664,7 +664,7 @@ unlock:
             op_errno = ENOMEM;
             goto unwind;
         }
-        if (serz_len == -1)
+        if (IS_ERROR(serz_len))
             snprintf(lk_summary, sizeof(lk_summary), "No locks cleared.");
         ret = dict_set_dynstrn(xattr, local->cont.getxattr.name, keylen,
                                gf_strdup(lk_summary));
@@ -707,7 +707,7 @@ afr_getxattr_node_uuid_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret == -1) { /** query the _next_ child */
+    if (IS_ERROR(op_ret)) { /** query the _next_ child */
 
         /**
          * _current_ becomes _next_
@@ -763,7 +763,7 @@ afr_getxattr_list_node_uuids_cbk(call_frame_t *frame, void *cookie,
         local->replies[cky].op_ret = op_ret;
         local->replies[cky].op_errno = op_errno;
 
-        if (op_ret < 0)
+        if (IS_ERROR(op_ret))
             goto unlock;
 
         local->op_ret = 0;
@@ -882,7 +882,7 @@ afr_getxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         call_cnt = --local->call_count;
 
-        if ((op_ret < 0) || (!dict && !xdata)) {
+        if (IS_ERROR(op_ret) || (!dict && !xdata)) {
             goto unlock;
         }
 
@@ -955,7 +955,7 @@ unlock:
 
         op_ret = dict_set_dynptr(newdict, GF_XATTR_LOCKINFO_KEY,
                                  (void *)lockinfo_buf, len);
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             local->op_ret = -1;
             local->op_errno = -op_ret;
             goto unwind;
@@ -987,7 +987,7 @@ afr_fgetxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         call_cnt = --local->call_count;
 
-        if ((op_ret < 0) || (!dict && !xdata)) {
+        if (IS_ERROR(op_ret) || (!dict && !xdata)) {
             goto unlock;
         }
 
@@ -1060,7 +1060,7 @@ unlock:
 
         op_ret = dict_set_dynptr(newdict, GF_XATTR_LOCKINFO_KEY,
                                  (void *)lockinfo_buf, len);
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             local->op_ret = -1;
             local->op_errno = -op_ret;
             goto unwind;
@@ -1110,7 +1110,7 @@ afr_fgetxattr_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     {
         callcnt = --local->call_count;
 
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
         } else {
             local->op_ret = op_ret;
@@ -1118,7 +1118,7 @@ afr_fgetxattr_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 local->xdata_rsp = dict_ref(xdata);
         }
 
-        if (!dict || (op_ret < 0))
+        if (!dict || IS_ERROR(op_ret))
             goto unlock;
 
         if (!local->dict) {
@@ -1234,7 +1234,7 @@ afr_getxattr_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     {
         callcnt = --local->call_count;
 
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
         } else {
             local->op_ret = op_ret;
@@ -1242,7 +1242,7 @@ afr_getxattr_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 local->xdata_rsp = dict_ref(xdata);
         }
 
-        if (!dict || (op_ret < 0))
+        if (!dict || IS_ERROR(op_ret))
             goto unlock;
 
         if (!local->dict) {
@@ -1354,7 +1354,7 @@ afr_common_getxattr_stime_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     {
         callcnt = --local->call_count;
 
-        if (!dict || (op_ret < 0)) {
+        if (!dict || IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             goto cleanup;
         }
@@ -1607,7 +1607,7 @@ no_name:
 
     ret = 0;
 out:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         AFR_STACK_UNWIND(getxattr, frame, -1, op_errno, NULL, NULL);
     return 0;
 }
@@ -1622,7 +1622,7 @@ afr_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = -1;
         local->op_errno = op_errno;
 
@@ -1647,7 +1647,7 @@ afr_fgetxattr_wind(call_frame_t *frame, xlator_t *this, int subvol)
     local = frame->local;
     priv = this->private;
 
-    if (subvol == -1) {
+    if (IS_ERROR(subvol)) {
         AFR_STACK_UNWIND(fgetxattr, frame, local->op_ret, local->op_errno, NULL,
                          NULL);
         return 0;
@@ -1751,7 +1751,7 @@ afr_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = -1;
         local->op_errno = op_errno;
 
@@ -1773,7 +1773,7 @@ afr_readv_wind(call_frame_t *frame, xlator_t *this, int subvol)
     local = frame->local;
     priv = this->private;
 
-    if (subvol == -1) {
+    if (IS_ERROR(subvol)) {
         AFR_STACK_UNWIND(readv, frame, local->op_ret, local->op_errno, 0, 0, 0,
                          0, 0);
         return 0;
@@ -1829,7 +1829,7 @@ afr_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = -1;
         local->op_errno = op_errno;
 
@@ -1850,7 +1850,7 @@ afr_seek_wind(call_frame_t *frame, xlator_t *this, int subvol)
     local = frame->local;
     priv = this->private;
 
-    if (subvol == -1) {
+    if (IS_ERROR(subvol)) {
         AFR_STACK_UNWIND(seek, frame, local->op_ret, local->op_errno, 0, NULL);
         return 0;
     }

--- a/xlators/cluster/afr/src/afr-inode-write.c
+++ b/xlators/cluster/afr/src/afr-inode-write.c
@@ -143,7 +143,7 @@ __afr_inode_write_fill(call_frame_t *frame, xlator_t *this, int child_index,
     if (xdata)
         local->replies[child_index].xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         if (prebuf)
             local->replies[child_index].prestat = *prebuf;
         if (postbuf)

--- a/xlators/cluster/afr/src/afr-inode-write.c
+++ b/xlators/cluster/afr/src/afr-inode-write.c
@@ -50,7 +50,7 @@ __afr_inode_write_finalize(call_frame_t *frame, xlator_t *this)
         for (i = 0; i < priv->child_count; i++) {
             if (!local->replies[i].valid)
                 continue;
-            if (local->replies[i].op_ret == -1)
+            if (IS_ERROR(local->replies[i].op_ret))
                 continue;
             if (!gf_uuid_is_null(local->replies[i].poststat.ia_gfid)) {
                 gf_uuid_copy(args.gfid, local->replies[i].poststat.ia_gfid);
@@ -84,7 +84,7 @@ __afr_inode_write_finalize(call_frame_t *frame, xlator_t *this)
     for (i = 0; i < priv->child_count; i++) {
         if (!local->replies[i].valid)
             continue;
-        if (local->replies[i].op_ret < 0)
+        if (IS_ERROR(local->replies[i].op_ret))
             continue;
 
         /* Order of checks in the compound conditional
@@ -260,7 +260,7 @@ afr_writev_handle_short_writes(call_frame_t *frame, xlator_t *this)
      * already been marked as failed.
      */
     for (i = 0; i < priv->child_count; i++) {
-        if ((!local->replies[i].valid) || (local->replies[i].op_ret == -1))
+        if ((!local->replies[i].valid) || IS_ERROR(local->replies[i].op_ret))
             continue;
 
         if (local->replies[i].op_ret < local->op_ret)
@@ -283,7 +283,7 @@ afr_inode_write_fill(call_frame_t *frame, xlator_t *this, int child_index,
     {
         __afr_inode_write_fill(frame, this, child_index, op_ret, op_errno,
                                prebuf, postbuf, NULL, xdata);
-        if (op_ret == -1 || !xdata)
+        if (IS_ERROR(op_ret) || !xdata)
             goto unlock;
 
         write_is_append = 0;
@@ -293,7 +293,7 @@ afr_inode_write_fill(call_frame_t *frame, xlator_t *this, int child_index,
             local->append_write = _gf_false;
 
         ret = dict_get_uint32(xdata, GLUSTERFS_ACTIVE_FD_COUNT, &open_fd_count);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto unlock;
         if (open_fd_count > local->open_fd_count) {
             local->open_fd_count = open_fd_count;
@@ -302,7 +302,7 @@ afr_inode_write_fill(call_frame_t *frame, xlator_t *this, int child_index,
 
         ret = dict_get_int32_sizen(xdata, GLUSTERFS_INODELK_COUNT,
                                    &num_inodelks);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto unlock;
         if (num_inodelks > local->num_inodelks) {
             local->num_inodelks = num_inodelks;
@@ -468,7 +468,7 @@ afr_do_writev(call_frame_t *frame, xlator_t *this)
     }
 
     ret = afr_transaction(transaction_frame, this, AFR_DATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -654,7 +654,7 @@ afr_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     local->stable_write = _gf_true;
 
     ret = afr_transaction(transaction_frame, this, AFR_DATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -771,7 +771,7 @@ afr_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     local->stable_write = _gf_true;
 
     ret = afr_transaction(transaction_frame, this, AFR_DATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -873,7 +873,7 @@ afr_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc, struct iatt *buf,
     local->transaction.len = 0;
 
     ret = afr_transaction(transaction_frame, this, AFR_METADATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -978,7 +978,7 @@ afr_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iatt *buf,
     local->transaction.len = 0;
 
     ret = afr_transaction(transaction_frame, this, AFR_METADATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -1144,7 +1144,7 @@ _afr_handle_empty_brick_type(xlator_t *this, call_frame_t *frame, loc_t *loc,
         goto out;
 
     ret = afr_set_pending_dict(priv, local->xattr_req, local->pending);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (AFR_ENTRY_TRANSACTION == type) {
@@ -1316,7 +1316,7 @@ afr_split_brain_resolve_do(call_frame_t *frame, xlator_t *this, loc_t *loc,
     afr_heal_splitbrain_file(frame, this, loc);
     ret = 0;
 out:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         AFR_STACK_UNWIND(setxattr, frame, -1, op_errno, NULL);
     return 0;
 }
@@ -1334,7 +1334,7 @@ afr_get_split_brain_child_index(xlator_t *this, void *value, size_t len)
         return -2;
 
     spb_child_index = afr_get_child_index_from_name(this, spb_child_str);
-    if (spb_child_index < 0) {
+    if (IS_ERROR(spb_child_index)) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, AFR_MSG_INVALID_SUBVOL,
                 "subvol=%s", spb_child_str, NULL);
     }
@@ -1399,7 +1399,7 @@ afr_handle_split_brain_commands(xlator_t *this, call_frame_t *frame, loc_t *loc,
     if (choice_value) {
         spb_child_index = afr_get_split_brain_child_index(this, choice_value,
                                                           len);
-        if (spb_child_index < 0) {
+        if (IS_ERROR(spb_child_index)) {
             /* Case where value was "none" */
             if (spb_child_index == -2)
                 spb_child_index = -1;
@@ -1435,7 +1435,7 @@ afr_handle_split_brain_commands(xlator_t *this, call_frame_t *frame, loc_t *loc,
     if (resolve_value) {
         spb_child_index = afr_get_split_brain_child_index(this, resolve_value,
                                                           len);
-        if (spb_child_index < 0) {
+        if (IS_ERROR(spb_child_index)) {
             ret = 1;
             goto out;
         }
@@ -1505,7 +1505,7 @@ afr_handle_empty_brick(xlator_t *this, call_frame_t *frame, loc_t *loc,
     }
     empty_index = afr_get_child_index_from_name(this, empty_brick);
 
-    if (empty_index < 0) {
+    if (IS_ERROR(empty_index)) {
         /* Didn't belong to this replica pair
          * Just do a no-op
          */
@@ -1612,7 +1612,7 @@ afr_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
     local->op = GF_FOP_SETXATTR;
 
     ret = afr_transaction(transaction_frame, this, AFR_METADATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -1719,7 +1719,7 @@ afr_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
     local->transaction.len = 0;
 
     ret = afr_transaction(transaction_frame, this, AFR_METADATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -1824,7 +1824,7 @@ afr_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     local->transaction.len = 0;
 
     ret = afr_transaction(transaction_frame, this, AFR_METADATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -1926,7 +1926,7 @@ afr_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     local->transaction.len = 0;
 
     ret = afr_transaction(transaction_frame, this, AFR_METADATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -2033,7 +2033,7 @@ afr_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
     afr_fix_open(fd, this);
 
     ret = afr_transaction(transaction_frame, this, AFR_DATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -2142,7 +2142,7 @@ afr_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     afr_fix_open(fd, this);
 
     ret = afr_transaction(transaction_frame, this, AFR_DATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -2249,7 +2249,7 @@ afr_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     afr_fix_open(fd, this);
 
     ret = afr_transaction(transaction_frame, this, AFR_DATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -2345,7 +2345,7 @@ afr_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc,
     local->transaction.len = 0;
 
     ret = afr_transaction(transaction_frame, this, AFR_METADATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -2440,7 +2440,7 @@ afr_fxattrop(call_frame_t *frame, xlator_t *this, fd_t *fd,
     local->transaction.len = 0;
 
     ret = afr_transaction(transaction_frame, this, AFR_METADATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }
@@ -2542,7 +2542,7 @@ afr_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t datasync,
     local->transaction.main_frame = frame;
 
     ret = afr_transaction(transaction_frame, this, AFR_DATA_TRANSACTION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto out;
     }

--- a/xlators/cluster/afr/src/afr-lk-common.c
+++ b/xlators/cluster/afr/src/afr-lk-common.c
@@ -286,7 +286,7 @@ afr_unlock_common_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     lockee_num = (int)((long)cookie) / priv->child_count;
     child_index = (int)((long)cookie) % priv->child_count;
 
-    if (op_ret < 0 && op_errno != ENOTCONN && op_errno != EBADFD) {
+    if (IS_ERROR(op_ret) && op_errno != ENOTCONN && op_errno != EBADFD) {
         afr_log_locks_failure(frame, priv->children[child_index]->name,
                               "unlock", op_errno);
     }
@@ -439,7 +439,7 @@ afr_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             if (op_errno == ENOSYS) {
                 /* return ENOTSUP */
                 gf_msg(this->name, GF_LOG_ERROR, ENOSYS,
@@ -458,7 +458,7 @@ afr_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     }
     UNLOCK(&frame->lock);
 
-    if ((op_ret == -1) && (op_errno == ENOSYS)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOSYS)) {
         afr_unlock_now(frame, this);
     } else {
         if (op_ret == 0) {
@@ -548,7 +548,7 @@ afr_lock_blocking(call_frame_t *frame, xlator_t *this, int cookie)
     if (local->fd) {
         ret = fd_ctx_get(local->fd, this, &ctx);
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_INFO, 0, AFR_MSG_FD_CTX_GET_FAILED,
                    "unable to get fd ctx for fd=%p", local->fd);
 
@@ -644,7 +644,7 @@ afr_nb_internal_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     LOCK(&frame->lock);
     {
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             if (op_errno == ENOSYS) {
                 /* return ENOTSUP */
                 gf_msg(this->name, GF_LOG_ERROR, ENOSYS,

--- a/xlators/cluster/afr/src/afr-open.c
+++ b/xlators/cluster/afr/src/afr-open.c
@@ -69,7 +69,7 @@ afr_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             fd_ctx->opened_on[child_index] = AFR_FD_NOT_OPENED;
         } else {
@@ -84,7 +84,7 @@ afr_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     if (call_count == 0) {
         afr_handle_replies_quorum(frame, this);
-        if (local->op_ret == -1) {
+        if (IS_ERROR(local->op_ret)) {
             AFR_STACK_UNWIND(open, frame, local->op_ret, local->op_errno, NULL,
                              NULL);
         } else if (fd_ctx->flags & O_TRUNC) {
@@ -178,10 +178,10 @@ afr_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
     ret = afr_inode_get_readable(frame, local->inode, this, NULL,
                                  &event_generation, AFR_DATA_TRANSACTION);
-    if ((ret < 0) &&
+    if (IS_ERROR(ret) &&
         (afr_inode_split_brain_choice_get(local->inode, this, &spb_choice) ==
          0) &&
-        spb_choice < 0) {
+        IS_ERROR(spb_choice)) {
         afr_inode_refresh(frame, this, local->inode, local->inode->gfid,
                           afr_open_continue);
     } else {
@@ -309,7 +309,7 @@ afr_fix_open(fd_t *fd, xlator_t *this)
 
     local->loc.inode = inode_ref(fd->inode);
     ret = loc_path(&local->loc, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     local->fd = fd_ref(fd);

--- a/xlators/cluster/afr/src/afr-open.c
+++ b/xlators/cluster/afr/src/afr-open.c
@@ -209,7 +209,7 @@ afr_openfd_fix_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_msg_debug(this->name, 0,
                      "fd for %s opened "
                      "successfully on subvolume %s",
@@ -224,7 +224,7 @@ afr_openfd_fix_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     LOCK(&local->fd->lock);
     {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             fd_ctx->opened_on[child_index] = AFR_FD_OPENED;
         } else {
             fd_ctx->opened_on[child_index] = AFR_FD_NOT_OPENED;

--- a/xlators/cluster/afr/src/afr-read-txn.c
+++ b/xlators/cluster/afr/src/afr-read-txn.c
@@ -304,7 +304,7 @@ afr_read_txn_refresh_done(call_frame_t *frame, xlator_t *this, int err)
 readfn:
     if (IS_ERROR(read_subvol)) {
         ret = afr_inode_split_brain_choice_get(inode, this, &spb_choice);
-        if (IS_SUCCESS((ret == 0) && spb_choice))
+        if ((ret == 0) && IS_SUCCESS(spb_choice))
             read_subvol = spb_choice;
     }
 

--- a/xlators/cluster/afr/src/afr-read-txn.c
+++ b/xlators/cluster/afr/src/afr-read-txn.c
@@ -304,7 +304,7 @@ afr_read_txn_refresh_done(call_frame_t *frame, xlator_t *this, int err)
 readfn:
     if (IS_ERROR(read_subvol)) {
         ret = afr_inode_split_brain_choice_get(inode, this, &spb_choice);
-        if ((ret == 0) && spb_choice >= 0)
+        if (IS_SUCCESS((ret == 0) && spb_choice))
             read_subvol = spb_choice;
     }
 

--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -37,7 +37,7 @@ afr_lookup_and_heal_gfid(xlator_t *this, inode_t *parent, const char *name,
 
     priv = this->private;
     wind_on = alloca0(priv->child_count);
-    if (source >= 0 && replies[source].valid && replies[source].op_ret == 0)
+    if (IS_SUCCESS(source) && replies[source].valid && replies[source].op_ret == 0)
         ia_type = replies[source].poststat.ia_type;
 
     if (ia_type != IA_INVAL)
@@ -1229,25 +1229,25 @@ afr_sh_get_fav_by_policy(xlator_t *this, struct afr_reply *replies,
     switch (priv->fav_child_policy) {
         case AFR_FAV_CHILD_BY_SIZE:
             fav_child = afr_sh_fav_by_size(this, replies, inode);
-            if (policy_str && fav_child >= 0) {
+            if (IS_SUCCESS(policy_str && fav_child)) {
                 *policy_str = "SIZE";
             }
             break;
         case AFR_FAV_CHILD_BY_CTIME:
             fav_child = afr_sh_fav_by_ctime(this, replies, inode);
-            if (policy_str && fav_child >= 0) {
+            if (IS_SUCCESS(policy_str && fav_child)) {
                 *policy_str = "CTIME";
             }
             break;
         case AFR_FAV_CHILD_BY_MTIME:
             fav_child = afr_sh_fav_by_mtime(this, replies, inode);
-            if (policy_str && fav_child >= 0) {
+            if (IS_SUCCESS(policy_str && fav_child)) {
                 *policy_str = "MTIME";
             }
             break;
         case AFR_FAV_CHILD_BY_MAJORITY:
             fav_child = afr_sh_fav_by_majority(this, replies, inode);
-            if (policy_str && fav_child >= 0) {
+            if (IS_SUCCESS(policy_str && fav_child)) {
                 *policy_str = "MAJORITY";
             }
             break;
@@ -1284,7 +1284,7 @@ afr_mark_split_brain_source_sinks_by_policy(
                "Invalid child (%d) "
                "selected by policy %s.",
                fav_child, policy_str);
-    } else if (fav_child >= 0) {
+    } else if (IS_SUCCESS(fav_child)) {
         time = replies[fav_child].poststat.ia_mtime;
         tm_ptr = localtime(&time);
         strftime(mtime_str, sizeof(mtime_str), "%Y-%m-%d %H:%M:%S", tm_ptr);
@@ -1407,7 +1407,7 @@ afr_mark_split_brain_source_sinks(
 
     source = afr_mark_source_sinks_if_file_empty(
         this, sources, sinks, healed_sinks, locked_on, replies, type);
-    if (source >= 0)
+    if (IS_SUCCESS(source))
         return source;
 
     ret = dict_get_int32_sizen(xdata_req, "heal-op", &heal_op);
@@ -2627,7 +2627,7 @@ __afr_dequeue_heals(afr_private_t *priv)
 
     local = list_entry(priv->heal_waiting.next, afr_local_t, healer);
     priv->heal_waiters--;
-    GF_ASSERT(priv->heal_waiters >= 0);
+    GF_ASSERT(IS_SUCCESS(priv->heal_waiters));
     list_del_init(&local->healer);
     list_add(&local->healer, &priv->healing);
     priv->healers++;
@@ -2663,7 +2663,7 @@ afr_refresh_heal_done(int ret, call_frame_t *frame, void *opaque)
     {
         list_del_init(&local->healer);
         priv->healers--;
-        GF_ASSERT(priv->healers >= 0);
+        GF_ASSERT(IS_SUCCESS(priv->healers));
         local = __afr_dequeue_heals(priv);
     }
     UNLOCK(&priv->lock);

--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -53,7 +53,7 @@ afr_lookup_and_heal_gfid(xlator_t *this, inode_t *parent, const char *name,
      * ia_type.
      * */
     for (i = 0; i < priv->child_count; i++) {
-        if (source == -1) {
+        if (IS_ERROR(source)) {
             /* case (a) above. */
             if (replies[i].valid && replies[i].op_ret == 0 &&
                 replies[i].poststat.ia_type != IA_INVAL) {
@@ -127,7 +127,7 @@ heal:
         afr_reply_wipe(&replies[i]);
         afr_reply_copy(&replies[i], &local->replies[i]);
     }
-    if (gfid_idx && (*gfid_idx == -1)) {
+    if (gfid_idx && IS_ERROR(*gfid_idx)) {
         /*Pick a brick where the gifd heal was successful.*/
         for (i = 0; i < priv->child_count; i++) {
             if (!wind_on[i])
@@ -140,7 +140,7 @@ heal:
         }
     }
 out:
-    if (gfid_idx && (*gfid_idx == -1) && (ret == 0)) {
+    if (gfid_idx && IS_ERROR(*gfid_idx) && (ret == 0)) {
         ret = -afr_final_errno(local, priv);
     }
     loc_wipe(&loc);
@@ -161,7 +161,7 @@ afr_gfid_sbrain_source_from_src_brick(xlator_t *this, struct afr_reply *replies,
 
     priv = this->private;
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         if (strcmp(priv->children[i]->name, src_brick) == 0)
             return i;
@@ -178,7 +178,7 @@ afr_selfheal_gfid_mismatch_by_majority(struct afr_reply *replies,
     int votes;
 
     for (i = 0; i < child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
 
         votes = 1;
@@ -203,7 +203,7 @@ afr_gfid_sbrain_source_from_bigger_file(struct afr_reply *replies,
     uint64_t size = 0;
 
     for (i = 0; i < child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         if (size < replies[i].poststat.ia_size) {
             src = i;
@@ -289,7 +289,7 @@ afr_gfid_split_brain_source(xlator_t *this, struct afr_reply *replies,
         case GF_SHD_OP_SBRAIN_HEAL_FROM_BIGGER_FILE:
             *src = afr_gfid_sbrain_source_from_bigger_file(replies,
                                                            priv->child_count);
-            if (*src == -1) {
+            if (IS_ERROR(*src)) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN,
                        SNO_BIGGER_FILE);
                 if (xdata) {
@@ -307,7 +307,7 @@ afr_gfid_split_brain_source(xlator_t *this, struct afr_reply *replies,
         case GF_SHD_OP_SBRAIN_HEAL_FROM_LATEST_MTIME:
             *src = afr_gfid_sbrain_source_from_latest_mtime(replies,
                                                             priv->child_count);
-            if (*src == -1) {
+            if (IS_ERROR(*src)) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN,
                        SNO_DIFF_IN_MTIME);
                 if (xdata) {
@@ -332,7 +332,7 @@ afr_gfid_split_brain_source(xlator_t *this, struct afr_reply *replies,
             }
             *src = afr_gfid_sbrain_source_from_src_brick(this, replies,
                                                          src_brick);
-            if (*src == -1) {
+            if (IS_ERROR(*src)) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN,
                        SERROR_GETTING_SRC_BRICK);
                 if (xdata) {
@@ -370,7 +370,7 @@ fav_child:
             else
                 *src = -1;
 
-            if (*src == -1) {
+            if (IS_ERROR(*src)) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN,
                        "No majority to resolve "
                        "gfid split brain");
@@ -381,7 +381,7 @@ fav_child:
     }
 
 out:
-    if (*src == -1) {
+    if (IS_ERROR(*src)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN,
                "Gfid mismatch detected for <gfid:%s>/%s>, %s on %s and"
                " %s on %s.",
@@ -444,7 +444,7 @@ afr_selfheal_post_op(call_frame_t *frame, xlator_t *this, inode_t *inode,
                GF_XATTROP_ADD_ARRAY, xattr, xdata);
 
     syncbarrier_wait(&local->barrier, 1);
-    if (local->op_ret < 0)
+    if (IS_ERROR(local->op_ret))
         ret = -local->op_errno;
 
     loc_wipe(&loc);
@@ -1023,7 +1023,7 @@ afr_mark_split_brain_source_sinks_by_heal_op(
             if (ret)
                 goto out;
             source = afr_get_child_index_from_name(this, name);
-            if (source < 0) {
+            if (IS_ERROR(source)) {
                 ret = dict_set_sizen_str_sizen(xdata_rsp, "sh-fail-msg",
                                                SINVALID_BRICK_NAME);
                 if (!ret)
@@ -1054,7 +1054,7 @@ afr_mark_split_brain_source_sinks_by_heal_op(
     healed_sinks[source] = 0;
     ret = source;
 out:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         memset(sources, 0, sizeof(*sources) * priv->child_count);
     return ret;
 }
@@ -1207,7 +1207,7 @@ afr_sh_fav_by_size(xlator_t *this, struct afr_reply *replies, inode_t *inode)
             fav_child = -1;
         }
     }
-    if (fav_child == -1) {
+    if (IS_ERROR(fav_child)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SPLIT_BRAIN,
                "No bigger file");
     }
@@ -1276,7 +1276,7 @@ afr_mark_split_brain_source_sinks_by_policy(
     priv = this->private;
 
     fav_child = afr_sh_get_fav_by_policy(this, replies, inode, &policy_str);
-    if (fav_child == -1) {
+    if (IS_ERROR(fav_child)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_SBRAIN_FAV_CHILD_POLICY,
                "No child selected by favorite-child policy.");
     } else if (fav_child > priv->child_count - 1) {
@@ -1366,7 +1366,7 @@ mark:
     /* data/metadata is same on all bricks. Pick one of them as source. Rest
      * are sinks.*/
     for (i = 0; i < priv->child_count; i++) {
-        if (source == -1) {
+        if (IS_ERROR(source)) {
             source = i;
             sources[i] = 1;
             sinks[i] = 0;
@@ -1730,7 +1730,7 @@ afr_log_selfheal(uuid_t gfid, xlator_t *this, int ret, char *type, int source,
         }
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         status = "Failed";
         loglevel = GF_LOG_DEBUG;
     } else {
@@ -2026,7 +2026,7 @@ afr_selfheal_inodelk(call_frame_t *frame, xlator_t *this, inode_t *inode,
               NULL);
 
     for (i = 0; i < priv->child_count; i++) {
-        if (local->replies[i].op_ret == -1 &&
+        if (IS_ERROR(local->replies[i].op_ret) &&
             local->replies[i].op_errno == EAGAIN) {
             afr_locked_fill(frame, this, locked_on);
             afr_selfheal_uninodelk(frame, this, inode, dom, off, size,
@@ -2054,7 +2054,8 @@ afr_get_lock_and_eagain_counts(afr_private_t *priv, struct afr_reply *replies,
             continue;
         if (replies[i].op_ret == 0) {
             (*lock_count)++;
-        } else if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        } else if (IS_ERROR(replies[i].op_ret) &&
+                   replies[i].op_errno == EAGAIN) {
             (*eagain_count)++;
         }
     }
@@ -2174,7 +2175,7 @@ afr_selfheal_entrylk(call_frame_t *frame, xlator_t *this, inode_t *inode,
               ENTRYLK_LOCK_NB, ENTRYLK_WRLCK, NULL);
 
     for (i = 0; i < priv->child_count; i++) {
-        if (local->replies[i].op_ret == -1 &&
+        if (IS_ERROR(local->replies[i].op_ret) &&
             local->replies[i].op_errno == EAGAIN) {
             afr_locked_fill(frame, this, locked_on);
             afr_selfheal_unentrylk(frame, this, inode, dom, name, locked_on,
@@ -2309,7 +2310,7 @@ afr_selfheal_unlocked_inspect(call_frame_t *frame, xlator_t *this, uuid_t gfid,
     for (i = 0; i < priv->child_count; i++) {
         if (!replies[i].valid)
             continue;
-        if (replies[i].op_ret == -1)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         /* The data segment of the changelog can be non-zero to indicate
@@ -2570,7 +2571,7 @@ afr_selfheal_do(call_frame_t *frame, xlator_t *this, uuid_t gfid)
         ret = -EIO;
     else if (data_ret == 1 && metadata_ret == 1 && entry_ret == 1)
         ret = 1;
-    else if (or_ret < 0)
+    else if (IS_ERROR(or_ret))
         ret = or_ret;
     else
         ret = 0;
@@ -2683,7 +2684,7 @@ afr_heal_synctask(xlator_t *this, afr_local_t *local)
     heal_frame = local->heal_frame;
     ret = synctask_new(this->ctx->env, afr_refresh_selfheal_wrap,
                        afr_refresh_heal_done, heal_frame, heal_frame);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         /* Heal not launched. Will be queued when the next inode
          * refresh happens and shd hasn't healed it yet. */
         afr_refresh_heal_done(ret, heal_frame, heal_frame);

--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -1229,25 +1229,25 @@ afr_sh_get_fav_by_policy(xlator_t *this, struct afr_reply *replies,
     switch (priv->fav_child_policy) {
         case AFR_FAV_CHILD_BY_SIZE:
             fav_child = afr_sh_fav_by_size(this, replies, inode);
-            if (IS_SUCCESS(policy_str && fav_child)) {
+            if (policy_str && IS_SUCCESS(fav_child)) {
                 *policy_str = "SIZE";
             }
             break;
         case AFR_FAV_CHILD_BY_CTIME:
             fav_child = afr_sh_fav_by_ctime(this, replies, inode);
-            if (IS_SUCCESS(policy_str && fav_child)) {
+            if (policy_str && IS_SUCCESS(fav_child)) {
                 *policy_str = "CTIME";
             }
             break;
         case AFR_FAV_CHILD_BY_MTIME:
             fav_child = afr_sh_fav_by_mtime(this, replies, inode);
-            if (IS_SUCCESS(policy_str && fav_child)) {
+            if (policy_str && IS_SUCCESS(fav_child)) {
                 *policy_str = "MTIME";
             }
             break;
         case AFR_FAV_CHILD_BY_MAJORITY:
             fav_child = afr_sh_fav_by_majority(this, replies, inode);
-            if (IS_SUCCESS(policy_str && fav_child)) {
+            if (policy_str && IS_SUCCESS(fav_child)) {
                 *policy_str = "MAJORITY";
             }
             break;

--- a/xlators/cluster/afr/src/afr-self-heal-data.c
+++ b/xlators/cluster/afr/src/afr-self-heal-data.c
@@ -130,7 +130,7 @@ __afr_is_sink_zero_filled(xlator_t *this, fd_t *fd, size_t size, off_t offset,
     priv = this->private;
     ret = syncop_readv(priv->children[sink], fd, size, offset, 0, &iovec,
                        &count, &iobref, NULL, NULL, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
     ret = iov_0filled(iovec, count);
     if (!ret)
@@ -367,7 +367,7 @@ afr_selfheal_data_do(call_frame_t *frame, xlator_t *this, fd_t *fd, int source,
 
         ret = afr_selfheal_data_block(iter_frame, this, fd, source,
                                       healed_sinks, off, block, type, replies);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         AFR_STACK_RESET(iter_frame);
@@ -410,7 +410,7 @@ __afr_selfheal_truncate_sinks(call_frame_t *frame, xlator_t *this, fd_t *fd,
                NULL);
 
     for (i = 0; i < priv->child_count; i++)
-        if (healed_sinks[i] && local->replies[i].op_ret == -1)
+        if (healed_sinks[i] && IS_ERROR(local->replies[i].op_ret))
             /* truncate() failed. Do NOT consider this server
                as successfully healed. Mark it so.
             */
@@ -450,7 +450,7 @@ afr_does_size_mismatch(xlator_t *this, unsigned char *sources,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret < 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         if (!sources[i])
@@ -554,7 +554,7 @@ __afr_selfheal_data_finalize_source(
         source = afr_mark_split_brain_source_sinks(
             frame, this, inode, sources, sinks, healed_sinks, locked_on,
             replies, AFR_DATA_TRANSACTION);
-        if (source < 0) {
+        if (IS_ERROR(source)) {
             gf_event(EVENT_AFR_SPLIT_BRAIN,
                      "client-pid=%d;"
                      "subvol=%s;type=data;"
@@ -643,7 +643,7 @@ __afr_selfheal_data_prepare(call_frame_t *frame, xlator_t *this, inode_t *inode,
     source = __afr_selfheal_data_finalize_source(
         frame, this, inode, sources, sinks, healed_sinks, locked_on,
         undid_pending, replies, witness);
-    if (source < 0)
+    if (IS_ERROR(source))
         return -EIO;
 
     return source;
@@ -693,7 +693,7 @@ __afr_selfheal_data(call_frame_t *frame, xlator_t *this, fd_t *fd,
         ret = __afr_selfheal_data_prepare(frame, this, fd->inode, data_lock,
                                           sources, sinks, healed_sinks,
                                           undid_pending, locked_replies, NULL);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto unlock;
 
         if (AFR_COUNT(healed_sinks, priv->child_count) == 0) {
@@ -716,7 +716,7 @@ __afr_selfheal_data(call_frame_t *frame, xlator_t *this, fd_t *fd,
         ret = __afr_selfheal_truncate_sinks(
             frame, this, fd, healed_sinks,
             locked_replies[source].poststat.ia_size);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto unlock;
 
         if (priv->arbiter_count &&
@@ -729,7 +729,7 @@ __afr_selfheal_data(call_frame_t *frame, xlator_t *this, fd_t *fd,
     }
 unlock:
     afr_selfheal_uninodelk(frame, this, fd->inode, this->name, 0, 0, data_lock);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (!did_sh)
@@ -828,7 +828,7 @@ afr_selfheal_data_open(xlator_t *this, inode_t *inode, fd_t **fd)
         if (!local->replies[i].valid)
             continue;
 
-        if (local->replies[i].op_ret < 0) {
+        if (IS_ERROR(local->replies[i].op_ret)) {
             ret = -local->replies[i].op_errno;
             continue;
         }
@@ -837,7 +837,7 @@ afr_selfheal_data_open(xlator_t *this, inode_t *inode, fd_t **fd)
         break;
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         fd_unref(fd_tmp);
         goto out;
     } else {

--- a/xlators/cluster/afr/src/afr-self-heal-metadata.c
+++ b/xlators/cluster/afr/src/afr-self-heal-metadata.c
@@ -53,7 +53,7 @@ __afr_selfheal_metadata_do(call_frame_t *frame, xlator_t *this, inode_t *inode,
 
     ret = syncop_getxattr(priv->children[source], &loc, &xattr, NULL, NULL,
                           NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -EIO;
         goto out;
     }
@@ -153,7 +153,7 @@ afr_dirtime_splitbrain_source(call_frame_t *frame, xlator_t *this,
         source = i;
     }
 
-    if (source == -1)
+    if (IS_ERROR(source))
         goto out;
 
     source_ia = replies[source].poststat;
@@ -226,7 +226,7 @@ __afr_selfheal_metadata_mark_pending_xattrs(call_frame_t *frame, xlator_t *this,
         if (!sources[i])
             continue;
         ret = afr_selfheal_post_op(frame, this, inode, i, xattr, NULL);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_INFO, -ret, AFR_MSG_SELF_HEAL_INFO,
                    "Failed to set pending metadata xattr on child %d for %s", i,
                    uuid_utoa(inode->gfid));
@@ -358,7 +358,7 @@ __afr_selfheal_metadata_finalize_source(call_frame_t *frame, xlator_t *this,
         (AFR_COUNT(healed_sinks, priv->child_count) != 0)) {
         ret = __afr_selfheal_metadata_mark_pending_xattrs(frame, this, inode,
                                                           replies, sources);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             return ret;
     }
 out:
@@ -425,7 +425,7 @@ __afr_selfheal_metadata_prepare(call_frame_t *frame, xlator_t *this,
         frame, this, inode, sources, sinks, healed_sinks, undid_pending,
         locked_on, replies);
 
-    if (source < 0)
+    if (IS_ERROR(source))
         return -EIO;
 
     return source;
@@ -466,7 +466,7 @@ afr_selfheal_metadata(call_frame_t *frame, xlator_t *this, inode_t *inode)
         ret = __afr_selfheal_metadata_prepare(
             frame, this, inode, data_lock, sources, sinks, healed_sinks,
             undid_pending, locked_replies, NULL);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto unlock;
 
         source = ret;

--- a/xlators/cluster/afr/src/afr-self-heal-metadata.c
+++ b/xlators/cluster/afr/src/afr-self-heal-metadata.c
@@ -274,7 +274,7 @@ __afr_selfheal_metadata_finalize_source(call_frame_t *frame, xlator_t *this,
         source = afr_mark_split_brain_source_sinks(
             frame, this, inode, sources, sinks, healed_sinks, locked_on,
             replies, AFR_METADATA_TRANSACTION);
-        if (source >= 0) {
+        if (IS_SUCCESS(source)) {
             _afr_fav_child_reset_sink_xattrs(
                 frame, this, inode, source, healed_sinks, undid_pending,
                 AFR_METADATA_TRANSACTION, locked_on, replies);

--- a/xlators/cluster/afr/src/afr-self-heal-name.c
+++ b/xlators/cluster/afr/src/afr-self-heal-name.c
@@ -277,7 +277,7 @@ afr_selfheal_name_gfid_mismatch_check(xlator_t *this, struct afr_reply *replies,
                 ret = afr_gfid_split_brain_source(this, replies, inode, pargfid,
                                                   bname, gfid_idx_iter, i,
                                                   locked_on, gfid_idx, xdata);
-                if (!ret && *gfid_idx >= 0) {
+                if (IS_SUCCESS(!ret && *gfid_idx)) {
                     ret = dict_set_sizen_str_sizen(xdata, "gfid-heal-msg",
                                                    "GFID split-brain resolved");
                     if (ret)

--- a/xlators/cluster/afr/src/afr-self-heal-name.c
+++ b/xlators/cluster/afr/src/afr-self-heal-name.c
@@ -277,7 +277,7 @@ afr_selfheal_name_gfid_mismatch_check(xlator_t *this, struct afr_reply *replies,
                 ret = afr_gfid_split_brain_source(this, replies, inode, pargfid,
                                                   bname, gfid_idx_iter, i,
                                                   locked_on, gfid_idx, xdata);
-                if (IS_SUCCESS(!ret && *gfid_idx)) {
+                if (!ret && IS_SUCCESS(*gfid_idx)) {
                     ret = dict_set_sizen_str_sizen(xdata, "gfid-heal-msg",
                                                    "GFID split-brain resolved");
                     if (ret)

--- a/xlators/cluster/afr/src/afr-self-heal-name.c
+++ b/xlators/cluster/afr/src/afr-self-heal-name.c
@@ -161,10 +161,10 @@ afr_selfheal_name_need_heal_check(xlator_t *this, struct afr_reply *replies)
         if (!replies[i].valid)
             continue;
 
-        if ((replies[i].op_ret == -1) && (replies[i].op_errno == ENODATA))
+        if (IS_ERROR((replies[i].op_ret)) && (replies[i].op_errno == ENODATA))
             need_heal = _gf_true;
 
-        if (first_idx == -1) {
+        if (IS_ERROR(first_idx)) {
             first_idx = i;
             continue;
         }
@@ -210,8 +210,8 @@ afr_selfheal_name_type_mismatch_check(xlator_t *this, struct afr_reply *replies,
             continue;
         }
         inode_type1 = replies[i].poststat.ia_type;
-        if (sources[i] || source == -1) {
-            if ((sources[type_idx] || source == -1) &&
+        if (sources[i] || IS_ERROR(source)) {
+            if ((sources[type_idx] || IS_ERROR(source)) &&
                 (inode_type != inode_type1)) {
                 gf_msg(this->name, GF_LOG_WARNING, 0, AFR_MSG_SPLIT_BRAIN,
                        "Type mismatch for <gfid:%s>/%s: "
@@ -271,8 +271,8 @@ afr_selfheal_name_gfid_mismatch_check(xlator_t *this, struct afr_reply *replies,
         }
 
         gfid1 = &replies[i].poststat.ia_gfid;
-        if (sources[i] || source == -1) {
-            if ((sources[gfid_idx_iter] || source == -1) &&
+        if (sources[i] || IS_ERROR(source)) {
+            if ((sources[gfid_idx_iter] || IS_ERROR(source)) &&
                 gf_uuid_compare(gfid, gfid1)) {
                 ret = afr_gfid_split_brain_source(this, replies, inode, pargfid,
                                                   bname, gfid_idx_iter, i,
@@ -307,7 +307,7 @@ afr_selfheal_name_source_empty_check(xlator_t *this, struct afr_reply *replies,
 
     priv = this->private;
 
-    if (source == -1) {
+    if (IS_ERROR(source)) {
         source_is_empty = _gf_false;
         goto out;
     }
@@ -316,7 +316,7 @@ afr_selfheal_name_source_empty_check(xlator_t *this, struct afr_reply *replies,
         if (!sources[i])
             continue;
 
-        if (replies[i].op_ret == -1 && replies[i].op_errno == ENOENT)
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == ENOENT)
             continue;
 
         source_is_empty = _gf_false;
@@ -366,18 +366,18 @@ __afr_selfheal_name_do(call_frame_t *frame, xlator_t *this, inode_t *parent,
     if (ret)
         return ret;
 
-    if (gfid_idx == -1) {
+    if (IS_ERROR(gfid_idx)) {
         if (!gfid_req || gf_uuid_is_null(gfid_req))
             return -1;
         gfid = gfid_req;
     } else {
         gfid = &replies[gfid_idx].poststat.ia_gfid;
-        if (source == -1)
+        if (IS_ERROR(source))
             /* Either entry split-brain or dirty xattrs are present on parent.*/
             source = gfid_idx;
     }
 
-    is_gfid_absent = (gfid_idx == -1) ? _gf_true : _gf_false;
+    is_gfid_absent = (IS_ERROR(gfid_idx)) ? _gf_true : _gf_false;
     ret = __afr_selfheal_assign_gfid(this, parent, pargfid, bname, inode,
                                      replies, gfid, locked_on, source, sources,
                                      is_gfid_absent, &gfid_idx);
@@ -463,7 +463,7 @@ __afr_selfheal_name_prepare(call_frame_t *frame, xlator_t *this,
 
     source = __afr_selfheal_name_finalize_source(this, sources, healed_sinks,
                                                  locked_on, witness);
-    if (source < 0) {
+    if (IS_ERROR(source)) {
         /* If source is < 0 (typically split-brain), we perform a
            conservative merge of entries rather than erroring out */
     }
@@ -576,12 +576,12 @@ afr_selfheal_name_unlocked_inspect(call_frame_t *frame, xlator_t *this,
         if (!replies[i].valid)
             continue;
 
-        if ((replies[i].op_ret == -1) && (replies[i].op_errno == ENODATA)) {
+        if (IS_ERROR((replies[i].op_ret)) && (replies[i].op_errno == ENODATA)) {
             *need_heal = _gf_true;
             break;
         }
 
-        if (first_idx == -1) {
+        if (IS_ERROR(first_idx)) {
             first_idx = i;
             continue;
         }

--- a/xlators/cluster/afr/src/afr-transaction.c
+++ b/xlators/cluster/afr/src/afr-transaction.c
@@ -200,7 +200,7 @@ afr_pick_error_xdata(afr_local_t *local, afr_private_t *priv, inode_t *inode1,
         if (!local->replies[i].valid)
             continue;
 
-        if (local->replies[i].op_ret >= 0)
+        if (IS_SUCCESS(local->replies[i].op_ret))
             continue;
 
         if (local->replies[i].op_errno == ENOTCONN)
@@ -211,14 +211,14 @@ afr_pick_error_xdata(afr_local_t *local, afr_private_t *priv, inode_t *inode1,
             s = i;
     }
 
-    if ((s >= 0) && local->replies[s].xdata) {
+    if (IS_SUCCESS((s)) && local->replies[s].xdata) {
         local->xdata_rsp = dict_ref(local->replies[s].xdata);
     } else if (IS_ERROR(s)) {
         for (i = 0; i < priv->child_count; i++) {
             if (!local->replies[i].valid)
                 continue;
 
-            if (local->replies[i].op_ret >= 0)
+            if (IS_SUCCESS(local->replies[i].op_ret))
                 continue;
 
             if (!local->replies[i].xdata)

--- a/xlators/cluster/afr/src/afr-transaction.c
+++ b/xlators/cluster/afr/src/afr-transaction.c
@@ -207,13 +207,13 @@ afr_pick_error_xdata(afr_local_t *local, afr_private_t *priv, inode_t *inode1,
             continue;
 
         /*Order is important in the following condition*/
-        if ((s < 0) || (!readable[s] && readable[i]))
+        if (IS_ERROR(s) || (!readable[s] && readable[i]))
             s = i;
     }
 
-    if (s != -1 && local->replies[s].xdata) {
+    if ((s >= 0) && local->replies[s].xdata) {
         local->xdata_rsp = dict_ref(local->replies[s].xdata);
-    } else if (s == -1) {
+    } else if (IS_ERROR(s)) {
         for (i = 0; i < priv->child_count; i++) {
             if (!local->replies[i].valid)
                 continue;
@@ -997,7 +997,7 @@ afr_handle_quorum(call_frame_t *frame, xlator_t *this)
         return;
 
     /* If the fop already failed return right away to preserve errno */
-    if (local->op_ret == -1)
+    if (IS_ERROR(local->op_ret))
         return;
 
     /*
@@ -1219,7 +1219,7 @@ afr_set_changelog_xattr(afr_private_t *priv, unsigned char *pending,
                 changelog[i][idx] = hton32(1);
         }
         ret = afr_set_pending_dict(priv, xattr, changelog);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             afr_matrix_cleanup(changelog, priv->child_count);
             return NULL;
         }
@@ -1514,7 +1514,7 @@ afr_changelog_post_op_do(call_frame_t *frame, xlator_t *this)
     else
         need_undirty = _gf_true;
 
-    if (local->op_ret < 0 && !nothing_failed) {
+    if (IS_ERROR(local->op_ret) && !nothing_failed) {
         if (afr_need_dirty_marking(frame, this)) {
             local->dirty[idx] = hton32(1);
             goto set_dirty;
@@ -1541,7 +1541,7 @@ afr_changelog_post_op_do(call_frame_t *frame, xlator_t *this)
     }
 
     ret = afr_set_pending_dict(priv, xattr, local->pending);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         afr_changelog_post_op_fail(frame, this, ENOMEM);
         goto out;
     }
@@ -1770,7 +1770,7 @@ afr_changelog_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     local = frame->local;
     child_index = (long)cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
         afr_transaction_fop_failed(frame, this, child_index);
     }
@@ -2080,7 +2080,7 @@ afr_changelog_pre_op(call_frame_t *frame, xlator_t *this)
      * avoid ending up in split-brain.*/
 
     ret = afr_set_pending_dict(priv, xdata_req, local->pending);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = ENOMEM;
         goto err;
     }
@@ -2144,7 +2144,7 @@ afr_post_nonblocking_lock_cbk(call_frame_t *frame, xlator_t *this)
     int_lock = &local->internal_lock;
 
     /* Initiate blocking locks if non-blocking has failed */
-    if (int_lock->lock_op_ret < 0) {
+    if (IS_ERROR(int_lock->lock_op_ret)) {
         gf_msg_debug(this->name, 0,
                      "Non blocking locks failed. Proceeding to blocking");
         int_lock->lock_cbk = afr_internal_lock_finish;
@@ -2168,7 +2168,7 @@ afr_post_blocking_rename_cbk(call_frame_t *frame, xlator_t *this)
     local = frame->local;
     int_lock = &local->internal_lock;
 
-    if (int_lock->lock_op_ret < 0) {
+    if (IS_ERROR(int_lock->lock_op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, 0, AFR_MSG_INTERNAL_LKS_FAILED,
                "Blocking entrylks failed.");
 
@@ -2387,14 +2387,14 @@ afr_internal_lock_finish(call_frame_t *frame, xlator_t *this)
 
     local->internal_lock.lock_cbk = NULL;
     if (!local->transaction.eager_lock_on) {
-        if (local->internal_lock.lock_op_ret < 0) {
+        if (IS_ERROR(local->internal_lock.lock_op_ret)) {
             afr_transaction_done(frame, this);
             return 0;
         }
         afr_changelog_pre_op(frame, this);
     } else {
         lock = &local->inode_ctx->lock[local->transaction.type];
-        if (local->internal_lock.lock_op_ret < 0) {
+        if (IS_ERROR(local->internal_lock.lock_op_ret)) {
             afr_handle_lock_acquire_failure(local);
         } else {
             lock->event_generation = local->event_generation;
@@ -3011,7 +3011,7 @@ afr_transaction(call_frame_t *frame, xlator_t *this, afr_transaction_type type)
     }
 
     ret = afr_transaction_local_init(local, this);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = afr_transaction_lockee_init(frame);
@@ -3024,7 +3024,7 @@ afr_transaction(call_frame_t *frame, xlator_t *this, afr_transaction_type type)
 
     ret = afr_inode_get_readable(frame, local->inode, this, local->readable,
                                  &event_generation, type);
-    if (ret < 0 ||
+    if (IS_ERROR(ret) ||
         afr_is_inode_refresh_reqd(local->inode, this, priv->event_generation,
                                   event_generation)) {
         afr_inode_refresh(frame, this, local->inode, local->loc.gfid,

--- a/xlators/cluster/afr/src/afr.c
+++ b/xlators/cluster/afr/src/afr.c
@@ -113,7 +113,7 @@ afr_set_favorite_child_policy(afr_private_t *priv, char *policy)
     int index = -1;
 
     index = gf_get_index_by_elem(afr_favorite_child_policies, policy);
-    if (index < 0 || index >= AFR_FAV_CHILD_POLICY_MAX)
+    if (IS_ERROR(index) || index >= AFR_FAV_CHILD_POLICY_MAX)
         return -1;
 
     priv->fav_child_policy = index;
@@ -212,7 +212,7 @@ reconfigure(xlator_t *this, dict_t *options)
 
     if (read_subvol) {
         index = xlator_subvolume_index(this, read_subvol);
-        if (index == -1) {
+        if (IS_ERROR(index)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_INVALID_SUBVOL,
                    "%s not a subvolume", read_subvol->name);
             goto out;
@@ -279,7 +279,7 @@ reconfigure(xlator_t *this, dict_t *options)
 
     GF_OPTION_RECONF("favorite-child-policy", fav_child_policy, options, str,
                      out);
-    if (afr_set_favorite_child_policy(priv, fav_child_policy) == -1)
+    if (IS_ERROR(afr_set_favorite_child_policy(priv, fav_child_policy)))
         goto out;
 
     priv->did_discovery = _gf_false;
@@ -335,7 +335,7 @@ afr_pending_xattrs_init(afr_private_t *priv, xlator_t *this)
         while (i < child_count) {
             ret = gf_asprintf(&priv->pending_key[i], "%s.%s", AFR_XATTR_PREFIX,
                               trav->xlator->name);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 ret = -ENOMEM;
                 goto out;
             }
@@ -354,7 +354,7 @@ afr_pending_xattrs_init(afr_private_t *priv, xlator_t *this)
     for (i = 0, ptr = strtok(ptr, ","); ptr; ptr = strtok(NULL, ",")) {
         ret = gf_asprintf(&priv->pending_key[i], "%s.%s", AFR_XATTR_PREFIX,
                           ptr);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             ret = -ENOMEM;
             goto out;
         }
@@ -447,7 +447,7 @@ init(xlator_t *this)
     GF_OPTION_INIT("read-subvolume", read_subvol, xlator, out);
     if (read_subvol) {
         priv->read_child = xlator_subvolume_index(this, read_subvol);
-        if (priv->read_child == -1) {
+        if (IS_ERROR(priv->read_child)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_INVALID_SUBVOL,
                    "%s not a subvolume", read_subvol->name);
             goto out;
@@ -472,7 +472,7 @@ init(xlator_t *this)
     priv->favorite_child = -1;
 
     GF_OPTION_INIT("favorite-child-policy", fav_child_policy, str, out);
-    if (afr_set_favorite_child_policy(priv, fav_child_policy) == -1)
+    if (IS_ERROR(afr_set_favorite_child_policy(priv, fav_child_policy)))
         goto out;
 
     GF_OPTION_INIT("shd-max-threads", priv->shd.max_threads, uint32, out);
@@ -588,7 +588,7 @@ init(xlator_t *this)
     }
 
     ret = gf_asprintf(&priv->sh_domain, AFR_SH_DATA_DOMAIN_FMT, this->name);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         ret = -ENOMEM;
         goto out;
     }

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -84,7 +84,7 @@ dht_set_fixed_dir_stat(struct iatt *stat)
 static gf_boolean_t
 dht_match_xattr(const char *key)
 {
-    return gf_get_index_by_elem(xattrs_to_heal, (char *)key) >= 0;
+    return gf_get_index_by_elem(IS_SUCCESS(xattrs_to_heal, (char *)key));
 }
 
 static int
@@ -1443,7 +1443,7 @@ dht_lookup_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         if (__is_root_gfid(stbuf->ia_gfid)) {
             ret = dht_dir_has_layout(xattr, conf->xattr_name);
-            if (ret >= 0) {
+            if (IS_SUCCESS(ret)) {
                 if (is_greater_time(local->prebuf.ia_ctime,
                                     local->prebuf.ia_ctime_nsec,
                                     stbuf->ia_ctime, stbuf->ia_ctime_nsec)) {
@@ -1764,7 +1764,7 @@ dht_revalidate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
         if (is_dir) {
             ret = dht_dir_has_layout(xattr, conf->xattr_name);
-            if (ret >= 0) {
+            if (IS_SUCCESS(ret)) {
                 if (is_greater_time(local->prebuf.ia_ctime,
                                     local->prebuf.ia_ctime_nsec,
                                     stbuf->ia_ctime, stbuf->ia_ctime_nsec)) {
@@ -4521,7 +4521,7 @@ dht_linkinfo_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int ret = 0;
     char *value = NULL;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         ret = dict_get_str(xattr, GF_XATTR_PATHINFO_KEY, &value);
         if (!ret) {
             ret = dict_set_str(xattr, GF_XATTR_LINKINFO_KEY, value);
@@ -4610,11 +4610,11 @@ dht_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
         dict_del(xattr, conf->commithash_xattr_name);
 
-        if (frame->root->pid >= 0 && dht_is_tier_xlator(this)) {
+        if (IS_SUCCESS(frame->root->pid) && dht_is_tier_xlator(this)) {
             dict_del(xattr, GF_XATTR_TIER_LAYOUT_FIXED_KEY);
         }
 
-        if (frame->root->pid >= 0) {
+        if (IS_SUCCESS(frame->root->pid)) {
             GF_REMOVE_INTERNAL_XATTR("trusted.glusterfs.quota*", xattr);
             GF_REMOVE_INTERNAL_XATTR("trusted.pgfid*", xattr);
         }
@@ -5121,7 +5121,7 @@ no_dht_is_dir:
         return 0;
     }
 
-    if (dht_is_debug_xattr_key(dht_dbg_vxattrs, (char *)key) >= 0) {
+    if (IS_SUCCESS(dht_is_debug_xattr_key(dht_dbg_vxattrs, (char *)key))) {
         dht_handle_debug_getxattr(frame, this, loc, key);
         return 0;
     }
@@ -9104,7 +9104,7 @@ dht_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (subvol_filled && (op_ret >= 0)) {
+        if (IS_SUCCESS(subvol_filled && (op_ret))) {
             ret = dht_layout_merge(this, layout, prev, -1, ENOSPC, NULL);
         } else {
             if (IS_ERROR(op_ret) && op_errno == EEXIST) {
@@ -11398,7 +11398,7 @@ dht_pt_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     dict_del(xattr, conf->mds_xattr_key);
     dict_del(xattr, conf->commithash_xattr_name);
 
-    if (frame->root->pid >= 0) {
+    if (IS_SUCCESS(frame->root->pid)) {
         GF_REMOVE_INTERNAL_XATTR("trusted.glusterfs.quota*", xattr);
         GF_REMOVE_INTERNAL_XATTR("trusted.pgfid*", xattr);
     }
@@ -11425,7 +11425,7 @@ dht_pt_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     conf = this->private;
     dict_del(xattr, conf->xattr_name);
 
-    if (frame->root->pid >= 0) {
+    if (IS_SUCCESS(frame->root->pid)) {
         GF_REMOVE_INTERNAL_XATTR("trusted.glusterfs.quota*", xattr);
         GF_REMOVE_INTERNAL_XATTR("trusted.pgfid*", xattr);
     }

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -84,7 +84,7 @@ dht_set_fixed_dir_stat(struct iatt *stat)
 static gf_boolean_t
 dht_match_xattr(const char *key)
 {
-    return gf_get_index_by_elem(IS_SUCCESS(xattrs_to_heal, (char *)key));
+    return IS_SUCCESS(gf_get_index_by_elem(xattrs_to_heal, (char *)key));
 }
 
 static int
@@ -9104,7 +9104,7 @@ dht_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (IS_SUCCESS(subvol_filled && (op_ret))) {
+        if (subvol_filled && IS_SUCCESS(op_ret)) {
             ret = dht_layout_merge(this, layout, prev, -1, ENOSPC, NULL);
         } else {
             if (IS_ERROR(op_ret) && op_errno == EEXIST) {

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -58,7 +58,7 @@ static const char *dht_dbg_vxattrs[] = {DHT_DBG_HASHED_SUBVOL_PATTERN, NULL};
 int32_t
 dht_check_remote_fd_failed_error(dht_local_t *local, int op_ret, int op_errno)
 {
-    if (op_ret == -1 && (op_errno == EBADF || op_errno == EBADFD) &&
+    if (IS_ERROR(op_ret) && (op_errno == EBADF || op_errno == EBADFD) &&
         !(local->fd_checked)) {
         return 1;
     }
@@ -105,7 +105,7 @@ dht_aggregate_quota_xattr(dict_t *dst, char *key, data_t *value)
     }
 
     ret = dict_get_bin(dst, key, (void **)&meta_dst);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         meta_dst = GF_CALLOC(1, sizeof(quota_meta_t), gf_common_quota_meta_t);
         if (meta_dst == NULL) {
             gf_msg("dht", GF_LOG_WARNING, ENOMEM, DHT_MSG_NO_MEMORY,
@@ -114,7 +114,7 @@ dht_aggregate_quota_xattr(dict_t *dst, char *key, data_t *value)
             goto out;
         }
         ret = dict_set_bin(dst, key, meta_dst, sizeof(quota_meta_t));
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg("dht", GF_LOG_WARNING, EINVAL, DHT_MSG_DICT_SET_FAILED,
                    "dht aggregate dict set failed");
             GF_FREE(meta_dst);
@@ -303,7 +303,7 @@ dht_aggregate_split_brain_xattr(dict_t *dst, char *key, data_t *value)
                               "metadata-split-brain:%s   Choices:%s",
                               "no", "yes", full_choice);
 
-            if (-1 == ret) {
+            if (IS_ERROR(ret)) {
                 gf_msg("dht", GF_LOG_WARNING, 0, DHT_MSG_NO_MEMORY,
                        "Error to prepare status ");
                 goto out;
@@ -546,7 +546,7 @@ dht_discover_complete(xlator_t *this, call_frame_t *discover_frame)
     }
 
     ret = dict_get_int8(local->xattr_req, QUOTA_READ_ONLY_KEY, &is_read_only);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_msg_debug(this->name, 0, "key = %s not present in dict",
                      QUOTA_READ_ONLY_KEY);
 
@@ -562,7 +562,7 @@ dht_discover_complete(xlator_t *this, call_frame_t *discover_frame)
 
     if (local->cached_subvol) {
         ret = dht_layout_preset(this, local->cached_subvol, local->inode);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, 0, DHT_MSG_LAYOUT_SET_FAILED,
                    "failed to set layout for subvolume %s",
                    local->cached_subvol ? local->cached_subvol->name : "<nil>");
@@ -571,7 +571,7 @@ dht_discover_complete(xlator_t *this, call_frame_t *discover_frame)
         }
     } else {
         ret = dht_layout_normalize(this, &local->loc, layout);
-        if ((ret < 0) || ((ret > 0) && (local->op_ret != 0))) {
+        if (IS_ERROR(ret) || ((ret > 0) && (local->op_ret != 0))) {
             /* either the layout is incorrect or the directory is
              * not found even in one subvolume.
              */
@@ -579,7 +579,7 @@ dht_discover_complete(xlator_t *this, call_frame_t *discover_frame)
                          "normalizing failed on %s "
                          "(overlaps/holes present: %s, "
                          "ENOENT errors: %d)",
-                         local->loc.path, (ret < 0) ? "yes" : "no",
+                         local->loc.path, (IS_ERROR(ret)) ? "yes" : "no",
                          (ret > 0) ? ret : 0);
             layout_anomalies = 1;
         } else if (local->inode) {
@@ -969,7 +969,7 @@ dht_dict_get_array(dict_t *dict, char *key, int32_t value[], int32_t size,
 
     for (vindex = 0; vindex < size; vindex++) {
         value[vindex] = ntoh32(*((int32_t *)ptr + vindex));
-        if (value[vindex] < 0)
+        if (IS_ERROR(value[vindex]))
             ret = -1;
     }
 
@@ -1033,7 +1033,7 @@ dht_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                    "%s: failed to merge layouts for subvol %s", local->loc.path,
                    prev->name);
 
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             gf_msg_debug(this->name, op_errno,
                          "lookup of %s on %s returned error", local->loc.path,
@@ -1100,7 +1100,7 @@ dht_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                    local->loc.path, prev->name);
         }
 
-        if ((check_mds < 0) && !errst) {
+        if (IS_ERROR(check_mds) && !errst) {
             local->mds_xattr = dict_ref(xattr);
             gf_msg_debug(this->name, 0,
                          "Value of %s is not zero on mds subvol"
@@ -1155,7 +1155,7 @@ dht_set_file_xattr_req(xlator_t *this, loc_t *loc, dict_t *xattr_req)
     /* Used to check whether this is a linkto file.
      */
     ret = dict_set_uint32(xattr_req, conf->link_xattr_name, 256);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, DHT_MSG_DICT_SET_FAILED,
                "Failed to set dictionary value:key = %s for "
                "path %s",
@@ -1413,7 +1413,7 @@ dht_lookup_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         */
         ret = dht_layout_merge(this, layout, prev, op_ret, op_errno, xattr);
 
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
 
             /* The GFID is missing on this subvol. Force a heal. */
@@ -1500,7 +1500,7 @@ dht_lookup_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
         check_mds = dht_dict_get_array(xattr, conf->mds_xattr_key,
                                        mds_xattr_val, 1, &errst);
-        if ((check_mds < 0) && !errst) {
+        if (IS_ERROR(check_mds) && !errst) {
             /* Check if xattrs need to be healed on the directories */
             local->mds_xattr = dict_ref(xattr);
             gf_msg_debug(this->name, 0,
@@ -1692,7 +1692,7 @@ dht_revalidate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             memcpy(local->gfid, local->loc.gfid, 16);
         }
 
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
 
             if ((op_errno != ENOTCONN) && (op_errno != ENOENT) &&
@@ -1811,7 +1811,7 @@ dht_revalidate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                            "Failed to set MDS subvol for %s vol is %s",
                            local->loc.path, prev->name);
                 }
-                if ((check_mds < 0) && !errst) {
+                if (IS_ERROR(check_mds) && !errst) {
                     /* Check if xattrs need to be healed on the directory
                      */
                     local->mds_xattr = dict_ref(xattr);
@@ -2005,7 +2005,7 @@ dht_lookup_linkfile_create_cbk(call_frame_t *frame, void *cooie, xlator_t *this,
         dht_unlock_namespace(frame, &local->lock[0]);
 
     ret = dht_layout_preset(this, local->cached_subvol, local->loc.inode);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, EINVAL,
                      "Failed to set layout for subvolume %s, "
                      "(gfid = %s)",
@@ -2220,7 +2220,7 @@ dht_linkfile_create_lookup_cbk(call_frame_t *frame, void *cookie,
                          "creating linkto",
                          uuid_utoa(buf->ia_gfid), subvol->name, gfid_str);
             local->dont_create_linkto = _gf_true;
-        } else if (op_ret == -1) {
+        } else if (IS_ERROR(op_ret)) {
             local->dont_create_linkto = _gf_true;
         }
     }
@@ -2240,7 +2240,7 @@ dht_linkfile_create_lookup_cbk(call_frame_t *frame, void *cookie,
                                       this, local->cached_subvol,
                                       local->hashed_subvol, &local->loc);
 
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto no_linkto;
         }
     }
@@ -2276,7 +2276,7 @@ dht_call_lookup_linkfile_create(call_frame_t *frame, void *cookie,
     else
         gf_uuid_unparse(local->gfid, gfid);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_WARNING,
                "protecting namespace failed, skipping linkto "
                "creation (path:%s)(gfid:%s)(hashed-subvol:%s)"
@@ -2580,7 +2580,7 @@ preset_layout:
         }
 
         ret = dht_layout_set(this, local->inode, layout);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_INFO, 0, DHT_MSG_SUBVOL_INFO,
                    "%s: failed to set layout for subvol %s, "
                    "gfid = %s",
@@ -2611,7 +2611,7 @@ preset_layout:
         local->op_errno = 0;
 
         ret = dht_layout_preset(frame->this, cached_subvol, local->inode);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_INFO, 0, DHT_MSG_LAYOUT_PRESET_FAILED,
                    "Failed to set layout for subvol %s"
                    ", gfid = %s",
@@ -2698,7 +2698,7 @@ dht_lookup_everywhere_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             if (op_errno != ENOENT)
                 local->op_errno = op_errno;
             if (op_errno == ENODATA)
@@ -2922,7 +2922,7 @@ dht_lookup_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     gf_uuid_unparse(loc->gfid, gfid);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, op_errno, DHT_MSG_LINK_FILE_LOOKUP_INFO,
                "Lookup of %s on %s (following linkfile) failed "
                ",gfid = %s",
@@ -2969,7 +2969,7 @@ dht_lookup_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     ret = dht_layout_preset(this, prev, inode);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_INFO, 0, DHT_MSG_LAYOUT_PRESET_FAILED,
                "Failed to set layout for subvolume %s,"
                "gfid = %s",
@@ -3077,7 +3077,7 @@ dht_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                  "%s: fresh_lookup on %s returned with op_ret %d", loc->path,
                  prev->name, op_ret);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (ENTRY_MISSING(op_ret, op_errno)) {
             if (1 == conf->subvolume_cnt) {
                 /* No need to lookup again */
@@ -3145,7 +3145,7 @@ dht_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
          */
 
         ret = dht_layout_preset(this, prev, inode);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_INFO, 0, DHT_MSG_LAYOUT_PRESET_FAILED,
                    "%s: could not set pre-set layout for subvolume %s",
                    loc->path, prev->name);
@@ -3368,7 +3368,7 @@ dht_do_fresh_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc)
                       hashed_subvol->fops->lookup, loc, local->xattr_req);
     return 0;
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
     return 0;
 }
@@ -3481,7 +3481,7 @@ dht_do_revalidate(call_frame_t *frame, xlator_t *this, loc_t *loc)
     }
     return 0;
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
     return 0;
 }
@@ -3528,7 +3528,7 @@ dht_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
         loc_wipe(&new_loc);
 
         /* check if loc_dup() is successful */
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             op_errno = errno;
             gf_msg_debug(this->name, errno,
                          "copying location failed for path=%s", loc->path);
@@ -3581,7 +3581,7 @@ dht_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
 
     return 0;
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
     return 0;
 }
@@ -3599,7 +3599,7 @@ dht_unlink_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     LOCK(&frame->lock);
     {
-        if ((op_ret == -1) &&
+        if (IS_ERROR(op_ret) &&
             !((op_errno == ENOENT) || (op_errno == ENOTCONN))) {
             local->op_errno = op_errno;
             UNLOCK(&frame->lock);
@@ -3634,7 +3634,7 @@ dht_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             if (op_errno != ENOENT) {
                 local->op_ret = -1;
                 local->op_errno = op_errno;
@@ -3724,7 +3724,7 @@ dht_err_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             UNLOCK(&frame->lock);
             gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -3954,7 +3954,7 @@ dht_setxattr_mds_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     conf = this->private;
     mds_subvol = local->mds_subvol;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -4036,7 +4036,7 @@ dht_xattrop_mds_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
         local->op_ret = op_ret;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -4282,7 +4282,7 @@ dht_find_local_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     LOCK(&frame->lock);
     {
         this_call_cnt = --local->call_cnt;
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             local->op_ret = -1;
             local->op_errno = op_errno;
             UNLOCK(&frame->lock);
@@ -4296,7 +4296,7 @@ dht_find_local_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         ret = dict_get_str(xattr, local->xsel, &uuid_list);
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_DICT_GET_FAILED,
                    "Failed to get %s", local->xsel);
             local->op_ret = -1;
@@ -4383,7 +4383,7 @@ post_unlock:
     if (!is_last_call(this_call_cnt))
         goto out;
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         goto unwind;
     }
 
@@ -4418,7 +4418,7 @@ dht_vgetxattr_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     LOCK(&frame->lock);
     {
         this_call_cnt = --local->call_cnt;
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             if (op_errno != ENOTCONN) {
                 local->op_ret = -1;
                 local->op_errno = op_errno;
@@ -4447,7 +4447,7 @@ post_unlock:
 
     /* -- last call: do patch ups -- */
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         goto unwind;
     }
 
@@ -4480,7 +4480,7 @@ dht_vgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     local = frame->local;
     prev = cookie;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = -1;
         local->op_errno = op_errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, DHT_MSG_GET_XATTR_FAILED,
@@ -4521,7 +4521,7 @@ dht_linkinfo_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int ret = 0;
     char *value = NULL;
 
-    if (op_ret != -1) {
+    if (op_ret >= 0) {
         ret = dict_get_str(xattr, GF_XATTR_PATHINFO_KEY, &value);
         if (!ret) {
             ret = dict_set_str(xattr, GF_XATTR_LINKINFO_KEY, value);
@@ -4549,7 +4549,7 @@ dht_mds_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     conf = this->private;
     local = frame->local;
 
-    if (!xattr || (op_ret == -1)) {
+    if (!xattr || IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         goto out;
     }
@@ -4594,7 +4594,7 @@ dht_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (!xattr || (op_ret == -1)) {
+        if (!xattr || IS_ERROR(op_ret)) {
             local->op_ret = op_ret;
             goto unlock;
         }
@@ -4682,7 +4682,7 @@ dht_getxattr_get_real_filename_cbk(call_frame_t *frame, void *cookie,
             goto unlock;
         }
 
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             if (op_errno == EOPNOTSUPP) {
                 /* This subvol does not have the optimization.
                  * Better let the user know we don't support it.
@@ -4835,7 +4835,7 @@ dht_handle_debug_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     local = frame->local;
 
-    if (dht_is_debug_xattr_key(dht_dbg_vxattrs, (char *)key) == -1) {
+    if (IS_ERROR(dht_is_debug_xattr_key(dht_dbg_vxattrs, (char *)key))) {
         goto out;
     }
 
@@ -4872,7 +4872,7 @@ dht_handle_debug_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         }
 
         ret = dict_set_dynstr(local->xattr, (char *)key, value);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             op_errno = -ret;
             ret = -1;
             goto out;
@@ -4929,7 +4929,7 @@ dht_vgetxattr_subvol_status(call_frame_t *frame, xlator_t *this,
         }
     }
     ret = dict_set_int8(local->xattr, (char *)key, value);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         ret = -1;
         goto out;
@@ -5016,7 +5016,7 @@ dht_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *key,
 
     if (!strcmp(key, GF_REBAL_FIND_LOCAL_SUBVOL)) {
         ret = gf_asprintf(&node_uuid_key, "%s", GF_XATTR_LIST_NODE_UUIDS_KEY);
-        if (ret == -1 || !node_uuid_key) {
+        if (IS_ERROR(ret) || !node_uuid_key) {
             gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_NO_MEMORY,
                    "Failed to copy node uuid key");
             op_errno = ENOMEM;
@@ -5037,7 +5037,7 @@ dht_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *key,
 
     if (!strcmp(key, GF_REBAL_OLD_FIND_LOCAL_SUBVOL)) {
         ret = gf_asprintf(&node_uuid_key, "%s", GF_XATTR_NODE_UUID_KEY);
-        if (ret == -1 || !node_uuid_key) {
+        if (IS_ERROR(ret) || !node_uuid_key) {
             gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_NO_MEMORY,
                    "Failed to copy node uuid key");
             op_errno = ENOMEM;
@@ -5182,7 +5182,7 @@ no_key:
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(getxattr, frame, -1, op_errno, NULL, NULL);
 
     return 0;
@@ -5292,7 +5292,7 @@ dht_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *key,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(fgetxattr, frame, -1, op_errno, NULL, NULL);
 
     return 0;
@@ -5369,7 +5369,7 @@ dht_file_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if (IS_ERROR(op_ret) && !dht_inode_missing(op_errno)) {
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1.",
                      prev->name);
         goto out;
@@ -5390,7 +5390,7 @@ dht_file_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->rebalance.xdata = dict_ref(xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(stbuf)) {
+    if (IS_ERROR(op_ret) || IS_DHT_MIGRATION_PHASE2(stbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -5682,7 +5682,7 @@ dht_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xattr,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(fsetxattr, frame, -1, op_errno, NULL);
 
     return 0;
@@ -5705,7 +5705,7 @@ dht_checking_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     prev = cookie;
     conf = this->private;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto out;
 
     ret = dict_get_str(xattr, GF_XATTR_PATHINFO_KEY, &value);
@@ -6017,7 +6017,7 @@ dht_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(setxattr, frame, -1, op_errno, NULL);
 
     return 0;
@@ -6091,7 +6091,7 @@ dht_file_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if (IS_ERROR(op_ret) && !dht_inode_missing(op_errno)) {
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
                      prev->name);
         goto out;
@@ -6113,7 +6113,7 @@ dht_file_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->rebalance.xdata = dict_ref(xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(stbuf)) {
+    if (IS_ERROR(op_ret) || IS_DHT_MIGRATION_PHASE2(stbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -6221,7 +6221,7 @@ dht_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(removexattr, frame, -1, op_errno, NULL);
 
     return 0;
@@ -6299,7 +6299,7 @@ dht_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *key,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(fremovexattr, frame, -1, op_errno, NULL);
 
     return 0;
@@ -6318,7 +6318,7 @@ dht_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             UNLOCK(&frame->lock);
             gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -6382,7 +6382,7 @@ dht_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             goto unlock;
         }
@@ -6516,7 +6516,7 @@ dht_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(statfs, frame, -1, op_errno, NULL, NULL);
 
     return 0;
@@ -6597,7 +6597,7 @@ dht_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(opendir, frame, -1, op_errno, NULL, NULL);
 
     return 0;
@@ -6939,7 +6939,7 @@ unwind:
      * distribute we're not concerned only with a posix's view of the
      * directory but the aggregated namespace' view of the directory.
      */
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         op_ret = 0;
 
     if (prev != dht_last_up_subvol(this))
@@ -7157,7 +7157,7 @@ dht_do_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(readdir, frame, -1, op_errno, NULL, NULL);
 
     return 0;
@@ -7209,7 +7209,7 @@ dht_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1)
+        if (IS_ERROR(op_ret))
             local->op_errno = op_errno;
         else if (op_ret == 0)
             local->op_ret = 0;
@@ -7256,7 +7256,7 @@ dht_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(fsyncdir, frame, -1, op_errno, NULL);
 
     return 0;
@@ -7271,7 +7271,7 @@ dht_newfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     int ret = -1;
     dht_local_t *local = NULL;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto out;
 
     local = frame->local;
@@ -7289,7 +7289,7 @@ dht_newfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     }
 
     ret = dht_layout_preset(this, prev, inode);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, EINVAL,
                      "could not set pre-set layout for subvolume %s",
                      prev ? prev->name : NULL);
@@ -7345,7 +7345,7 @@ dht_mknod_linkfile_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto err;
     }
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
         goto err;
     }
@@ -7547,7 +7547,7 @@ dht_mknod_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto err;
     }
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg("DHT", GF_LOG_ERROR, 0, DHT_MSG_INODE_LK_ERROR,
                "mknod lock failed for file: %s", local->loc2.name);
 
@@ -7601,7 +7601,7 @@ dht_mknod_lock(call_frame_t *frame, xlator_t *subvol)
 
     ret = dht_blocking_inodelk(frame, lk_array, count, dht_mknod_lock_cbk);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->lock[0].layout.parent_layout.locks = NULL;
         local->lock[0].layout.parent_layout.lk_count = 0;
         goto err;
@@ -7633,7 +7633,7 @@ dht_refresh_parent_layout_resume(call_frame_t *frame, xlator_t *this, int ret,
     parent_frame = stub->frame;
     parent_local = parent_frame->local;
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         parent_local->op_ret = -1;
         parent_local->op_errno = local->op_errno ? local->op_errno : EIO;
     } else {
@@ -7655,7 +7655,7 @@ dht_refresh_parent_layout_done(call_frame_t *frame)
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         ret = -1;
         goto resume;
     }
@@ -7714,7 +7714,7 @@ dht_call_mkdir_stub(call_frame_t *frame, void *cookie, xlator_t *this,
     stub = local->stub;
     local->stub = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = -1;
         local->op_errno = op_errno;
     } else {
@@ -7787,7 +7787,7 @@ dht_guard_parent_layout_and_namespace(xlator_t *subvol, call_stub_t *stub)
 
     ret = dht_disk_layout_extract_for_subvol(this, parent_layout, hashed_subvol,
                                              &parent_disk_layout);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         local->op_errno = EINVAL;
         gf_msg(this->name, GF_LOG_WARNING, local->op_errno,
                DHT_MSG_PARENT_LAYOUT_CHANGED,
@@ -7804,7 +7804,7 @@ dht_guard_parent_layout_and_namespace(xlator_t *subvol, call_stub_t *stub)
     parent_layout = NULL;
 
     ret = dict_set_str(local->params, GF_PREOP_PARENT_KEY, conf->xattr_name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->op_errno = -ret;
         gf_msg(this->name, GF_LOG_WARNING, local->op_errno,
                DHT_MSG_PARENT_LAYOUT_CHANGED,
@@ -7817,7 +7817,7 @@ dht_guard_parent_layout_and_namespace(xlator_t *subvol, call_stub_t *stub)
 
     ret = dict_set_bin(local->params, conf->xattr_name, parent_disk_layout,
                        4 * 4);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->op_errno = -ret;
         gf_msg(this->name, GF_LOG_WARNING, local->op_errno,
                DHT_MSG_PARENT_LAYOUT_CHANGED,
@@ -7833,7 +7833,7 @@ dht_guard_parent_layout_and_namespace(xlator_t *subvol, call_stub_t *stub)
     local->current = &local->lock[0];
     ret = dht_protect_namespace(frame, loc, hashed_subvol, &local->current->ns,
                                 dht_call_mkdir_stub);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     return 0;
@@ -7934,7 +7934,7 @@ dht_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
                 ret = dht_mknod_lock(frame, subvol);
 
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_INODE_LK_ERROR,
                            "locking parent failed");
                     goto err;
@@ -7952,7 +7952,7 @@ done:
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
 
     return 0;
@@ -7992,7 +7992,7 @@ dht_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
 
     return 0;
@@ -8031,7 +8031,7 @@ dht_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
 
     return 0;
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(unlink, frame, -1, op_errno, NULL, NULL, NULL);
 
     return 0;
@@ -8102,7 +8102,7 @@ dht_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     local = frame->local;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Remove the linkto if exists */
         if (local->linked) {
             cleanup_frame = create_frame(this, this->ctx->pool);
@@ -8269,7 +8269,7 @@ dht_link_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     dht_local_t *local = NULL;
     xlator_t *srcvol = NULL;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto err;
 
     local = frame->local;
@@ -8330,7 +8330,7 @@ dht_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 
     ret = loc_copy(&local->loc2, newloc);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         op_errno = ENOMEM;
         goto err;
     }
@@ -8349,7 +8349,7 @@ dht_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
 
     return 0;
@@ -8376,7 +8376,7 @@ dht_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         goto out;
     }
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
         parent_layout_changed = (xdata &&
                                  dict_get(xdata, GF_PREOP_CHECK_FAILED))
@@ -8428,7 +8428,7 @@ dht_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
             subvol = dht_subvol_get_hashed(this, &local->loc2);
 
             ret = dht_create_lock(frame, subvol);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_INODE_LK_ERROR,
                        "locking parent failed");
                 goto out;
@@ -8510,7 +8510,7 @@ dht_create_linkfile_create_cbk(call_frame_t *frame, void *cookie,
         goto err;
     }
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
         goto err;
     }
@@ -8776,7 +8776,7 @@ dht_create_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto err;
     }
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg("DHT", GF_LOG_ERROR, 0, DHT_MSG_INODE_LK_ERROR,
                "Create lock failed for file: %s", local->loc2.name);
 
@@ -8830,7 +8830,7 @@ dht_create_lock(call_frame_t *frame, xlator_t *subvol)
 
     ret = dht_blocking_inodelk(frame, lk_array, count, dht_create_lock_cbk);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->lock[0].layout.parent_layout.locks = NULL;
         local->lock[0].layout.parent_layout.lk_count = 0;
         goto err;
@@ -8863,7 +8863,7 @@ dht_set_parent_layout_in_dict(loc_t *loc, xlator_t *this, dht_local_t *local)
 
     ret = dht_disk_layout_extract_for_subvol(this, parent_layout, hashed_subvol,
                                              &parent_disk_layout);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, local->op_errno,
                DHT_MSG_PARENT_LAYOUT_CHANGED,
                "%s (%s/%s) (path: %s): "
@@ -8874,7 +8874,7 @@ dht_set_parent_layout_in_dict(loc_t *loc, xlator_t *this, dht_local_t *local)
 
     ret = dict_set_str_sizen(local->params, GF_PREOP_PARENT_KEY,
                              conf->xattr_name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, local->op_errno,
                DHT_MSG_PARENT_LAYOUT_CHANGED,
                "%s (%s/%s) (path: %s): "
@@ -8886,7 +8886,7 @@ dht_set_parent_layout_in_dict(loc_t *loc, xlator_t *this, dht_local_t *local)
 
     ret = dict_set_bin(local->params, conf->xattr_name, parent_disk_layout,
                        4 * 4);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, local->op_errno,
                DHT_MSG_PARENT_LAYOUT_CHANGED,
                "%s (%s/%s) (path: %s): "
@@ -9024,7 +9024,7 @@ dht_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
                 ret = dht_create_lock(frame, subvol);
 
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_INODE_LK_ERROR,
                            "locking parent failed");
                     goto err;
@@ -9042,7 +9042,7 @@ done:
 
 err:
 
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(create, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL,
                      NULL);
 
@@ -9104,10 +9104,10 @@ dht_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (subvol_filled && (op_ret != -1)) {
+        if (subvol_filled && (op_ret >= 0)) {
             ret = dht_layout_merge(this, layout, prev, -1, ENOSPC, NULL);
         } else {
-            if (op_ret == -1 && op_errno == EEXIST) {
+            if (IS_ERROR(op_ret) && op_errno == EEXIST) {
                 /* Very likely just a race between mkdir and
                    self-heal (from lookup of a concurrent mkdir
                    attempt).
@@ -9125,7 +9125,7 @@ dht_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                    "%s: failed to merge layouts for subvol %s", local->loc.path,
                    prev->name);
 
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             goto unlock;
         }
@@ -9181,7 +9181,7 @@ dht_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     conf = this->private;
     local = frame->local;
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, local->op_errno,
                DHT_MSG_PARENT_LAYOUT_CHANGED,
                "mkdir (%s/%s) (path: %s): refreshing parent layout "
@@ -9210,7 +9210,7 @@ dht_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     ret = dht_disk_layout_extract_for_subvol(this, parent_layout, hashed_subvol,
                                              &parent_disk_layout);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, EIO, DHT_MSG_PARENT_LAYOUT_CHANGED,
                "mkdir (%s/%s) (path: %s): "
                "extracting in-memory layout of parent failed. ",
@@ -9237,7 +9237,7 @@ dht_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     parent_layout = NULL;
 
     ret = dict_set_str(params, GF_PREOP_PARENT_KEY, conf->xattr_name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->op_errno = -ret;
         gf_msg(this->name, GF_LOG_WARNING, local->op_errno,
                DHT_MSG_PARENT_LAYOUT_CHANGED,
@@ -9248,7 +9248,7 @@ dht_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 
     ret = dict_set_bin(params, conf->xattr_name, parent_disk_layout, 4 * 4);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->op_errno = -ret;
         gf_msg(this->name, GF_LOG_WARNING, local->op_errno,
                DHT_MSG_PARENT_LAYOUT_CHANGED,
@@ -9308,7 +9308,7 @@ dht_mkdir_hashed_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (gf_uuid_is_null(local->loc.gfid) && !op_ret)
         gf_uuid_copy(local->loc.gfid, stbuf->ia_gfid);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
 
         parent_layout_changed = (xdata &&
@@ -9427,7 +9427,7 @@ dht_mkdir_guard_parent_layout_cbk(call_frame_t *frame, xlator_t *this,
 
     gf_uuid_unparse(loc->parent->gfid, pgfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, local->op_errno,
                DHT_MSG_PARENT_LAYOUT_CHANGED,
                "mkdir (%s/%s) (path: %s): "
@@ -9545,7 +9545,7 @@ dht_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 
     ret = dht_guard_parent_layout_and_namespace(this, stub);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, 0, DHT_MSG_PARENT_LAYOUT_CHANGED,
                "mkdir (%s/%s) (path: %s) cannot wind lock request to "
                "guard parent layout",
@@ -9605,7 +9605,7 @@ dht_rmdir_hashed_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             local->op_ret = -1;
             if (conf->subvolume_cnt != 1) {
@@ -9762,7 +9762,7 @@ dht_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             if ((op_errno != ENOENT) && (op_errno != ESTALE)) {
                 local->op_errno = op_errno;
                 local->op_ret = -1;
@@ -9890,7 +9890,7 @@ dht_rmdir_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     conf = this->private;
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, DHT_MSG_INODE_LK_ERROR,
                "acquiring entrylk after inodelk failed rmdir for %s)",
                local->loc.path);
@@ -9933,7 +9933,7 @@ dht_rmdir_do(call_frame_t *frame, xlator_t *this)
     VALIDATE_OR_GOTO(this->private, out);
     conf = this->private;
 
-    if (local->op_ret == -1)
+    if (IS_ERROR(local->op_ret))
         goto out;
 
     local->call_cnt = conf->subvolume_cnt;
@@ -9963,7 +9963,7 @@ dht_rmdir_do(call_frame_t *frame, xlator_t *this)
     local->current = &local->lock[0];
     ret = dht_protect_namespace(frame, &local->loc, local->hashed_subvol,
                                 &local->current->ns, dht_rmdir_lock_cbk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->op_ret = -1;
         local->op_errno = errno ? errno : EINVAL;
         goto out;
@@ -9999,7 +9999,7 @@ dht_rmdir_readdirp_done(call_frame_t *readdirp_frame, xlator_t *this)
      * This is a bit hit or miss - if readdirp failed on more than
      * one subvol, we don't know which error is returned.
      */
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         main_local->op_ret = local->op_ret;
         main_local->op_errno = local->op_errno;
     }
@@ -10024,7 +10024,7 @@ dht_rmdir_readdirp_do(call_frame_t *readdirp_frame, xlator_t *this)
 
     local = readdirp_frame->local;
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         /* there is no point doing another readdirp on this
          * subvol . */
         dht_rmdir_readdirp_done(readdirp_frame, this);
@@ -10449,7 +10449,7 @@ dht_rmdir_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     prev = cookie;
 
     this_call_cnt = dht_frame_return(frame);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_uuid_unparse(local->loc.gfid, gfid);
 
         gf_msg_debug(this->name, op_errno,
@@ -10466,7 +10466,7 @@ dht_rmdir_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!is_last_call(this_call_cnt))
         return 0;
 
-    if (local->op_ret == -1)
+    if (IS_ERROR(local->op_ret))
         goto err;
 
     fd_bind(fd);
@@ -10616,7 +10616,7 @@ dht_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(rmdir, frame, -1, op_errno, NULL, NULL, NULL);
 
     return 0;
@@ -10676,7 +10676,7 @@ dht_entrylk(call_frame_t *frame, xlator_t *this, const char *volume, loc_t *loc,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(entrylk, frame, -1, op_errno, NULL);
 
     return 0;
@@ -10723,7 +10723,7 @@ dht_fentrylk(call_frame_t *frame, xlator_t *this, const char *volume, fd_t *fd,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(fentrylk, frame, -1, op_errno, NULL);
 
     return 0;
@@ -10744,7 +10744,7 @@ dht_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret < 0 && op_errno != ENOTCONN) {
+        if (IS_ERROR(op_ret) && op_errno != ENOTCONN) {
             local->op_errno = op_errno;
             goto unlock;
         }
@@ -10790,7 +10790,7 @@ dht_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
     local->call_cnt = call_cnt;
 
     if (xdata) {
-        if (dict_set_int8(xdata, conf->xattr_name, 0) < 0)
+        if (IS_ERROR(dict_set_int8(xdata, conf->xattr_name, 0)))
             goto err;
     }
 
@@ -10884,7 +10884,7 @@ dht_notify(xlator_t *this, int event, void *data, ...)
                 }
             }
 
-            if (cnt == -1) {
+            if (IS_ERROR(cnt)) {
                 gf_msg_debug(this->name, 0,
                              "got GF_EVENT_CHILD_UP bad "
                              "subvolume %s",
@@ -10939,7 +10939,7 @@ dht_notify(xlator_t *this, int event, void *data, ...)
                 }
             }
 
-            if (cnt == -1) {
+            if (IS_ERROR(cnt)) {
                 gf_msg_debug(this->name, 0,
                              "got GF_EVENT_CHILD_DOWN bad "
                              "subvolume %s",
@@ -10970,7 +10970,7 @@ dht_notify(xlator_t *this, int event, void *data, ...)
                 }
             }
 
-            if (cnt == -1) {
+            if (IS_ERROR(cnt)) {
                 gf_msg_debug(this->name, 0,
                              "got GF_EVENT_CHILD_CONNECTING"
                              " bad subvolume %s",
@@ -11157,7 +11157,7 @@ dht_log_new_layout_for_dir_selfheal(xlator_t *this, loc_t *loc,
     ret = snprintf(string, sizeof(string), "Setting layout of %s with ",
                    loc->path);
 
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return;
 
     len += ret;
@@ -11180,7 +11180,7 @@ dht_log_new_layout_for_dir_selfheal(xlator_t *this, loc_t *loc,
                        layout->list[i].start, layout->list[i].stop,
                        layout->list[i].commit_hash);
 
-        if (ret < 0)
+        if (IS_ERROR(ret))
             return;
 
         len += ret;
@@ -11196,7 +11196,7 @@ dht_log_new_layout_for_dir_selfheal(xlator_t *this, loc_t *loc,
     ret = snprintf(output_string, len + 1, "Setting layout of %s with ",
                    loc->path);
 
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     off += ret;
@@ -11209,7 +11209,7 @@ dht_log_new_layout_for_dir_selfheal(xlator_t *this, loc_t *loc,
                        layout->list[i].start, layout->list[i].stop,
                        layout->list[i].commit_hash);
 
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto err;
 
         off += ret;

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -765,7 +765,8 @@ typedef struct dht_fd_ctx {
     GF_REF_DECL;
 } dht_fd_ctx_t;
 
-#define ENTRY_MISSING(op_ret, op_errno) (op_ret == -1 && op_errno == ENOENT)
+#define ENTRY_MISSING(op_ret, op_errno)                                        \
+    (IS_ERROR(op_ret) && (op_errno == ENOENT))
 
 #define is_revalidate(loc)                                                     \
     (dht_inode_ctx_layout_get((loc)->inode, this, NULL) == 0)

--- a/xlators/cluster/dht/src/dht-diskusage.c
+++ b/xlators/cluster/dht/src/dht-diskusage.c
@@ -32,7 +32,7 @@ dht_du_info_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     conf = this->private;
     prev = cookie;
 
-    if (op_ret == -1 || !statvfs) {
+    if (IS_ERROR(op_ret) || !statvfs) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno,
                DHT_MSG_GET_DISK_INFO_ERROR, "failed to get disk info from %s",
                prev->name);

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -63,7 +63,7 @@ __dht_fd_ctx_set(xlator_t *this, fd_t *fd, xlator_t *dst)
     value = (uint64_t)(uintptr_t)fd_ctx;
 
     ret = __fd_ctx_set(fd, this, value);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, 0, DHT_MSG_FD_CTX_SET_FAILED,
                 "fd=0x%p", fd, NULL);
         GF_REF_PUT(fd_ctx);
@@ -123,7 +123,7 @@ dht_fd_ctx_get(xlator_t *this, fd_t *fd)
     LOCK(&fd->lock);
     {
         ret = __fd_ctx_get(fd, this, &tmp_val);
-        if ((ret < 0) || (tmp_val == 0)) {
+        if (IS_ERROR(ret) || (tmp_val == 0)) {
             goto unlock;
         }
 
@@ -185,7 +185,7 @@ dht_inode_ctx_set_mig_info(xlator_t *this, inode_t *inode, xlator_t *src_subvol,
     value = (uint64_t)(uintptr_t)miginfo;
 
     ret = inode_ctx_set1(inode, this, &value);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         GF_REF_PUT(miginfo);
     }
 
@@ -204,7 +204,7 @@ dht_inode_ctx_get_mig_info(xlator_t *this, inode_t *inode,
     LOCK(&inode->lock);
     {
         ret = __inode_ctx_get1(inode, this, &tmp_miginfo);
-        if ((ret < 0) || (tmp_miginfo == 0)) {
+        if (IS_ERROR(ret) || (tmp_miginfo == 0)) {
             UNLOCK(&inode->lock);
             goto out;
         }
@@ -512,7 +512,7 @@ dht_check_and_open_fd_on_subvol_task(void *data)
     ret = syncop_open(subvol, &loc, (fd->flags & ~(O_CREAT | O_EXCL | O_TRUNC)),
                       fd, NULL, NULL);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_OPEN_FD_ON_DST_FAILED,
                 "fd=%p", fd, "flags=0%o", fd->flags, "gfid=%s",
                 uuid_utoa(fd->inode->gfid), "name=%s", subvol->name, NULL);
@@ -670,7 +670,7 @@ dht_get_subvol_from_id(xlator_t *this, int client_id)
     conf = this->private;
 
     ret = gf_asprintf(&sid, "%d", client_id);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, DHT_MSG_ASPRINTF_FAILED, NULL);
         goto out;
     }
@@ -1453,7 +1453,7 @@ dht_migration_complete_check_task(void *data)
         ret = syncop_open(dst_node, &tmp_loc,
                           (iter_fd->flags & ~(O_CREAT | O_EXCL | O_TRUNC)),
                           iter_fd, NULL, NULL);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_smsg(this->name, GF_LOG_ERROR, -ret,
                     DHT_MSG_OPEN_FD_ON_DST_FAILED, "id=%p", iter_fd,
                     "flags=0%o", iter_fd->flags, "path=%s", path, "name=%s",
@@ -1621,7 +1621,7 @@ dht_rebalance_inprogress_task(void *data)
         goto out;
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_GET_XATTR_FAILED,
                 "path=%s", local->loc.path, NULL);
         ret = -1;
@@ -1725,7 +1725,7 @@ dht_rebalance_inprogress_task(void *data)
         ret = syncop_open(dst_node, &tmp_loc,
                           (iter_fd->flags & ~(O_CREAT | O_EXCL | O_TRUNC)),
                           iter_fd, NULL, NULL);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_smsg(this->name, GF_LOG_ERROR, -ret,
                     DHT_MSG_OPEN_FD_ON_DST_FAILED, "fd=%p", iter_fd,
                     "flags=0%o", iter_fd->flags, "path=%s", path, "name=%s",

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -895,7 +895,7 @@ dht_last_up_subvol(xlator_t *this)
 
     LOCK(&conf->subvolume_lock);
     {
-        for (IS_SUCCESS(i = conf->subvolume_cnt - 1; i); i--) {
+        for (i = conf->subvolume_cnt - 1; i >= 0; i--) {
             if (conf->subvolume_status[i]) {
                 child = conf->subvolumes[i];
                 break;

--- a/xlators/cluster/dht/src/dht-helper.c
+++ b/xlators/cluster/dht/src/dht-helper.c
@@ -895,7 +895,7 @@ dht_last_up_subvol(xlator_t *this)
 
     LOCK(&conf->subvolume_lock);
     {
-        for (i = conf->subvolume_cnt - 1; i >= 0; i--) {
+        for (IS_SUCCESS(i = conf->subvolume_cnt - 1; i); i--) {
             if (conf->subvolume_status[i]) {
                 child = conf->subvolumes[i];
                 break;

--- a/xlators/cluster/dht/src/dht-inode-write.c
+++ b/xlators/cluster/dht/src/dht-inode-write.c
@@ -56,7 +56,7 @@ dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         return 0;
     }
 
-    if (op_ret == -1 && !dht_inode_missing(op_errno)) {
+    if (IS_ERROR(op_ret) && !dht_inode_missing(op_errno)) {
         local->op_errno = op_errno;
         local->op_ret = -1;
         gf_msg_debug(this->name, 0, "subvolume %s returned -1 (%s)", prev->name,
@@ -85,7 +85,7 @@ dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     dht_set_local_rebalance(this, local, NULL, prebuf, postbuf, xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
+    if (IS_ERROR((op_ret)) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -229,7 +229,7 @@ dht_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(writev, frame, -1, op_errno, NULL, NULL, NULL);
 
     return 0;
@@ -270,7 +270,7 @@ dht_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if (IS_ERROR((op_ret)) && !dht_inode_missing(op_errno)) {
         local->op_errno = op_errno;
         local->op_ret = -1;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -299,7 +299,7 @@ dht_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     dht_set_local_rebalance(this, local, NULL, prebuf, postbuf, xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
+    if (IS_ERROR((op_ret)) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -416,7 +416,7 @@ dht_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(truncate, frame, -1, op_errno, NULL, NULL, NULL);
 
     return 0;
@@ -458,7 +458,7 @@ dht_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(ftruncate, frame, -1, op_errno, NULL, NULL, NULL);
 
     return 0;
@@ -496,7 +496,7 @@ dht_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if (IS_ERROR((op_ret)) && !dht_inode_missing(op_errno)) {
         local->op_errno = op_errno;
         local->op_ret = -1;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -520,7 +520,7 @@ dht_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     dht_set_local_rebalance(this, local, NULL, prebuf, postbuf, xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
+    if (IS_ERROR((op_ret)) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -636,7 +636,7 @@ dht_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(fallocate, frame, -1, op_errno, NULL, NULL, NULL);
 
     return 0;
@@ -673,7 +673,7 @@ dht_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if (IS_ERROR((op_ret)) && !dht_inode_missing(op_errno)) {
         local->op_errno = op_errno;
         local->op_ret = -1;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -697,7 +697,7 @@ dht_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     dht_set_local_rebalance(this, local, NULL, prebuf, postbuf, xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
+    if (IS_ERROR((op_ret)) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -809,7 +809,7 @@ dht_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(discard, frame, -1, op_errno, NULL, NULL, NULL);
 
     return 0;
@@ -845,7 +845,7 @@ dht_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if (IS_ERROR((op_ret)) && !dht_inode_missing(op_errno)) {
         local->op_errno = op_errno;
         local->op_ret = -1;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -868,7 +868,7 @@ dht_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     dht_set_local_rebalance(this, local, NULL, prebuf, postbuf, xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
+    if (IS_ERROR((op_ret)) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -984,7 +984,7 @@ dht_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(zerofill, frame, -1, op_errno, NULL, NULL, NULL);
 
     return 0;
@@ -1013,7 +1013,7 @@ dht_file_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if (IS_ERROR((op_ret)) && !dht_inode_missing(op_errno)) {
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
                      prev->name);
         goto out;
@@ -1028,7 +1028,7 @@ dht_file_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local->rebalance.target_op_fn = dht_setattr2;
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
+    if (IS_ERROR((op_ret)) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
         dht_set_local_rebalance(this, local, NULL, prebuf, postbuf, xdata);
 
         ret = dht_rebalance_complete_check(this, frame);
@@ -1111,7 +1111,7 @@ dht_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             UNLOCK(&frame->lock);
             gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -1151,7 +1151,7 @@ dht_non_mds_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, op_errno, 0, 0, "subvolume %s returned -1",
                prev->name);
         goto post_unlock;
@@ -1197,7 +1197,7 @@ dht_mds_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     conf = this->private;
     mds_subvol = local->mds_subvol;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -1331,7 +1331,7 @@ dht_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc, struct iatt *stbuf,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(setattr, frame, -1, op_errno, NULL, NULL, NULL);
 
     return 0;
@@ -1399,7 +1399,7 @@ dht_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iatt *stbuf,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(fsetattr, frame, -1, op_errno, NULL, NULL, NULL);
 
     return 0;

--- a/xlators/cluster/dht/src/dht-layout.c
+++ b/xlators/cluster/dht/src/dht-layout.c
@@ -596,7 +596,7 @@ dht_layout_missing_dirs(dht_layout_t *layout)
 
     for (i = 0; i < layout->cnt; i++) {
         if ((layout->list[i].err == ENOENT) ||
-            ((layout->list[i].err == -1) && (layout->list[i].start == 0) &&
+            (IS_ERROR((layout->list[i].err)) && (layout->list[i].start == 0) &&
              (layout->list[i].stop == 0))) {
             missing++;
         }
@@ -618,7 +618,7 @@ dht_layout_normalize(xlator_t *this, loc_t *loc, dht_layout_t *layout)
     char gfid[GF_UUID_BUF_SIZE] = {0};
 
     ret = dht_layout_sort(layout);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, 0, DHT_MSG_LAYOUT_SORT_FAILED,
                 NULL);
         goto out;
@@ -691,7 +691,7 @@ dht_layout_dir_mismatch(xlator_t *this, dht_layout_t *layout, xlator_t *subvol,
         }
     }
 
-    if (pos == -1) {
+    if (IS_ERROR(pos)) {
         if (loc) {
             gf_msg_debug(this->name, 0, "%s - no layout info for subvolume %s",
                          loc ? loc->path : "path not found", subvol->name);
@@ -718,7 +718,7 @@ dht_layout_dir_mismatch(xlator_t *this, dht_layout_t *layout, xlator_t *subvol,
 
     dict_ret = dict_get_ptr(xattr, conf->xattr_name, &disk_layout_raw);
 
-    if (dict_ret < 0) {
+    if (IS_ERROR(dict_ret)) {
         if (err == 0 && layout->list[pos].stop) {
             if (loc) {
                 gf_smsg(this->name, GF_LOG_INFO, 0, DHT_MSG_DISK_LAYOUT_MISSING,

--- a/xlators/cluster/dht/src/dht-layout.c
+++ b/xlators/cluster/dht/src/dht-layout.c
@@ -25,7 +25,7 @@ dht_layout_new(xlator_t *this, int cnt)
     dht_conf_t *conf = NULL;
 
     REQUIRE(NULL != this);
-    REQUIRE(cnt >= 0);
+    REQUIRE(IS_SUCCESS(cnt));
 
     conf = this->private;
 
@@ -643,7 +643,7 @@ dht_layout_normalize(xlator_t *this, loc_t *loc, dht_layout_t *layout)
         ret = -1;
     }
 
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         missing_dirs = dht_layout_missing_dirs(layout);
         /* TODO During DHT selfheal rewrite (almost) find a better place
          * to detect this - probably in dht_layout_anomalies()

--- a/xlators/cluster/dht/src/dht-linkfile.c
+++ b/xlators/cluster/dht/src/dht-linkfile.c
@@ -137,7 +137,7 @@ dht_linkfile_create(call_frame_t *frame, fop_mknod_cbk_t linkfile_cbk,
 
     ret = dict_set_str(dict, conf->link_xattr_name, tovol->name);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(frame->this->name, GF_LOG_INFO, 0, DHT_MSG_CREATE_LINK_FAILED,
                 "path=%s", loc->path, "gfid=%s", gfid, NULL);
         goto out;
@@ -178,7 +178,7 @@ dht_linkfile_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     subvol = cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_uuid_unparse(local->loc.gfid, gfid);
         gf_smsg(this->name, GF_LOG_INFO, op_errno, DHT_MSG_UNLINK_FAILED,
                 "path=%s", local->loc.path, "gfid=%s", gfid, "subvolume=%s",
@@ -236,7 +236,7 @@ dht_linkfile_subvol(xlator_t *this, inode_t *inode, struct iatt *stbuf,
 
     ret = dict_get_ptr(xattr, conf->link_xattr_name, &volname);
 
-    if ((-1 == ret) || !volname)
+    if (IS_ERROR(ret) || !volname)
         goto out;
 
     for (i = 0; i < conf->subvolume_cnt; i++) {
@@ -318,7 +318,7 @@ dht_linkfile_attr_heal(call_frame_t *frame, xlator_t *this)
                xattr);
     ret = 0;
 out:
-    if ((ret < 0) && (copy))
+    if (IS_ERROR(ret) && (copy))
         DHT_STACK_DESTROY(copy);
 
     if (xattr)

--- a/xlators/cluster/dht/src/dht-lock.c
+++ b/xlators/cluster/dht/src/dht-lock.c
@@ -270,7 +270,7 @@ dht_local_entrylk_init(call_frame_t *frame, dht_lock_t **lk_array, int lk_count,
 
     ret = dht_lock_order_requests(local->lock[0].ns.directory_ns.locks,
                                   local->lock[0].ns.directory_ns.lk_count);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = 0;
@@ -313,7 +313,7 @@ dht_unlock_entrylk_done(call_frame_t *frame, void *cookie, xlator_t *this,
     gf_uuid_unparse(local->lock[0].ns.directory_ns.locks[0]->loc.inode->gfid,
                     gfid);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, op_errno,
                 DHT_MSG_UNLOCK_GFID_FAILED, "gfid=%s", gfid,
                 "DHT_LAYOUT_HEAL_DOMAIN", NULL);
@@ -337,7 +337,7 @@ dht_unlock_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     uuid_utoa_r(local->lock[0].ns.directory_ns.locks[lk_index]->loc.gfid, gfid);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, op_errno, DHT_MSG_UNLOCKING_FAILED,
                 "name=%s",
                 local->lock[0].ns.directory_ns.locks[lk_index]->xl->name,
@@ -384,7 +384,7 @@ dht_unlock_entrylk(call_frame_t *frame, dht_lock_t **lk_array, int lk_count,
     }
 
     ret = dht_local_entrylk_init(lock_frame, lk_array, lk_count, entrylk_cbk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, 0,
                 DHT_MSG_LOCAL_LOCKS_STORE_FAILED_UNLOCKING_FOLLOWING_ENTRYLK,
                 NULL);
@@ -607,7 +607,7 @@ dht_blocking_entrylk(call_frame_t *frame, dht_lock_t **lk_array, int lk_count,
         goto out;
 
     ret = dht_local_entrylk_init(lock_frame, lk_array, lk_count, entrylk_cbk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -649,7 +649,7 @@ dht_local_inodelk_init(call_frame_t *frame, dht_lock_t **lk_array, int lk_count,
 
     ret = dht_lock_order_requests(local->lock[0].layout.my_layout.locks,
                                   local->lock[0].layout.my_layout.lk_count);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = 0;
@@ -692,7 +692,7 @@ dht_unlock_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     lk_index = (long)cookie;
 
     local = frame->local;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->lock[0].layout.my_layout.locks[lk_index]->loc.gfid,
                     gfid);
 
@@ -723,7 +723,7 @@ dht_unlock_inodelk_done(call_frame_t *frame, void *cookie, xlator_t *this,
     gf_uuid_unparse(local->lock[0].layout.my_layout.locks[0]->loc.inode->gfid,
                     gfid);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, op_errno,
                 DHT_MSG_UNLOCK_GFID_FAILED, "DHT_LAYOUT_HEAL_DOMAIN gfid=%s",
                 gfid, NULL);
@@ -766,7 +766,7 @@ dht_unlock_inodelk(call_frame_t *frame, dht_lock_t **lk_array, int lk_count,
     }
 
     ret = dht_local_inodelk_init(lock_frame, lk_array, lk_count, inodelk_cbk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, 0,
                 DHT_MSG_LOCAL_LOCKS_STORE_FAILED_UNLOCKING_FOLLOWING_ENTRYLK,
                 NULL);
@@ -909,7 +909,7 @@ dht_nonblocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     lk_index = (long)cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->lock[0].layout.my_layout.op_ret = -1;
         local->lock[0].layout.my_layout.op_errno = op_errno;
 
@@ -935,7 +935,7 @@ dht_nonblocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 out:
     call_cnt = dht_frame_return(frame);
     if (is_last_call(call_cnt)) {
-        if (local->lock[0].layout.my_layout.op_ret < 0) {
+        if (IS_ERROR(local->lock[0].layout.my_layout.op_ret)) {
             dht_inodelk_cleanup(frame);
             return 0;
         }
@@ -966,7 +966,7 @@ dht_nonblocking_inodelk(call_frame_t *frame, dht_lock_t **lk_array,
         goto out;
 
     ret = dht_local_inodelk_init(lock_frame, lk_array, lk_count, inodelk_cbk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -1148,7 +1148,7 @@ dht_blocking_inodelk(call_frame_t *frame, dht_lock_t **lk_array, int lk_count,
     }
 
     ret = dht_local_inodelk_init(lock_frame, lk_array, lk_count, inodelk_cbk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_uuid_unparse(tmp_local->loc.gfid, gfid);
         gf_smsg("dht", GF_LOG_ERROR, ENOMEM, DHT_MSG_LOCAL_LOCK_INIT_FAILED,
                 "gfid=%s", gfid, "path=%s", tmp_local->loc.path, NULL);
@@ -1213,7 +1213,7 @@ dht_blocking_entrylk_after_inodelk(call_frame_t *frame, void *cookie,
     local = frame->local;
     entrylk = &local->current->ns.directory_ns;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = -1;
         local->op_errno = op_errno;
         goto err;
@@ -1229,7 +1229,7 @@ dht_blocking_entrylk_after_inodelk(call_frame_t *frame, void *cookie,
     ret = dht_blocking_entrylk(frame, lk_array, count,
                                dht_protect_namespace_cbk);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->op_ret = -1;
         local->op_errno = EIO;
         gf_smsg(this->name, GF_LOG_WARNING, local->op_errno,
@@ -1358,7 +1358,7 @@ dht_protect_namespace(call_frame_t *frame, loc_t *loc, xlator_t *subvol,
     lk_array = inodelk->locks;
     ret = dht_blocking_inodelk(frame, lk_array, count,
                                dht_blocking_entrylk_after_inodelk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->op_errno = EIO;
         gf_smsg(this->name, GF_LOG_WARNING, local->op_errno,
                 DHT_MSG_BLOCK_INODELK_FAILED, "fop=%s", gf_fop_list[local->fop],

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -1153,7 +1153,7 @@ __dht_rebalance_migrate_data(xlator_t *this, gf_defrag_info_t *defrag,
         iobref_unref(iobref);
     GF_FREE(vector);
 
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         ret = 0;
     else
         ret = -1;

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -174,7 +174,7 @@ dht_write_with_holes(xlator_t *to, fd_t *fd, struct iovec *vec, int count,
                     to, fd, (buf + tmp_offset), (start_idx - tmp_offset),
                     (offset + tmp_offset), iobref, 0, NULL, NULL);
                 /* 'path' will be logged in calling function */
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     gf_log(THIS->name, GF_LOG_WARNING, "failed to write (%s)",
                            strerror(-ret));
                     *fop_errno = -ret;
@@ -192,7 +192,7 @@ dht_write_with_holes(xlator_t *to, fd_t *fd, struct iovec *vec, int count,
             ret = syncop_write(to, fd, (buf + tmp_offset),
                                (buf_len - tmp_offset), (offset + tmp_offset),
                                iobref, 0, NULL, NULL);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 /* 'path' will be logged in calling function */
                 gf_log(THIS->name, GF_LOG_WARNING, "failed to write (%s)",
                        strerror(-ret));
@@ -708,7 +708,7 @@ __dht_rebalance_create_dst_file(xlator_t *this, xlator_t *to, xlator_t *from,
             goto out;
         }
     }
-    if ((ret < 0) && (-ret != ENOENT)) {
+    if (IS_ERROR(ret) && (-ret != ENOENT)) {
         /* File exists in destination, but not accessible */
         gf_msg(THIS->name, GF_LOG_WARNING, -ret, DHT_MSG_MIGRATE_FILE_FAILED,
                "%s: failed to lookup file", loc->path);
@@ -724,7 +724,7 @@ __dht_rebalance_create_dst_file(xlator_t *this, xlator_t *to, xlator_t *from,
          * File already present, just open the file.
          */
         ret = syncop_open(to, loc, O_RDWR, fd, NULL, NULL);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_MIGRATE_FILE_FAILED,
                    "failed to open %s on %s", loc->path, to->name);
             *fop_errno = -ret;
@@ -734,7 +734,7 @@ __dht_rebalance_create_dst_file(xlator_t *this, xlator_t *to, xlator_t *from,
     } else {
         ret = syncop_create(to, loc, O_RDWR, DHT_LINKFILE_MODE, fd, &new_stbuf,
                             dict, NULL);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_MIGRATE_FILE_FAILED,
                    "failed to create %s on %s", loc->path, to->name);
             *fop_errno = -ret;
@@ -780,7 +780,7 @@ __dht_rebalance_create_dst_file(xlator_t *this, xlator_t *to, xlator_t *from,
 
     ret = syncop_fsetattr(to, fd, stbuf, (GF_SET_ATTR_UID | GF_SET_ATTR_GID),
                           NULL, NULL, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         *fop_errno = -ret;
         gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_MIGRATE_FILE_FAILED,
                "chown failed for %s on %s", loc->path, to->name);
@@ -790,7 +790,7 @@ __dht_rebalance_create_dst_file(xlator_t *this, xlator_t *to, xlator_t *from,
     if (stbuf->ia_size > 0) {
         if (conf->use_fallocate && !file_has_holes) {
             ret = syncop_fallocate(to, fd, 0, 0, stbuf->ia_size, NULL, NULL);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 if (ret == -EOPNOTSUPP || ret == -EINVAL || ret == -ENOSYS) {
                     conf->use_fallocate = _gf_false;
                 } else {
@@ -805,7 +805,7 @@ __dht_rebalance_create_dst_file(xlator_t *this, xlator_t *to, xlator_t *from,
                      * in some cases
                      */
                     ret2 = syncop_ftruncate(to, fd, 0, NULL, NULL, NULL, NULL);
-                    if (ret2 < 0) {
+                    if (IS_ERROR(ret2)) {
                         gf_msg(this->name, GF_LOG_WARNING, -ret2,
                                DHT_MSG_MIGRATE_FILE_FAILED,
                                "ftruncate failed for "
@@ -818,7 +818,7 @@ __dht_rebalance_create_dst_file(xlator_t *this, xlator_t *to, xlator_t *from,
         } else {
             ret = syncop_ftruncate(to, fd, stbuf->ia_size, NULL, NULL, NULL,
                                    NULL);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 *fop_errno = -ret;
                 gf_msg(this->name, GF_LOG_WARNING, -ret,
                        DHT_MSG_MIGRATE_FILE_FAILED,
@@ -1082,7 +1082,7 @@ __dht_rebalance_migrate_data(xlator_t *this, gf_defrag_info_t *defrag,
 
         ret = syncop_readv(from, src, read_size, offset, 0, &vector, &count,
                            &iobref, NULL, NULL, NULL);
-        if (!ret || (ret < 0)) {
+        if (!ret || IS_ERROR(ret)) {
             if (!ret) {
                 /* File was probably truncated*/
                 ret = -1;
@@ -1131,12 +1131,12 @@ __dht_rebalance_migrate_data(xlator_t *this, gf_defrag_info_t *defrag,
             }
             ret = syncop_writev(to, dst, vector, count, offset, iobref, 0, NULL,
                                 NULL, xdata, NULL);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 *fop_errno = -ret;
             }
         }
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             break;
         }
 
@@ -1192,7 +1192,7 @@ __dht_rebalance_open_src_file(xlator_t *this, xlator_t *from, xlator_t *to,
     }
 
     ret = syncop_open(from, loc, O_RDWR, fd, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_MIGRATE_FILE_FAILED,
                "failed to open file %s on %s", loc->path, from->name);
         *fop_errno = -ret;
@@ -1294,7 +1294,7 @@ migrate_special_files(xlator_t *this, xlator_t *from, xlator_t *to, loc_t *loc,
 
     /* check in the destination if the file is link file */
     ret = syncop_lookup(to, loc, &stbuf, NULL, dict, &rsp_dict);
-    if ((ret < 0) && (-ret != ENOENT)) {
+    if (IS_ERROR(ret) && (-ret != ENOENT)) {
         gf_msg(this->name, GF_LOG_WARNING, -ret, DHT_MSG_MIGRATE_FILE_FAILED,
                "%s: lookup failed", loc->path);
         *fop_errno = -ret;
@@ -1343,7 +1343,7 @@ migrate_special_files(xlator_t *this, xlator_t *from, xlator_t *to, loc_t *loc,
     if (IA_ISLNK(buf->ia_type)) {
         /* Handle symlinks separately */
         ret = syncop_readlink(from, loc, &link, buf->ia_size, NULL, NULL);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, -ret,
                    DHT_MSG_MIGRATE_FILE_FAILED,
                    "%s: readlink on symlink failed", loc->path);
@@ -1424,7 +1424,7 @@ __dht_migration_cleanup_src_file(xlator_t *this, loc_t *loc, fd_t *fd,
 
     /*Revert source mode and xattr changes*/
     ret = syncop_fstat(from, fd, &new_stbuf, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /* Failed to get the stat info */
         gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_MIGRATE_FILE_FAILED,
                "Migrate file cleanup failed: failed to fstat "
@@ -1602,7 +1602,7 @@ dht_migrate_file(xlator_t *this, loc_t *loc, xlator_t *from, xlator_t *to,
      */
 
     ret = dht_build_parent_loc(this, &parent_loc, loc, fop_errno);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -1;
         gf_msg(this->name, GF_LOG_WARNING, *fop_errno,
                DHT_MSG_MIGRATE_FILE_FAILED,
@@ -1638,7 +1638,7 @@ dht_migrate_file(xlator_t *this, loc_t *loc, xlator_t *from, xlator_t *to,
      */
     ret = syncop_inodelk(from, DHT_FILE_MIGRATE_DOMAIN, &tmp_loc, F_SETLKW,
                          &flock, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         *fop_errno = -ret;
         ret = -1;
         gf_msg(this->name, GF_LOG_WARNING, *fop_errno,
@@ -1657,7 +1657,7 @@ dht_migrate_file(xlator_t *this, loc_t *loc, xlator_t *from, xlator_t *to,
      */
     ret = syncop_entrylk(hashed_subvol, DHT_ENTRY_SYNC_DOMAIN, &parent_loc,
                          loc->name, ENTRYLK_LOCK, ENTRYLK_WRLCK, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         *fop_errno = -ret;
         ret = -1;
         gf_msg(this->name, GF_LOG_WARNING, *fop_errno,
@@ -1784,7 +1784,7 @@ dht_migrate_file(xlator_t *this, loc_t *loc, xlator_t *from, xlator_t *to,
 
     /* TODO: move all xattr related operations to fd based operations */
     ret = syncop_listxattr(from, loc, &xattr, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         *fop_errno = -ret;
         gf_msg(this->name, GF_LOG_WARNING, *fop_errno,
                DHT_MSG_MIGRATE_FILE_FAILED,
@@ -1807,7 +1807,7 @@ dht_migrate_file(xlator_t *this, loc_t *loc, xlator_t *from, xlator_t *to,
      * set on the dst could cause data corruption
      */
     ret = syncop_fsetxattr(to, dst_fd, xattr, 0, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         *fop_errno = -ret;
         gf_msg(this->name, GF_LOG_WARNING, -ret, DHT_MSG_MIGRATE_FILE_FAILED,
                "%s: failed to set xattr on %s", loc->path, to->name);
@@ -1863,7 +1863,7 @@ dht_migrate_file(xlator_t *this, loc_t *loc, xlator_t *from, xlator_t *to,
     /* Phase 2 - Data-Migration Complete, Housekeeping updates pending */
 
     ret = syncop_fstat(from, src_fd, &new_stbuf, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /* Failed to get the stat info */
         gf_msg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_MIGRATE_FILE_FAILED,
                "Migrate file failed: failed to fstat file %s on %s ", loc->path,
@@ -2059,7 +2059,7 @@ dht_migrate_file(xlator_t *this, loc_t *loc, xlator_t *from, xlator_t *to,
                 ret = syncop_fsetattr(old_target, linkto_fd, &stbuf,
                                       (GF_SET_ATTR_UID | GF_SET_ATTR_GID), NULL,
                                       NULL, NULL, NULL);
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     *fop_errno = -ret;
                     gf_msg(this->name, GF_LOG_ERROR, -ret,
                            DHT_MSG_MIGRATE_FILE_FAILED,
@@ -2085,7 +2085,7 @@ dht_migrate_file(xlator_t *this, loc_t *loc, xlator_t *from, xlator_t *to,
     /* Set only the Posix ACLs this time */
     ret = syncop_getxattr(from, loc, &xattr, POSIX_ACL_ACCESS_XATTR, NULL,
                           NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if ((-ret != ENODATA) && (-ret != ENOATTR)) {
             gf_msg(this->name, GF_LOG_WARNING, -ret,
                    DHT_MSG_MIGRATE_FILE_FAILED,
@@ -2096,7 +2096,7 @@ dht_migrate_file(xlator_t *this, loc_t *loc, xlator_t *from, xlator_t *to,
         }
     } else {
         ret = syncop_setxattr(to, loc, xattr, 0, NULL, NULL);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             /* Potential problem here where Posix ACLs will
              * not be set on the target file */
 
@@ -2266,7 +2266,7 @@ out:
 
         lk_ret = syncop_inodelk(from, DHT_FILE_MIGRATE_DOMAIN, &tmp_loc,
                                 F_SETLK, &flock, NULL, NULL);
-        if (lk_ret < 0) {
+        if (IS_ERROR(lk_ret)) {
             gf_msg(this->name, GF_LOG_WARNING, -lk_ret,
                    DHT_MSG_MIGRATE_FILE_FAILED,
                    "%s: failed to unlock file on %s", loc->path, from->name);
@@ -2277,7 +2277,7 @@ out:
         lk_ret = syncop_entrylk(hashed_subvol, DHT_ENTRY_SYNC_DOMAIN,
                                 &parent_loc, loc->name, ENTRYLK_UNLOCK,
                                 ENTRYLK_UNLOCK, NULL, NULL);
-        if (lk_ret < 0) {
+        if (IS_ERROR(lk_ret)) {
             gf_msg(this->name, GF_LOG_WARNING, -lk_ret,
                    DHT_MSG_MIGRATE_FILE_FAILED,
                    "%s: failed to unlock entrylk on %s", loc->path,
@@ -2289,7 +2289,7 @@ out:
         plock.l_type = F_UNLCK;
         lk_ret = syncop_lk(from, src_fd, F_SETLK, &plock, NULL, NULL);
 
-        if (lk_ret < 0) {
+        if (IS_ERROR(lk_ret)) {
             gf_msg(this->name, GF_LOG_WARNING, -lk_ret,
                    DHT_MSG_MIGRATE_FILE_FAILED,
                    "%s: failed to unlock file on %s", loc->path, from->name);
@@ -2353,7 +2353,7 @@ rebalance_task_completion(int op_ret, call_frame_t *sync_frame, void *data)
 {
     int32_t op_errno = EINVAL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Failure of migration process, mostly due to write process.
            as we can't preserve the exact errno, lets say there was
            no space to migrate-data
@@ -2589,7 +2589,7 @@ gf_defrag_should_i_migrate(xlator_t *this, int local_subvol_index, uuid_t gfid)
             /* Fall back to the first non-null index */
             index = dht_get_first_non_null_index(entry);
 
-            if (index == -1) {
+            if (IS_ERROR(index)) {
                 /* None of the bricks in the subvol are up.
                  * CHILD_DOWN will kill the process soon */
 
@@ -2839,7 +2839,7 @@ gf_defrag_migrate_single_file(void *opaque)
 
         ret = 0;
         goto out;
-    } else if (ret < 0) {
+    } else if (IS_ERROR(ret)) {
         if (fop_errno != EEXIST) {
             gf_msg(this->name, GF_LOG_ERROR, fop_errno,
                    DHT_MSG_MIGRATE_FILE_FAILED, "migrate-data failed for %s",
@@ -3081,7 +3081,7 @@ int static gf_defrag_get_entry(xlator_t *this, int i,
             goto out;
         }
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, -ret,
                    DHT_MSG_MIGRATE_DATA_FAILED,
                    "Readdirp failed. Aborting data migration for "
@@ -3731,7 +3731,7 @@ gf_defrag_fix_layout(xlator_t *this, gf_defrag_info_t *defrag, loc_t *loc,
 
     while ((ret = syncop_readdirp(this, fd, 131072, offset, &entries, NULL,
                                   NULL)) != 0) {
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             if (-ret == ENOENT || -ret == ESTALE) {
                 if (conf->decommission_subvols_cnt) {
                     defrag->total_failures++;

--- a/xlators/cluster/dht/src/dht-rename.c
+++ b/xlators/cluster/dht/src/dht-rename.c
@@ -1525,7 +1525,7 @@ dht_rename_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->op_errno = ENOENT;
     }
 
-    if (IS_SUCCESS(!local->is_linkfile && (op_ret)) &&
+    if (!local->is_linkfile && IS_SUCCESS(op_ret) &&
         gf_uuid_compare(loc->gfid, stbuf->ia_gfid)) {
         gf_uuid_unparse(loc->gfid, gfid_local);
         gf_uuid_unparse(stbuf->ia_gfid, gfid_server);

--- a/xlators/cluster/dht/src/dht-rename.c
+++ b/xlators/cluster/dht/src/dht-rename.c
@@ -70,7 +70,7 @@ dht_rename_dir_unlock_dst(call_frame_t *frame, xlator_t *this)
     op_ret = dht_unlock_inodelk(frame, local->lock[1].ns.parent_layout.locks,
                                 local->lock[1].ns.parent_layout.lk_count,
                                 dht_rename_unlock_cbk);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -125,7 +125,7 @@ dht_rename_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     subvol_cnt = dht_subvol_cnt(this, prev);
     local->ret_cache[subvol_cnt] = op_ret;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_uuid_unparse(local->loc.inode->gfid, gfid);
 
         gf_msg(this->name, GF_LOG_INFO, op_errno, DHT_MSG_RENAME_FAILED,
@@ -212,7 +212,7 @@ dht_rename_hashed_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_uuid_unparse(local->loc.inode->gfid, gfid);
 
         gf_msg(this->name, GF_LOG_INFO, op_errno, DHT_MSG_RENAME_FAILED,
@@ -267,7 +267,7 @@ dht_rename_dir_do(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret == -1)
+    if (IS_ERROR(local->op_ret))
         goto err;
 
     local->op_ret = 0;
@@ -322,7 +322,7 @@ dht_rename_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_uuid_unparse(local->loc.inode->gfid, gfid);
         gf_msg(this->name, GF_LOG_INFO, op_errno, DHT_MSG_OPENDIR_FAILED,
                "opendir on %s for %s failed,(gfid = %s) ", prev->name,
@@ -359,7 +359,7 @@ dht_rename_dir_lock2_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     conf = this->private;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -418,7 +418,7 @@ dht_rename_dir_lock1_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -447,7 +447,7 @@ dht_rename_dir_lock1_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
     ret = dht_protect_namespace(frame, loc, subvol, &local->current->ns,
                                 dht_rename_dir_lock2_cbk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = EINVAL;
         goto err;
     }
@@ -597,7 +597,7 @@ dht_rename_dir(call_frame_t *frame, xlator_t *this)
      */
     ret = dht_protect_namespace(frame, loc, subvol, &local->current->ns,
                                 dht_rename_dir_lock1_cbk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = EINVAL;
         goto err;
     }
@@ -712,7 +712,7 @@ dht_rename_unlock(call_frame_t *frame, xlator_t *this)
     inodelk_wrapper.lk_count = local->rename_inodelk_bc_count;
 
     op_ret = dht_unlock_inodelk_wrapper(frame, &inodelk_wrapper);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -779,7 +779,7 @@ dht_rename_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     this_call_cnt = dht_frame_return(frame);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, DHT_MSG_UNLINK_FAILED,
                "%s: Rename: unlink on %s failed ", local->loc.path, prev->name);
     }
@@ -1018,7 +1018,7 @@ dht_rename_links_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     main_frame = local->main_frame;
 
     /* TODO: Handle this case in lookup-optimize */
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, DHT_MSG_CREATE_LINK_FAILED,
                "link/file %s on %s failed", local->loc.path, prev->name);
     }
@@ -1076,7 +1076,7 @@ dht_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
      * lookup, the first case by a rebalance, like for all stale linkto
      * files */
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Critical failure: unable to rename the cached file */
         if (prev == src_cached) {
             gf_msg(this->name, GF_LOG_WARNING, op_errno, DHT_MSG_RENAME_FAILED,
@@ -1209,7 +1209,7 @@ dht_rename_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg_debug(this->name, 0, "link/file on %s failed (%s)", prev->name,
                      strerror(op_errno));
         local->op_ret = -1;
@@ -1218,7 +1218,7 @@ dht_rename_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     } else
         dht_iatt_merge(this, &local->stbuf, stbuf);
 
-    if (local->op_ret == -1)
+    if (IS_ERROR(local->op_ret))
         goto cleanup;
 
     dht_do_rename(frame);
@@ -1247,7 +1247,7 @@ dht_rename_linkto_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     prev = cookie;
     src_cached = local->src_cached;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg_debug(this->name, 0, "link/file on %s failed (%s)", prev->name,
                      strerror(op_errno));
         local->op_ret = -1;
@@ -1297,14 +1297,14 @@ dht_rename_unlink_links_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
 
-    if ((op_ret == -1) && (op_errno != ENOENT)) {
+    if (IS_ERROR((op_ret)) && (op_errno != ENOENT)) {
         gf_msg_debug(this->name, 0, "unlink of %s on %s failed (%s)",
                      local->loc2.path, prev->name, strerror(op_errno));
         local->op_ret = -1;
         local->op_errno = op_errno;
     }
 
-    if (local->op_ret == -1)
+    if (IS_ERROR(local->op_ret))
         goto cleanup;
 
     dht_do_rename(frame);
@@ -1488,7 +1488,7 @@ dht_rename_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if (is_src) {
             /* The meaning of is_linkfile is overloaded here. For locking
              * to work properly both rebalance and rename should acquire
@@ -1572,7 +1572,7 @@ dht_rename_file_lock1_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -1604,7 +1604,7 @@ dht_rename_file_lock1_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     ret = dht_protect_namespace(frame, loc, subvol, &local->current->ns,
                                 dht_rename_lock_cbk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = EINVAL;
         goto err;
     }
@@ -1630,7 +1630,7 @@ dht_rename_file_protect_namespace(call_frame_t *frame, void *cookie,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -1661,7 +1661,7 @@ dht_rename_file_protect_namespace(call_frame_t *frame, void *cookie,
 
     ret = dht_protect_namespace(frame, loc, subvol, &local->current->ns,
                                 dht_rename_file_lock1_cbk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = EINVAL;
         goto err;
     }
@@ -1693,7 +1693,7 @@ dht_rename_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     conf = this->private;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -1722,7 +1722,7 @@ dht_rename_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     op_ret = dict_set_uint32(xattr_req, conf->link_xattr_name, 256);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = -1;
         local->op_errno = -op_ret;
         goto done;
@@ -1848,7 +1848,7 @@ dht_rename_lock(call_frame_t *frame)
      */
     ret = dht_blocking_inodelk(frame, lk_array, count,
                                dht_rename_file_protect_namespace);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->rename_inodelk_backward_compatible = NULL;
         local->rename_inodelk_bc_count = 0;
         goto err;
@@ -1932,7 +1932,7 @@ dht_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     local->cached_subvol = NULL;
 
     ret = loc_copy(&local->loc2, newloc);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         op_errno = ENOMEM;
         goto err;
     }
@@ -1959,7 +1959,7 @@ dht_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     } else {
         local->op_ret = 0;
         ret = dht_rename_lock(frame);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             op_errno = ENOMEM;
             goto err;
         }
@@ -1968,7 +1968,7 @@ dht_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL,
                      NULL);
 

--- a/xlators/cluster/dht/src/dht-rename.c
+++ b/xlators/cluster/dht/src/dht-rename.c
@@ -1446,7 +1446,7 @@ dht_rename_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     else
         loc = &local->loc2;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         if (is_src)
             local->src_cached = dht_subvol_get_cached(this, local->loc.inode);
         else {
@@ -1525,7 +1525,7 @@ dht_rename_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->op_errno = ENOENT;
     }
 
-    if (!local->is_linkfile && (op_ret >= 0) &&
+    if (IS_SUCCESS(!local->is_linkfile && (op_ret)) &&
         gf_uuid_compare(loc->gfid, stbuf->ia_gfid)) {
         gf_uuid_unparse(loc->gfid, gfid_local);
         gf_uuid_unparse(stbuf->ia_gfid, gfid_server);

--- a/xlators/cluster/dht/src/dht-selfheal.c
+++ b/xlators/cluster/dht/src/dht-selfheal.c
@@ -143,7 +143,7 @@ dht_refresh_layout_done(call_frame_t *frame)
     should_heal = local->selfheal.should_heal;
 
     ret = dht_layout_sort(refreshed);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, 0,
                 DHT_MSG_LAYOUT_SORT_FAILED, NULL);
         goto err;
@@ -198,7 +198,7 @@ dht_refresh_layout_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         dht_iatt_merge(this, &local->stbuf, stbuf);
 
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             gf_uuid_unparse(local->loc.gfid, gfid);
             local->op_errno = op_errno;
             gf_smsg(this->name, GF_LOG_ERROR, op_errno,
@@ -319,7 +319,7 @@ dht_selfheal_layout_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto err;
     }
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
         goto err;
     }
@@ -596,7 +596,7 @@ dht_selfheal_layout_lock(call_frame_t *frame, dht_layout_t *layout,
 
     ret = dht_blocking_inodelk(frame, lk_array, count,
                                dht_selfheal_layout_lock_cbk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->lock[0].layout.my_layout.locks = NULL;
         local->lock[0].layout.my_layout.lk_count = 0;
         goto err;
@@ -641,7 +641,7 @@ dht_selfheal_dir_xattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     ret = dict_get_bin(xdata, DHT_IATT_IN_XDATA_KEY, (void **)&stbuf);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_uuid_unparse(local->loc.gfid, gfid);
         gf_msg_debug(this->name, 0,
                      "key = %s not present in dict"
@@ -724,7 +724,7 @@ dht_selfheal_dir_xattr_persubvol(call_frame_t *frame, loc_t *loc,
         goto err;
 
     ret = dict_set_str(xdata, GLUSTERFS_INTERNAL_FOP_KEY, "yes");
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, 0, DHT_MSG_DICT_SET_FAILED,
                 "path=%s", loc->path, "key=%s", GLUSTERFS_INTERNAL_FOP_KEY,
                 "gfid=%s", gfid, NULL);
@@ -732,7 +732,7 @@ dht_selfheal_dir_xattr_persubvol(call_frame_t *frame, loc_t *loc,
     }
 
     ret = dict_set_int8(xdata, DHT_IATT_IN_XDATA_KEY, 1);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, 0, DHT_MSG_DICT_SET_FAILED,
                 "path=%s", loc->path, "key=%s", DHT_IATT_IN_XDATA_KEY,
                 "gfid=%s", gfid, NULL);
@@ -742,7 +742,7 @@ dht_selfheal_dir_xattr_persubvol(call_frame_t *frame, loc_t *loc,
     gf_uuid_unparse(loc->inode->gfid, gfid);
 
     ret = dht_disk_layout_extract(this, layout, i, &disk_layout);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, 0,
                 DHT_MSG_DIR_SELFHEAL_XATTR_FAILED,
                 "extract-disk-layout-failed, path=%s", loc->path, "subvol=%s",
@@ -751,7 +751,7 @@ dht_selfheal_dir_xattr_persubvol(call_frame_t *frame, loc_t *loc,
     }
 
     ret = dict_set_bin(xattr, conf->xattr_name, disk_layout, 4 * 4);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, 0,
                 DHT_MSG_DIR_SELFHEAL_XATTR_FAILED, "path=%s", loc->path,
                 "subvol=%s", subvol->name,
@@ -964,7 +964,7 @@ dht_selfheal_dir_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                        dht_selfheal_dir_xattr,
                                        dht_should_heal_layout);
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             dht_selfheal_dir_finish(frame, this, -1, 1);
         }
     }
@@ -995,7 +995,7 @@ dht_selfheal_dir_setattr(call_frame_t *frame, loc_t *loc, struct iatt *stbuf,
      */
 
     for (i = 0; i < layout->cnt; i++) {
-        if (layout->list[i].err == -1)
+        if (IS_ERROR(layout->list[i].err))
             missing_attr++;
     }
 
@@ -1010,7 +1010,7 @@ dht_selfheal_dir_setattr(call_frame_t *frame, loc_t *loc, struct iatt *stbuf,
                                        dht_selfheal_dir_xattr,
                                        dht_should_heal_layout);
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             dht_selfheal_dir_finish(frame, this, -1, 1);
         }
 
@@ -1047,7 +1047,7 @@ dht_selfheal_dir_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     prev = cookie;
     subvol = prev;
 
-    if ((op_ret == 0) || ((op_ret == -1) && (op_errno == EEXIST))) {
+    if ((op_ret == 0) || (IS_ERROR(op_ret) && (op_errno == EEXIST))) {
         for (i = 0; i < layout->cnt; i++) {
             if (layout->list[i].xlator == subvol) {
                 layout->list[i].err = -1;
@@ -1186,7 +1186,7 @@ dht_selfheal_dir_mkdir_lookup_cbk(call_frame_t *frame, void *cookie,
     LOCK(&frame->lock);
     {
         index = dht_layout_index_for_subvol(layout, prev);
-        if ((op_ret < 0) && (op_errno == ENOENT || op_errno == ESTALE)) {
+        if (IS_ERROR(op_ret) && (op_errno == ENOENT || op_errno == ESTALE)) {
             local->selfheal.hole_cnt = !local->selfheal.hole_cnt
                                            ? 1
                                            : local->selfheal.hole_cnt + 1;
@@ -1270,7 +1270,7 @@ dht_selfheal_dir_mkdir_lock_cbk(call_frame_t *frame, void *cookie,
 
     local->call_cnt = conf->subvolume_cnt;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         /* We get this error when the directory entry was not created
          * on a newky attached tier subvol. Hence proceed and do mkdir
          * on the tier subvol.
@@ -1388,7 +1388,7 @@ dht_selfheal_dir_mkdir(call_frame_t *frame, loc_t *loc, dht_layout_t *layout,
                                 &local->current->ns,
                                 dht_selfheal_dir_mkdir_lock_cbk);
 
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     return 0;
@@ -1892,7 +1892,7 @@ dht_selfheal_new_directory(call_frame_t *frame, dht_selfheal_dir_cbk_t dir_cbk,
                                    dht_should_heal_layout);
 
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         dir_cbk(frame, NULL, frame->this, -1, op_errno, NULL);
     }
 
@@ -2022,7 +2022,7 @@ dht_selfheal_directory(call_frame_t *frame, dht_selfheal_dir_cbk_t dir_cbk,
     }
 
     ret = dht_selfheal_dir_mkdir(frame, loc, layout, 0);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = 0;
         goto sorry_no_fix;
     }
@@ -2124,7 +2124,7 @@ dht_dir_heal_xattrs(void *data)
 
     ret = syncop_listxattr(local->mds_subvol, &local->loc, &mds_xattr, NULL,
                            NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, -ret, DHT_MSG_LIST_XATTRS_FAILED,
                 "path=%s", local->loc.path, "name=%s", local->mds_subvol->name,
                 NULL);
@@ -2318,7 +2318,7 @@ dht_update_commit_hash_for_layout_unlock(call_frame_t *frame, xlator_t *this)
     ret = dht_unlock_inodelk(frame, local->lock[0].layout.my_layout.locks,
                              local->lock[0].layout.my_layout.lk_count,
                              dht_update_commit_hash_for_layout_done);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /* preserve oldest error, just ... */
         if (!local->op_ret) {
             local->op_errno = errno;
@@ -2378,7 +2378,7 @@ dht_update_commit_hash_for_layout_resume(call_frame_t *frame, void *cookie,
     count = conf->local_subvols_cnt;
     layout = local->layout;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto err_done;
     }
 
@@ -2398,7 +2398,7 @@ dht_update_commit_hash_for_layout_resume(call_frame_t *frame, void *cookie,
     for (i = 0; i < count; i++) {
         /* find the layout index for the subvolume */
         ret = dht_layout_index_for_subvol(layout, conf->local_subvols[i]);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             local->op_errno = ENOENT;
 
             gf_smsg(this->name, GF_LOG_WARNING, 0, DHT_MSG_COMMIT_HASH_FAILED,
@@ -2415,7 +2415,7 @@ dht_update_commit_hash_for_layout_resume(call_frame_t *frame, void *cookie,
 
         /* extract the current layout */
         ret = dht_disk_layout_extract(this, layout, j, &disk_layout);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             local->op_errno = errno;
 
             gf_smsg(this->name, GF_LOG_WARNING, errno,
@@ -2545,7 +2545,7 @@ dht_update_commit_hash_for_layout(call_frame_t *frame)
 
     ret = dht_blocking_inodelk(frame, lk_array, count,
                                dht_update_commit_hash_for_layout_resume);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->lock[0].layout.my_layout.locks = NULL;
         local->lock[0].layout.my_layout.lk_count = 0;
         goto err;

--- a/xlators/cluster/dht/src/dht-selfheal.c
+++ b/xlators/cluster/dht/src/dht-selfheal.c
@@ -1193,7 +1193,7 @@ dht_selfheal_dir_mkdir_lookup_cbk(call_frame_t *frame, void *cookie,
             /* the status might have changed. Update the layout with the
              * new status
              */
-            if (index >= 0) {
+            if (IS_SUCCESS(index)) {
                 layout->list[index].err = op_errno;
             }
         }
@@ -1207,7 +1207,7 @@ dht_selfheal_dir_mkdir_lookup_cbk(call_frame_t *frame, void *cookie,
             /* the status might have changed. Update the layout with the
              * new status
              */
-            if (index >= 0) {
+            if (IS_SUCCESS(index)) {
                 layout->list[index].err = -1;
             }
         }

--- a/xlators/cluster/dht/src/dht-shared.c
+++ b/xlators/cluster/dht/src/dht-shared.c
@@ -478,7 +478,7 @@ dht_reconfigure(xlator_t *this, dict_t *options)
     if (conf->defrag) {
         if (dict_get_str(options, "rebal-throttle", &temp_str) == 0) {
             ret = dht_configure_throttle(this, conf, temp_str);
-            if (ret == -1)
+            if (IS_ERROR(ret))
                 goto out;
         }
     }
@@ -494,7 +494,7 @@ dht_reconfigure(xlator_t *this, dict_t *options)
 
     if (dict_get_str(options, "decommissioned-bricks", &temp_str) == 0) {
         ret = dht_parse_decommissioned_bricks(this, conf, temp_str);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto out;
     } else {
         dht_decommissioned_remove(this, conf);
@@ -710,7 +710,7 @@ dht_init(xlator_t *this)
         if (strcasecmp(temp_str, "auto")) {
             gf_boolean_t search_unhashed_bool;
             ret = gf_string2boolean(temp_str, &search_unhashed_bool);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 goto err;
             }
             conf->search_unhashed = search_unhashed_bool
@@ -749,7 +749,7 @@ dht_init(xlator_t *this)
 
         GF_OPTION_INIT("rebalance-stats", defrag->stats, bool, err);
         if (dict_get_str(this->options, "rebalance-filter", &temp_str) == 0) {
-            if (gf_defrag_pattern_list_fill(this, defrag, temp_str) == -1) {
+            if (IS_ERROR(gf_defrag_pattern_list_fill(this, defrag, temp_str))) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_INVALID_OPTION,
                        "Invalid option:"
                        " Cannot parse rebalance-filter (%s)",
@@ -766,7 +766,7 @@ dht_init(xlator_t *this)
         conf->disk_unit = 'p';
 
     ret = dht_init_subvolumes(this, conf);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -782,7 +782,7 @@ dht_init(xlator_t *this)
 
     if (dict_get_str(this->options, "decommissioned-bricks", &temp_str) == 0) {
         ret = dht_parse_decommissioned_bricks(this, conf, temp_str);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto err;
     }
 
@@ -792,7 +792,7 @@ dht_init(xlator_t *this)
                    &conf->extra_regex_valid, conf);
 
     ret = dht_layouts_init(this, conf);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -813,7 +813,7 @@ dht_init(xlator_t *this)
         GF_OPTION_INIT("rebal-throttle", temp_str, str, err);
         if (temp_str) {
             ret = dht_configure_throttle(this, conf, temp_str);
-            if (ret == -1)
+            if (IS_ERROR(ret))
                 goto err;
         }
     }

--- a/xlators/cluster/dht/src/nufa.c
+++ b/xlators/cluster/dht/src/nufa.c
@@ -45,7 +45,7 @@ nufa_local_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto out;
 
     is_linkfile = check_is_linkfile(inode, stbuf, xattr, conf->link_xattr_name);
@@ -54,7 +54,7 @@ nufa_local_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!is_dir && !is_linkfile) {
         /* non-directory and not a linkfile */
         ret = dht_layout_preset(this, prev, inode);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg_debug(this->name, 0,
                          "could not set pre-set layout for subvol"
                          " %s",
@@ -193,7 +193,7 @@ nufa_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
          *       revalidates directly go to the cached-subvolume.
          */
         ret = dict_set_uint32(local->xattr_req, conf->xattr_name, 4 * 4);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_DICT_SET_FAILED,
                    "Failed to set dict value.");
             op_errno = -1;
@@ -212,7 +212,7 @@ nufa_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
     } else {
     do_fresh_lookup:
         ret = dict_set_uint32(local->xattr_req, conf->xattr_name, 4 * 4);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_DICT_SET_FAILED,
                    "Failed to set dict value.");
             op_errno = -1;
@@ -220,7 +220,7 @@ nufa_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
         }
 
         ret = dict_set_uint32(local->xattr_req, conf->link_xattr_name, 256);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_DICT_SET_FAILED,
                    "Failed to set dict value.");
             op_errno = -1;
@@ -237,7 +237,7 @@ nufa_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
     return 0;
 }
@@ -253,7 +253,7 @@ nufa_create_linkfile_create_cbk(call_frame_t *frame, void *cookie,
 
     local = frame->local;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto err;
 
     STACK_WIND_COOKIE(frame, dht_create_cbk, local->cached_subvol,
@@ -328,7 +328,7 @@ nufa_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(create, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL,
                      NULL);
 
@@ -428,7 +428,7 @@ nufa_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
 
     return 0;

--- a/xlators/cluster/dht/src/nufa.c
+++ b/xlators/cluster/dht/src/nufa.c
@@ -350,7 +350,7 @@ nufa_mknod_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto err;
     }
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         STACK_WIND_COOKIE(
             frame, dht_newfile_cbk, (void *)local->cached_subvol,
             local->cached_subvol, local->cached_subvol->fops->mknod,

--- a/xlators/cluster/dht/src/switch.c
+++ b/xlators/cluster/dht/src/switch.c
@@ -126,7 +126,7 @@ switch_local_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto out;
 
     is_linkfile = check_is_linkfile(inode, stbuf, xattr, conf->link_xattr_name);
@@ -136,7 +136,7 @@ switch_local_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         /* non-directory and not a linkfile */
 
         ret = dht_layout_preset(this, prev, inode);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg_debug(this->name, 0,
                          "could not set pre-set layout "
                          "for subvol %s",
@@ -277,7 +277,7 @@ switch_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc,
          * attribute, revalidates directly go to the cached-subvolume.
          */
         ret = dict_set_uint32(local->xattr_req, conf->xattr_name, 4 * 4);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg(this->name, GF_LOG_WARNING, 0, DHT_MSG_DICT_SET_FAILED,
                    "failed to set dict value for %s", conf->xattr_name);
 
@@ -293,12 +293,12 @@ switch_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc,
     } else {
     do_fresh_lookup:
         ret = dict_set_uint32(local->xattr_req, conf->xattr_name, 4 * 4);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg(this->name, GF_LOG_WARNING, 0, DHT_MSG_DICT_SET_FAILED,
                    "failed to set dict value for %s", conf->xattr_name);
 
         ret = dict_set_uint32(local->xattr_req, conf->link_xattr_name, 256);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg(this->name, GF_LOG_WARNING, EINVAL, DHT_MSG_DICT_SET_FAILED,
                    "failed to set dict value for %s", conf->link_xattr_name);
 
@@ -343,7 +343,7 @@ switch_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
     return 0;
 }
@@ -359,7 +359,7 @@ switch_create_linkfile_create_cbk(call_frame_t *frame, void *cookie,
 
     local = frame->local;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto err;
 
     STACK_WIND_COOKIE(frame, dht_create_cbk, local->cached_subvol,
@@ -433,7 +433,7 @@ switch_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(create, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL,
                      NULL);
 
@@ -530,7 +530,7 @@ switch_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     return 0;
 
 err:
-    op_errno = (op_errno == -1) ? errno : op_errno;
+    op_errno = (IS_ERROR(op_errno)) ? errno : op_errno;
     DHT_STACK_UNWIND(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
 
     return 0;

--- a/xlators/cluster/dht/src/switch.c
+++ b/xlators/cluster/dht/src/switch.c
@@ -455,7 +455,7 @@ switch_mknod_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto err;
     }
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         STACK_WIND_COOKIE(
             frame, dht_newfile_cbk, (void *)local->cached_subvol,
             local->cached_subvol, local->cached_subvol->fops->mknod,

--- a/xlators/cluster/ec/src/ec-code.c
+++ b/xlators/cluster/ec/src/ec-code.c
@@ -418,7 +418,7 @@ ec_code_space_create(ec_code_t *code, size_t size)
      * memory mapped areas. */
     /* coverity[secure_temp] mkstemp uses 0600 as the mode and is safe */
     fd = mkstemp(path);
-    if (fd < 0) {
+    if (IS_ERROR(fd)) {
         err = errno;
         gf_msg(THIS->name, GF_LOG_ERROR, err, EC_MSG_DYN_CREATE_FAILED,
                "Unable to create a temporary file for the ec dynamic "
@@ -432,7 +432,7 @@ ec_code_space_create(ec_code_t *code, size_t size)
     sys_unlink(path);
 
     size = (size + EC_CODE_ALIGN - 1) & ~(EC_CODE_ALIGN - 1);
-    if (sys_ftruncate(fd, size) < 0) {
+    if (IS_ERROR(sys_ftruncate(fd, size))) {
         err = errno;
         gf_msg(THIS->name, GF_LOG_ERROR, err, EC_MSG_DYN_CREATE_FAILED,
                "Unable to resize the file for the ec dynamic code");
@@ -990,7 +990,7 @@ ec_code_detect(xlator_t *xl, const char *def)
     }
 
     file.fd = sys_open(PROC_CPUINFO, O_RDONLY, 0);
-    if (file.fd < 0) {
+    if (IS_ERROR(file.fd)) {
         goto out;
     }
     file.size = file.pos = 0;

--- a/xlators/cluster/ec/src/ec-combine.c
+++ b/xlators/cluster/ec/src/ec-combine.c
@@ -387,7 +387,7 @@ ec_dict_data_concat(ec_cbk_data_t *cbk, int32_t which, char *key, char *new_key,
         } else {
             len += data[i]->len - 1;
         }
-        if (num >= 0) {
+        if (IS_SUCCESS(num)) {
             len += seplen;
         }
         num++;
@@ -588,7 +588,7 @@ ec_dict_data_iatt(ec_cbk_data_t *cbk, int32_t which, char *key)
 
     dict = (which == EC_COMBINE_XDATA) ? cbk->xdata : cbk->dict;
     ret = dict_set_iatt(dict, key, stbuf, false);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         stbuf = NULL;
     }
 
@@ -935,7 +935,7 @@ ec_combine_check(ec_cbk_data_t *dst, ec_cbk_data_t *src, ec_combine_f combine)
         return 0;
     }
 
-    if ((dst->op_ret >= 0) && (combine != NULL)) {
+    if (IS_SUCCESS((dst->op_ret)) && (combine != NULL)) {
         return combine(fop, dst, src);
     }
 

--- a/xlators/cluster/ec/src/ec-combine.c
+++ b/xlators/cluster/ec/src/ec-combine.c
@@ -314,7 +314,7 @@ ec_concat_prepare(xlator_t *xl, char **str, char **sep, char **post,
     int32_t len;
 
     len = gf_vasprintf(str, fmt, args);
-    if (len < 0) {
+    if (IS_ERROR(len)) {
         return -ENOMEM;
     }
 
@@ -677,7 +677,7 @@ ec_dict_data_quota(ec_cbk_data_t *cbk, int32_t which, char *key)
      */
     for (i = 0; i < ec->nodes; i++) {
         if ((data[i] == NULL) || (data[i] == EC_MISSING_DATA) ||
-            (quota_data_to_meta(data[i], &size) < 0)) {
+            (IS_ERROR(quota_data_to_meta(data[i], &size)))) {
             continue;
         }
 
@@ -915,7 +915,7 @@ ec_combine_check(ec_cbk_data_t *dst, ec_cbk_data_t *src, ec_combine_f combine)
 
         return 0;
     }
-    if (dst->op_ret < 0) {
+    if (IS_ERROR(dst->op_ret)) {
         if (dst->op_errno != src->op_errno) {
             gf_msg_debug(fop->xl->name, 0,
                          "Mismatching errno code in "

--- a/xlators/cluster/ec/src/ec-common.c
+++ b/xlators/cluster/ec/src/ec-common.c
@@ -307,7 +307,7 @@ ec_check_status(ec_fop_data_t *fop)
         return;
     }
 
-    if (IS_SUCCESS(fop->answer && fop->answer->op_ret)) {
+    if (fop->answer && IS_SUCCESS(fop->answer->op_ret)) {
         if ((fop->id == GF_FOP_LOOKUP) || (fop->id == GF_FOP_STAT) ||
             (fop->id == GF_FOP_FSTAT)) {
             partial = fop->answer->iatt[0].ia_type == IA_IFDIR;
@@ -393,7 +393,7 @@ ec_fop_set_error(ec_fop_data_t *fop, int32_t error)
 gf_boolean_t
 ec_cbk_set_error(ec_cbk_data_t *cbk, int32_t error, gf_boolean_t ro)
 {
-    if (IS_SUCCESS((error != 0) && (cbk->op_ret))) {
+    if ((error != 0) && IS_SUCCESS(cbk->op_ret)) {
         /* If cbk->op_errno was 0, it means that the fop succeeded and this
          * error has happened while processing the answer. If the operation was
          * read-only, there's no problem (i.e. we simply return the generated
@@ -2124,7 +2124,7 @@ ec_lock_next_owner(ec_lock_link_t *link, ec_cbk_data_t *cbk,
 
     lock->release |= release;
 
-    if (IS_SUCCESS((fop->error == 0) && (cbk != NULL) && (cbk->op_ret))) {
+    if ((fop->error == 0) && (cbk != NULL) && IS_SUCCESS(cbk->op_ret)) {
         if (link->update[0]) {
             ctx->post_version[0]++;
         }

--- a/xlators/cluster/ec/src/ec-common.c
+++ b/xlators/cluster/ec/src/ec-common.c
@@ -118,7 +118,7 @@ ec_fix_open(ec_fop_data_t *fop, uintptr_t mask)
     loc.inode = inode_ref(fop->fd->inode);
     gf_uuid_copy(loc.gfid, fop->fd->inode->gfid);
     ret = loc_path(&loc, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -146,7 +146,7 @@ ec_range_end_get(off_t fl_start, uint64_t fl_size)
             fl_start = LLONG_MAX;
         } else {
             fl_start += fl_size - 1;
-            if (fl_start < 0) {
+            if (IS_ERROR(fl_start)) {
                 /* Overflow */
                 fl_start = LLONG_MAX;
             }
@@ -232,7 +232,7 @@ ec_heal_report(call_frame_t *frame, void *cookie, xlator_t *this,
                int32_t op_ret, int32_t op_errno, uintptr_t mask, uintptr_t good,
                uintptr_t bad, dict_t *xdata)
 {
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_DEBUG, op_errno, EC_MSG_HEAL_FAIL,
                "Heal failed");
     } else {
@@ -264,7 +264,7 @@ ec_fop_needs_name_heal(ec_fop_data_t *fop)
 
     list_for_each_entry(cbk, &fop->cbk_list, list)
     {
-        if (cbk->op_ret < 0 && cbk->op_errno == ENOENT) {
+        if (IS_ERROR(cbk->op_ret) && cbk->op_errno == ENOENT) {
             enoent_cbk = cbk;
             break;
         }
@@ -405,7 +405,7 @@ ec_cbk_set_error(ec_cbk_data_t *cbk, int32_t error, gf_boolean_t ro)
         ec_fop_set_error(cbk->fop, cbk->op_errno);
     }
 
-    return (cbk->op_ret < 0);
+    return (IS_ERROR(cbk->op_ret));
 }
 
 ec_cbk_data_t *
@@ -421,7 +421,7 @@ ec_fop_prepare_answer(ec_fop_data_t *fop, gf_boolean_t ro)
         return NULL;
     }
 
-    if (cbk->op_ret < 0) {
+    if (IS_ERROR(cbk->op_ret)) {
         ec_fop_set_error(fop, cbk->op_errno);
     }
 
@@ -816,7 +816,7 @@ ec_dispatch_one_retry(ec_fop_data_t *fop, ec_cbk_data_t **cbk)
     if (cbk != NULL) {
         *cbk = tmp;
     }
-    if ((tmp != NULL) && (tmp->op_ret < 0) &&
+    if ((tmp != NULL) && IS_ERROR(tmp->op_ret) &&
         ec_is_recoverable_error(tmp->op_errno)) {
         GF_ASSERT(fop->mask & (1ULL << tmp->idx));
         fop->mask ^= (1ULL << tmp->idx);
@@ -964,7 +964,7 @@ ec_lock_insert(ec_fop_data_t *fop, ec_lock_t *lock, uint32_t flags, loc_t *base,
     /* This check is only prepared for up to 2 locks per fop. If more locks
      * are needed this must be changed. */
     if ((fop->lock_count > 0) &&
-        (ec_lock_compare(fop->locks[0].lock, lock) < 0)) {
+        (IS_ERROR(ec_lock_compare(fop->locks[0].lock, lock)))) {
         fop->first_lock = fop->lock_count;
     } else {
         /* When the first lock is added to the current fop, request lock
@@ -1227,7 +1227,7 @@ ec_prepare_update_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 list_add_tail(&link->fop->cbk_list, &list);
         }
     }
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, EC_MSG_SIZE_VERS_GET_FAIL,
                "Failed to get size and version :  %s", ec_msg_str(fop));
 
@@ -1974,7 +1974,7 @@ ec_lock_timer_cancel(xlator_t *xl, ec_lock_t *lock)
     timer_link = lock->timer->data;
     GF_ASSERT(timer_link != NULL);
 
-    if (gf_timer_call_cancel(xl->ctx, lock->timer) < 0) {
+    if (IS_ERROR(gf_timer_call_cancel(xl->ctx, lock->timer))) {
         /* It's too late to avoid the execution of the timer callback.
          * Since we need to be sure that the callback has access to all
          * needed resources, we cannot resume the execution of the
@@ -2238,7 +2238,7 @@ ec_unlocked(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     ec_fop_data_t *fop = cookie;
     ec_lock_link_t *link = fop->data;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, EC_MSG_UNLOCK_FAILED,
                "entry/inode unlocking failed :(%s)", ec_msg_str(link->fop));
     } else {
@@ -2308,7 +2308,7 @@ ec_update_size_version_done(call_frame_t *frame, void *cookie, xlator_t *this,
     lock = link->lock;
     ctx = lock->ctx;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if (link->lock->fd == NULL) {
             ec_inode_bad_inc(link->lock->loc.inode, this);
         } else {

--- a/xlators/cluster/ec/src/ec-common.c
+++ b/xlators/cluster/ec/src/ec-common.c
@@ -35,7 +35,7 @@ ec_update_fd_status(fd_t *fd, xlator_t *xl, int idx, int32_t ret_status)
     {
         fd_ctx = __ec_fd_get(fd, xl);
         if (fd_ctx) {
-            if (ret_status >= 0)
+            if (IS_SUCCESS(ret_status))
                 fd_ctx->fd_status[idx] = EC_FD_OPENED;
             else
                 fd_ctx->fd_status[idx] = EC_FD_NOT_OPENED;
@@ -307,7 +307,7 @@ ec_check_status(ec_fop_data_t *fop)
         return;
     }
 
-    if (fop->answer && fop->answer->op_ret >= 0) {
+    if (IS_SUCCESS(fop->answer && fop->answer->op_ret)) {
         if ((fop->id == GF_FOP_LOOKUP) || (fop->id == GF_FOP_STAT) ||
             (fop->id == GF_FOP_FSTAT)) {
             partial = fop->answer->iatt[0].ia_type == IA_IFDIR;
@@ -393,7 +393,7 @@ ec_fop_set_error(ec_fop_data_t *fop, int32_t error)
 gf_boolean_t
 ec_cbk_set_error(ec_cbk_data_t *cbk, int32_t error, gf_boolean_t ro)
 {
-    if ((error != 0) && (cbk->op_ret >= 0)) {
+    if (IS_SUCCESS((error != 0) && (cbk->op_ret))) {
         /* If cbk->op_errno was 0, it means that the fop succeeded and this
          * error has happened while processing the answer. If the operation was
          * read-only, there's no problem (i.e. we simply return the generated
@@ -1684,7 +1684,7 @@ ec_get_real_size_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     ec_fop_data_t *fop = cookie;
     ec_lock_link_t *link;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         link = fop->data;
         link->size = buf->ia_size;
     } else {
@@ -1898,7 +1898,7 @@ ec_locked(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     link = fop->data;
     lock = link->lock;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         lock->mask = lock->good_mask = fop->good;
         lock->healing = 0;
 
@@ -2124,7 +2124,7 @@ ec_lock_next_owner(ec_lock_link_t *link, ec_cbk_data_t *cbk,
 
     lock->release |= release;
 
-    if ((fop->error == 0) && (cbk != NULL) && (cbk->op_ret >= 0)) {
+    if (IS_SUCCESS((fop->error == 0) && (cbk != NULL) && (cbk->op_ret))) {
         if (link->update[0]) {
             ctx->post_version[0]++;
         }
@@ -2839,7 +2839,7 @@ ec_update_stripe(ec_t *ec, ec_stripe_list_t *stripe_cache, ec_stripe_t *stripe,
     /* On write fops, we only update existing fragments if the write has
      * succeeded. Otherwise, we remove them from the cache. */
     if ((fop->id == GF_FOP_WRITE) && (fop->answer != NULL) &&
-        (fop->answer->op_ret >= 0)) {
+        (IS_SUCCESS(fop->answer->op_ret))) {
         base = stripe->frag_offset - fop->frag_range.first;
         base *= ec->fragments;
 
@@ -2995,10 +2995,10 @@ __ec_manager(ec_fop_data_t *fop, int32_t error)
         fop->jobs = 1;
 
         fop->state = fop->handler(fop, fop->state);
-        GF_ASSERT(fop->state >= 0);
+        GF_ASSERT(IS_SUCCESS(fop->state));
 
         error = ec_check_complete(fop, __ec_manager);
-    } while (error >= 0);
+    } while (IS_SUCCESS(error));
 }
 
 void

--- a/xlators/cluster/ec/src/ec-dir-read.c
+++ b/xlators/cluster/ec/src/ec-dir-read.c
@@ -289,13 +289,13 @@ ec_deitransform(xlator_t *this, off_t offset)
     client_id = gf_deitransform(this, offset);
     sprintf(id, "%d", client_id);
     err = dict_get_int32(ec->leaf_to_subvolid, id, &idx);
-    if (err < 0) {
+    if (IS_ERROR(err)) {
         idx = err;
         goto out;
     }
 
 out:
-    if (idx < 0) {
+    if (IS_ERROR(idx)) {
         gf_msg(this->name, GF_LOG_ERROR, EINVAL, EC_MSG_INVALID_REQUEST,
                "Invalid index %d in readdirp request", client_id);
         idx = -EINVAL;
@@ -419,7 +419,7 @@ ec_manager_readdir(ec_fop_data_t *fop, int32_t state)
 
                 idx = ec_deitransform(fop->xl, fop->offset);
 
-                if (idx < 0) {
+                if (IS_ERROR(idx)) {
                     fop->error = -idx;
                     return EC_STATE_REPORT;
                 }

--- a/xlators/cluster/ec/src/ec-dir-read.c
+++ b/xlators/cluster/ec/src/ec-dir-read.c
@@ -57,7 +57,7 @@ ec_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_OPENDIR, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (fd != NULL) {
                 cbk->fd = fd_ref(fd);
                 if (cbk->fd == NULL) {
@@ -352,7 +352,7 @@ ec_common_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (cbk) {
         if (xdata)
             cbk->xdata = dict_ref(xdata);
-        if (cbk->op_ret >= 0)
+        if (IS_SUCCESS(cbk->op_ret))
             list_splice_init(&entries->list, &cbk->entries.list);
         ec_combine(cbk, NULL);
     }

--- a/xlators/cluster/ec/src/ec-dir-write.c
+++ b/xlators/cluster/ec/src/ec-dir-write.c
@@ -46,7 +46,7 @@ ec_dir_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie, int op_ret,
     if (xdata)
         cbk->xdata = dict_ref(xdata);
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     if (poststat)

--- a/xlators/cluster/ec/src/ec-generic.c
+++ b/xlators/cluster/ec/src/ec-generic.c
@@ -666,7 +666,7 @@ ec_lookup_rebuild(ec_t *ec, ec_fop_data_t *fop, ec_cbk_data_t *cbk)
     uint64_t size = 0;
     int32_t have_size = 0, err;
 
-    if (cbk->op_ret < 0) {
+    if (IS_ERROR(cbk->op_ret)) {
         return;
     }
 

--- a/xlators/cluster/ec/src/ec-generic.c
+++ b/xlators/cluster/ec/src/ec-generic.c
@@ -280,7 +280,7 @@ ec_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_FSYNC, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (prebuf != NULL) {
                 cbk->iatt[0] = *prebuf;
             }
@@ -740,7 +740,7 @@ ec_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_LOOKUP, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (inode != NULL) {
                 cbk->inode = inode_ref(inode);
                 if (cbk->inode == NULL) {
@@ -974,7 +974,7 @@ ec_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_STATFS, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (buf != NULL) {
                 cbk->statvfs = *buf;
             }
@@ -1174,7 +1174,7 @@ ec_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!cbk)
         goto out;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         cbk->dict = dict_ref(xattr);
 
         data = dict_get(cbk->dict, EC_XATTR_VERSION);

--- a/xlators/cluster/ec/src/ec-heal.c
+++ b/xlators/cluster/ec/src/ec-heal.c
@@ -335,7 +335,7 @@ ec_heal_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                   ec_heal_writev_cbk, heal, heal->fd, vector, count,
                   heal->offset, 0, iobref, NULL);
     } else {
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             gf_msg_debug(fop->xl->name, 0,
                          "%s: read failed %s, failing "
                          "to heal block at %" PRIu64,
@@ -421,10 +421,10 @@ ec_heal_entry_find_direction(ec_t *ec, default_args_cbk_t *replies,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret == -1)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
-        if (source == -1)
+        if (IS_ERROR(source))
             source = i;
 
         ret = ec_dict_get_array(replies[i].xdata, EC_XATTR_VERSION, xattr,
@@ -445,14 +445,14 @@ ec_heal_entry_find_direction(ec_t *ec, default_args_cbk_t *replies,
         }
     }
 
-    if (source < 0)
+    if (IS_ERROR(source))
         goto out;
 
     for (i = 0; i < ec->nodes; i++) {
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret == -1)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         if (versions[i] == versions[source])
@@ -526,7 +526,7 @@ ec_adjust_versions(call_frame_t *frame, ec_t *ec, ec_txn_t type, inode_t *inode,
         versions_xattr[type] = hton64(versions[source] - versions[i]);
         ret = dict_set_bin(xattr[i], EC_XATTR_VERSION, versions_xattr,
                            (sizeof(*versions_xattr) * EC_VERSION_SIZE));
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             op_ret = -ENOMEM;
             continue;
         }
@@ -542,7 +542,7 @@ ec_adjust_versions(call_frame_t *frame, ec_t *ec, ec_txn_t type, inode_t *inode,
             dirty_xattr[type] = hton64(-dirty[i]);
             ret = dict_set_bin(xattr[i], EC_XATTR_DIRTY, dirty_xattr,
                                (sizeof(*dirty_xattr) * EC_VERSION_SIZE));
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 op_ret = -ENOMEM;
                 continue;
             }
@@ -616,7 +616,7 @@ ec_heal_metadata_find_direction(ec_t *ec, default_args_cbk_t *replies,
     for (i = 0; i < ec->nodes; i++) {
         if (!replies[i].valid)
             continue;
-        if (replies[i].op_ret < 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
         ret = ec_dict_get_array(replies[i].xdata, EC_XATTR_VERSION, xattr,
                                 EC_VERSION_SIZE);
@@ -636,7 +636,7 @@ ec_heal_metadata_find_direction(ec_t *ec, default_args_cbk_t *replies,
         same_count = 1;
         source_ia = replies[i].stat;
         for (j = i + 1; j < ec->nodes; j++) {
-            if (!replies[j].valid || replies[j].op_ret < 0)
+            if (!replies[j].valid || IS_ERROR(replies[j].op_ret))
                 continue;
             child_ia = replies[j].stat;
             if (!IA_EQUAL(source_ia, child_ia, gfid) ||
@@ -726,7 +726,7 @@ __ec_heal_metadata_prepare(call_frame_t *frame, ec_t *ec, inode_t *inode,
 
     source = ec_heal_metadata_find_direction(ec, replies, versions, dirty,
                                              sources, healed_sinks);
-    if (source < 0) {
+    if (IS_ERROR(source)) {
         ret = -EIO;
         goto out;
     }
@@ -757,7 +757,7 @@ __ec_removexattr_sinks(call_frame_t *frame, ec_t *ec, inode_t *inode,
             continue;
         ret = dict_foreach(replies[i].xdata, ec_heal_xattr_clean,
                            replies[source].xdata);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             sources[i] = 0;
             healed_sinks[i] = 0;
             continue;
@@ -776,7 +776,7 @@ __ec_removexattr_sinks(call_frame_t *frame, ec_t *ec, inode_t *inode,
 
         ret = syncop_removexattr(ec->xl_list[i], &loc, "", replies[i].xdata,
                                  NULL);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             healed_sinks[i] = 0;
     }
 
@@ -812,7 +812,7 @@ __ec_heal_metadata(call_frame_t *frame, ec_t *ec, inode_t *inode,
     dirty = alloca0(ec->nodes * sizeof(*dirty));
     source = __ec_heal_metadata_prepare(frame, ec, inode, locked_on, replies,
                                         versions, dirty, sources, healed_sinks);
-    if (source < 0) {
+    if (IS_ERROR(source)) {
         ret = -EIO;
         goto out;
     }
@@ -837,7 +837,7 @@ __ec_heal_metadata(call_frame_t *frame, ec_t *ec, inode_t *inode,
 
     ret = __ec_removexattr_sinks(frame, ec, inode, source, sources,
                                  healed_sinks, replies);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     source_dict = dict_ref(replies[source].xdata);
@@ -946,7 +946,7 @@ __ec_heal_entry_prepare(call_frame_t *frame, ec_t *ec, inode_t *inode,
 
     source = ec_heal_entry_find_direction(ec, replies, versions, dirty, sources,
                                           healed_sinks);
-    if (source < 0) {
+    if (IS_ERROR(source)) {
         ret = -EIO;
         goto out;
     }
@@ -1043,7 +1043,7 @@ ec_delete_stale_name(dict_t *gfid_db, char *key, data_t *d, void *data)
     for (i = 0; i < ec->nodes; i++) {
         if (!replies[i].valid)
             continue;
-        if (replies[i].op_ret == -1) {
+        if (IS_ERROR(replies[i].op_ret)) {
             if (replies[i].op_errno == ESTALE || replies[i].op_errno == ENOENT)
                 estale_count++;
             else
@@ -1115,7 +1115,7 @@ ec_delete_stale_name(dict_t *gfid_db, char *key, data_t *d, void *data)
     /*This will help in making decisions about creating names*/
     dict_del(gfid_db, key);
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(ec->xl->name, 0, "%s/%s: heal failed %s",
                      uuid_utoa(name_data->parent->gfid), name_data->name,
                      strerror(-ret));
@@ -1180,7 +1180,7 @@ ec_create_name(call_frame_t *frame, ec_t *ec, inode_t *parent, char *name,
     }
 
     ret = dict_foreach(gfid_db, _assign_same, &name_data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
     /*There should at least be one valid success reply with gfid*/
     for (i = 0; i < ec->nodes; i++)
@@ -1306,7 +1306,7 @@ ec_create_name(call_frame_t *frame, ec_t *ec, inode_t *parent, char *name,
 
     ret = 0;
 out:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_msg_debug(ec->xl->name, 0, "%s/%s: heal failed %s",
                      uuid_utoa(parent->gfid), name, strerror(-ret));
     cluster_replies_wipe(replies, ec->nodes);
@@ -1361,7 +1361,7 @@ __ec_heal_name(call_frame_t *frame, ec_t *ec, inode_t *parent, char *name,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret == -1) {
+        if (IS_ERROR(replies[i].op_ret)) {
             /*If ESTALE comes here, that means parent dir is not
              * present, nothing to do there, so reset participants
              * for that brick*/
@@ -1380,14 +1380,14 @@ __ec_heal_name(call_frame_t *frame, ec_t *ec, inode_t *parent, char *name,
         } else {
             uuid_utoa_r(ia->ia_gfid, gfid);
             ret = dict_get_bin(gfid_db, gfid, (void **)&same);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 same = alloca0(ec->nodes);
             }
             same[i] = 1;
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 ret = dict_set_static_bin(gfid_db, gfid, same, ec->nodes);
             }
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
         }
     }
@@ -1493,7 +1493,7 @@ ec_name_heal_handler(xlator_t *subvol, gf_dirent_t *entry, loc_t *parent,
     ret = ec_heal_name(name_data->frame, ec, parent->inode, entry->d_name,
                        name_on);
 
-    if (ret < 0)
+    if (IS_ERROR(ret))
         memset(name_on, 0, ec->nodes);
 
     for (i = 0; i < ec->nodes; i++)
@@ -1524,7 +1524,7 @@ ec_heal_names(call_frame_t *frame, ec_t *ec, inode_t *inode,
             continue;
         ret = syncop_dir_scan(ec->xl_list[i], &loc, GF_CLIENT_PID_SELF_HEALD,
                               &name_data, ec_name_heal_handler);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             break;
         }
         for (j = 0; j < ec->nodes; j++)
@@ -1580,7 +1580,7 @@ __ec_heal_entry(call_frame_t *frame, ec_t *ec, inode_t *inode,
 unlock:
     cluster_uninodelk(ec->xl_list, locked_on, ec->nodes, replies, output, frame,
                       ec->xl, ec->xl->name, inode, 0, 0);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     participants = alloca0(ec->nodes);
@@ -1677,7 +1677,7 @@ ec_heal_data_find_direction(ec_t *ec, default_args_cbk_t *replies,
     for (i = 0; i < ec->nodes; i++) {
         if (!replies[i].valid)
             continue;
-        if (replies[i].op_ret < 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
         dict = (which == EC_COMBINE_XDATA) ? replies[i].xdata
                                            : replies[i].xattr;
@@ -1698,7 +1698,7 @@ ec_heal_data_find_direction(ec_t *ec, default_args_cbk_t *replies,
                  data_versions[i], size[i]);
 
         ret = dict_get_bin(version_size_db, version_size, (void **)&same);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             same = alloca0(ec->nodes);
         }
 
@@ -1708,12 +1708,12 @@ ec_heal_data_find_direction(ec_t *ec, default_args_cbk_t *replies,
             source = i;
         }
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             ret = dict_set_static_bin(version_size_db, version_size, same,
                                       ec->nodes);
         }
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             ret = -ENOMEM;
             goto out;
         }
@@ -1728,7 +1728,7 @@ ec_heal_data_find_direction(ec_t *ec, default_args_cbk_t *replies,
                  data_versions[source], size[source]);
 
         ret = dict_get_bin(version_size_db, version_size, (void **)&same);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
         memcpy(sources, same, ec->nodes);
         for (i = 0; i < ec->nodes; i++) {
@@ -1826,7 +1826,7 @@ __ec_heal_data_prepare(call_frame_t *frame, ec_t *ec, fd_t *fd,
                                          sources, healed_sinks, _gf_true,
                                          EC_COMBINE_DICT);
     ret = source;
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (stbuf)
@@ -1850,7 +1850,7 @@ out:
         dict_unref(xattrs);
     cluster_replies_wipe(replies, ec->nodes);
     cluster_replies_wipe(fstat_replies, ec->nodes);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(ec->xl->name, 0, "%s: heal failed %s",
                      uuid_utoa(fd->inode->gfid), strerror(-ret));
     } else {
@@ -1923,7 +1923,7 @@ out:
     cluster_replies_wipe(replies, ec->nodes);
     if (xattrs)
         dict_unref(xattrs);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_msg_debug(ec->xl->name, 0, "%s: heal failed %s",
                      uuid_utoa(fd->inode->gfid), strerror(-ret));
     return ret;
@@ -2088,7 +2088,7 @@ ec_rebuild_data(call_frame_t *frame, ec_t *ec, fd_t *fd, uint64_t size,
                      EC_COUNT(healed_sinks, ec->nodes), heal->offset,
                      heal->size);
         ret = ec_sync_heal_block(frame, ec->xl, heal);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             break;
     }
     memset(healed_sinks, 0, ec->nodes);
@@ -2096,7 +2096,7 @@ ec_rebuild_data(call_frame_t *frame, ec_t *ec, fd_t *fd, uint64_t size,
     fd_unref(heal->fd);
     LOCK_DESTROY(&heal->lock);
     syncbarrier_destroy(heal->data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_msg_debug(ec->xl->name, 0, "%s: heal failed %s",
                      uuid_utoa(fd->inode->gfid), strerror(-ret));
     return ret;
@@ -2136,7 +2136,7 @@ __ec_heal_trim_sinks(call_frame_t *frame, ec_t *ec, fd_t *fd,
 
 out:
     cluster_replies_wipe(replies, ec->nodes);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_msg_debug(ec->xl->name, 0, "%s: heal failed %s",
                      uuid_utoa(fd->inode->gfid), strerror(-ret));
     return ret;
@@ -2156,20 +2156,20 @@ ec_data_undo_pending(call_frame_t *frame, ec_t *ec, fd_t *fd, dict_t *xattr,
     versions_xattr[EC_DATA_TXN] = hton64(versions[source] - versions[idx]);
     ret = dict_set_static_bin(xattr, EC_XATTR_VERSION, versions_xattr,
                               sizeof(versions_xattr));
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     size_xattr = hton64(size[source] - size[idx]);
     ret = dict_set_static_bin(xattr, EC_XATTR_SIZE, &size_xattr,
                               sizeof(size_xattr));
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (erase_dirty) {
         dirty_xattr[EC_DATA_TXN] = hton64(-dirty[idx]);
         ret = dict_set_static_bin(xattr, EC_XATTR_DIRTY, dirty_xattr,
                                   sizeof(dirty_xattr));
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 
@@ -2218,7 +2218,7 @@ __ec_fd_data_adjust_versions(call_frame_t *frame, ec_t *ec, fd_t *fd,
         }
     }
 
-    if (source == -1) {
+    if (IS_ERROR(source)) {
         op_ret = -ENOTCONN;
         goto out;
     }
@@ -2227,7 +2227,7 @@ __ec_fd_data_adjust_versions(call_frame_t *frame, ec_t *ec, fd_t *fd,
         if (healed_sinks[i]) {
             ret = ec_data_undo_pending(frame, ec, fd, xattr, versions, dirty,
                                        size, source, erase_dirty, i);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
         }
     }
@@ -2239,7 +2239,7 @@ __ec_fd_data_adjust_versions(call_frame_t *frame, ec_t *ec, fd_t *fd,
         if (sources[i]) {
             ret = ec_data_undo_pending(frame, ec, fd, xattr, versions, dirty,
                                        size, source, erase_dirty, i);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 continue;
         }
     }
@@ -2305,7 +2305,7 @@ ec_restore_time_and_adjust_versions(call_frame_t *frame, ec_t *ec, fd_t *fd,
                                      postsh_dirty, postsh_size, postsh_sources,
                                      postsh_healed_sinks, postsh_trim,
                                      &source_buf);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto unlock;
 
         loc.inode = inode_ref(fd->inode);
@@ -2367,7 +2367,7 @@ __ec_heal_data(call_frame_t *frame, ec_t *ec, fd_t *fd, unsigned char *heal_on,
 
         ret = __ec_heal_data_prepare(frame, ec, fd, locked_on, versions, dirty,
                                      size, sources, healed_sinks, trim, NULL);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto unlock;
 
         if (EC_COUNT(healed_sinks, ec->nodes) == 0) {
@@ -2378,7 +2378,7 @@ __ec_heal_data(call_frame_t *frame, ec_t *ec, fd_t *fd, unsigned char *heal_on,
 
         source = ret;
         ret = __ec_heal_mark_sinks(frame, ec, fd, versions, healed_sinks);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto unlock;
 
         ret = __ec_heal_trim_sinks(frame, ec, fd, healed_sinks, trim,
@@ -2387,7 +2387,7 @@ __ec_heal_data(call_frame_t *frame, ec_t *ec, fd_t *fd, unsigned char *heal_on,
 unlock:
     cluster_uninodelk(ec->xl_list, locked_on, ec->nodes, replies, output, frame,
                       ec->xl, ec->xl->name, fd->inode, 0, 0);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (EC_COUNT(healed_sinks, ec->nodes) == 0)
@@ -2400,7 +2400,7 @@ unlock:
                  EC_COUNT(healed_sinks, ec->nodes));
 
     ret = ec_rebuild_data(frame, ec, fd, size[source], sources, healed_sinks);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = ec_restore_time_and_adjust_versions(
@@ -2675,7 +2675,7 @@ ec_launch_heal(ec_t *ec, ec_fop_data_t *fop)
     ret = synctask_new(ec->xl->ctx->env, ec_synctask_heal_wrap, ec_heal_done,
                        frame, fop);
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ec_fop_set_error(fop, ENOMEM);
         ec_heal_fail(ec, fop);
     }
@@ -2868,7 +2868,7 @@ ec_replace_heal(ec_t *ec, inode_t *inode)
     loc.inode = inode_ref(inode);
     gf_uuid_copy(loc.gfid, inode->gfid);
     ret = syncop_getxattr(ec->xl, &loc, NULL, EC_XATTR_HEAL, NULL, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_msg_debug(ec->xl->name, 0, "Heal failed for replace brick ret = %d",
                      ret);
 
@@ -2912,7 +2912,7 @@ ec_launch_replace_heal(ec_t *ec)
     ret = synctask_new(ec->xl->ctx->env, ec_replace_brick_heal_wrap,
                        ec_replace_heal_done, NULL, ec);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(ec->xl->name, 0, "Heal failed for replace brick ret = %d",
                      ret);
         ec_replace_heal_done(-1, NULL, ec);
@@ -3005,7 +3005,7 @@ ec_need_metadata_heal(ec_t *ec, inode_t *inode, default_args_cbk_t *replies,
     meta_versions = alloca0(ec->nodes * sizeof(*meta_versions));
     ret = ec_heal_metadata_find_direction(ec, replies, meta_versions, dirty,
                                           sources, healed_sinks);
-    if (ret < 0 && ret != -EIO) {
+    if (IS_ERROR(ret) && ret != -EIO) {
         goto out;
     }
 
@@ -3041,7 +3041,7 @@ ec_need_data_heal(ec_t *ec, inode_t *inode, default_args_cbk_t *replies,
     ret = ec_heal_data_find_direction(
         ec, replies, data_versions, dirty, size, sources, healed_sinks,
         self_locked || thorough, EC_COMBINE_XDATA);
-    if (ret < 0 && ret != -EIO) {
+    if (IS_ERROR(ret) && ret != -EIO) {
         goto out;
     }
 
@@ -3069,7 +3069,7 @@ ec_need_entry_heal(ec_t *ec, inode_t *inode, default_args_cbk_t *replies,
 
     ret = ec_heal_entry_find_direction(ec, replies, data_versions, dirty,
                                        sources, healed_sinks);
-    if (ret < 0 && ret != -EIO) {
+    if (IS_ERROR(ret) && ret != -EIO) {
         goto out;
     }
 
@@ -3088,7 +3088,7 @@ ec_need_heal(ec_t *ec, inode_t *inode, default_args_cbk_t *replies,
 
     ret = ec_need_metadata_heal(ec, inode, replies, lock_count, self_locked,
                                 thorough, need_heal);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (*need_heal == EC_HEAL_MUST)
@@ -3251,7 +3251,7 @@ ec_get_heal_info(xlator_t *this, loc_t *entry_loc, dict_t **dict_rsp)
     }
     if (!loc.inode) {
         ret = syncop_inode_find(this, this, loc.gfid, &loc.inode, NULL, NULL);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 
@@ -3262,7 +3262,7 @@ ec_get_heal_info(xlator_t *this, loc_t *entry_loc, dict_t **dict_rsp)
     }
     need_heal = EC_HEAL_NONEED;
     ret = ec_heal_locked_inspect(frame, ec, loc.inode, &need_heal);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 set_heal:
     if (need_heal == EC_HEAL_MUST) {

--- a/xlators/cluster/ec/src/ec-heal.c
+++ b/xlators/cluster/ec/src/ec-heal.c
@@ -140,7 +140,7 @@ ec_reset_entry_healing(ec_fop_data_t *fop)
         }
     }
     UNLOCK(&loc->inode->lock);
-    GF_ASSERT(heal_count >= 0);
+    GF_ASSERT(IS_SUCCESS(heal_count));
 }
 
 uintptr_t
@@ -203,7 +203,7 @@ ec_heal_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     ec_fop_data_t *fop = cookie;
     ec_heal_t *heal = fop->data;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         GF_ASSERT(
             ec_set_inode_size(heal->fop, heal->fd->inode, heal->total_size));
     }
@@ -630,7 +630,7 @@ ec_heal_metadata_find_direction(ec_t *ec, default_args_cbk_t *replies,
         if (ret == 0) {
             dirty[i] = xattr[EC_METADATA_TXN];
         }
-        if (groups[i] >= 0) /*Already part of group*/
+        if (IS_SUCCESS(groups[i])) /*Already part of group*/
             continue;
         groups[i] = i;
         same_count = 1;
@@ -666,7 +666,7 @@ ec_heal_metadata_find_direction(ec_t *ec, default_args_cbk_t *replies,
     for (i = 0; i < ec->nodes; i++) {
         if (groups[i] == groups[same_source])
             sources[i] = 1;
-        else if (replies[i].valid && replies[i].op_ret >= 0)
+        else if (IS_SUCCESS(replies[i].valid && replies[i].op_ret))
             healed_sinks[i] = 1;
     }
     for (i = 0; i < ec->nodes; i++) {
@@ -2739,7 +2739,7 @@ ec_is_entry_healing(ec_fop_data_t *fop)
         }
     }
     UNLOCK(&loc->inode->lock);
-    GF_ASSERT(heal_count >= 0);
+    GF_ASSERT(IS_SUCCESS(heal_count));
     return heal_count;
 }
 

--- a/xlators/cluster/ec/src/ec-heal.c
+++ b/xlators/cluster/ec/src/ec-heal.c
@@ -666,7 +666,7 @@ ec_heal_metadata_find_direction(ec_t *ec, default_args_cbk_t *replies,
     for (i = 0; i < ec->nodes; i++) {
         if (groups[i] == groups[same_source])
             sources[i] = 1;
-        else if (IS_SUCCESS(replies[i].valid && replies[i].op_ret))
+        else if (replies[i].valid && IS_SUCCESS(replies[i].op_ret))
             healed_sinks[i] = 1;
     }
     for (i = 0; i < ec->nodes; i++) {

--- a/xlators/cluster/ec/src/ec-heald.c
+++ b/xlators/cluster/ec/src/ec-heald.c
@@ -163,7 +163,7 @@ ec_shd_selfheal(struct subvol_healer *healer, int child, loc_t *loc,
     int32_t ret;
 
     ret = syncop_getxattr(healer->this, loc, NULL, EC_XATTR_HEAL, NULL, NULL);
-    if (IS_SUCCESS(!full && (ret)) && (loc->inode->ia_type == IA_IFDIR)) {
+    if ((!full && IS_SUCCESS(ret)) && (loc->inode->ia_type == IA_IFDIR)) {
         /* If we have just healed a directory, it's possible that
          * other index entries have appeared to be healed. We put a
          * mark so that we can check it later and restart a scan

--- a/xlators/cluster/ec/src/ec-heald.c
+++ b/xlators/cluster/ec/src/ec-heald.c
@@ -163,7 +163,7 @@ ec_shd_selfheal(struct subvol_healer *healer, int child, loc_t *loc,
     int32_t ret;
 
     ret = syncop_getxattr(healer->this, loc, NULL, EC_XATTR_HEAL, NULL, NULL);
-    if (!full && (ret >= 0) && (loc->inode->ia_type == IA_IFDIR)) {
+    if (IS_SUCCESS(!full && (ret)) && (loc->inode->ia_type == IA_IFDIR)) {
         /* If we have just healed a directory, it's possible that
          * other index entries have appeared to be healed. We put a
          * mark so that we can check it later and restart a scan

--- a/xlators/cluster/ec/src/ec-heald.c
+++ b/xlators/cluster/ec/src/ec-heald.c
@@ -44,7 +44,7 @@ ec_subvol_name(xlator_t *this, int subvol)
     ec_t *ec = NULL;
 
     ec = this->private;
-    if (subvol < 0 || subvol > ec->nodes)
+    if (IS_ERROR(subvol) || subvol > ec->nodes)
         return NULL;
 
     return ec->xl_list[subvol]->name;
@@ -114,7 +114,7 @@ ec_shd_index_inode(xlator_t *this, xlator_t *subvol, inode_t **inode)
 
     ret = syncop_getxattr(subvol, &rootloc, &xattr, GF_XATTROP_INDEX_GFID, NULL,
                           NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
     if (!xattr) {
         ret = -EINVAL;
@@ -199,12 +199,12 @@ ec_shd_index_heal(xlator_t *subvol, gf_dirent_t *entry, loc_t *parent,
     /* If this fails with ENOENT/ESTALE index is stale */
     ret = syncop_gfid_to_path(healer->this->itable, subvol, loc.gfid,
                               (char **)&loc.path);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = syncop_inode_find(healer->this, healer->this, loc.gfid, &loc.inode,
                             NULL, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ec_shd_selfheal(healer, healer->subvol, &loc, _gf_false);
@@ -232,7 +232,7 @@ ec_shd_index_sweep(struct subvol_healer *healer)
     subvol = ec->xl_list[healer->subvol];
 
     ret = ec_shd_index_inode(healer->this, subvol, &loc.inode);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(healer->this->name, GF_LOG_WARNING, errno,
                EC_MSG_INDEX_DIR_GET_FAIL, "unable to get index-dir on %s",
                subvol->name);
@@ -295,11 +295,11 @@ ec_shd_full_heal(xlator_t *subvol, gf_dirent_t *entry, loc_t *parent,
     /* If this fails with ENOENT/ESTALE index is stale */
     ret = syncop_gfid_to_path(this->itable, subvol, loc.gfid,
                               (char **)&loc.path);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = syncop_inode_find(this, this, loc.gfid, &loc.inode, NULL, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ec_shd_selfheal(healer, healer->subvol, &loc, _gf_true);
@@ -340,7 +340,7 @@ ec_shd_index_healer(void *data)
 
     for (;;) {
         run = ec_shd_healer_wait(healer);
-        if (run == -1)
+        if (IS_ERROR(run))
             break;
 
         if (ec->xl_up_count > ec->fragments) {
@@ -371,7 +371,7 @@ ec_shd_full_healer(void *data)
     rootloc.inode = this->itable->root;
     for (;;) {
         run = ec_shd_healer_wait(healer);
-        if (run < 0) {
+        if (IS_ERROR(run)) {
             break;
         } else if (run == 0) {
             continue;

--- a/xlators/cluster/ec/src/ec-helpers.c
+++ b/xlators/cluster/ec/src/ec-helpers.c
@@ -49,7 +49,7 @@ failed:
 const char *
 ec_fop_name(int32_t id)
 {
-    if (id >= 0) {
+    if (IS_SUCCESS(id)) {
         return gf_fop_list[id];
     }
 
@@ -84,7 +84,7 @@ ec_trace(const char *event, ec_fop_data_t *fop, const char *fmt, ...)
                  ec_bin(str2, sizeof(str2), fop->remaining, ec->nodes),
                  ec_bin(str3, sizeof(str3), fop->good, ec->nodes), msg);
 
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         free(msg);
     }
 }

--- a/xlators/cluster/ec/src/ec-helpers.c
+++ b/xlators/cluster/ec/src/ec-helpers.c
@@ -69,7 +69,7 @@ ec_trace(const char *event, ec_fop_data_t *fop, const char *fmt, ...)
     ret = vasprintf(&msg, fmt, args);
     va_end(args);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         msg = "<memory allocation error>";
     }
 

--- a/xlators/cluster/ec/src/ec-helpers.h
+++ b/xlators/cluster/ec/src/ec-helpers.h
@@ -168,7 +168,7 @@ ec_adjust_offset_up(ec_t *ec, off_t *value, gf_boolean_t scale)
         tmp /= ec->fragments;
     } else {
         /* Check if there has been an overflow. */
-        if ((off_t)tmp < 0) {
+        if (IS_ERROR((off_t)tmp)) {
             tmp = GF_OFF_MAX;
             tail = -tail;
         }

--- a/xlators/cluster/ec/src/ec-inode-read.c
+++ b/xlators/cluster/ec/src/ec-inode-read.c
@@ -1020,7 +1020,7 @@ ec_manager_readlink(ec_fop_data_t *fop, int32_t state)
                 return EC_STATE_DISPATCH;
             }
 
-            if (IS_SUCCESS((cbk != NULL) && (cbk->op_ret))) {
+            if ((cbk != NULL) && IS_SUCCESS(cbk->op_ret)) {
                 ec_iatt_rebuild(fop->xl->private, &cbk->iatt[0], 1, 1);
             }
 
@@ -1574,7 +1574,7 @@ ec_manager_seek(ec_fop_data_t *fop, int32_t state)
             if (ec_dispatch_one_retry(fop, &cbk)) {
                 return EC_STATE_DISPATCH;
             }
-            if (IS_SUCCESS((cbk != NULL) && (cbk->op_ret))) {
+            if ((cbk != NULL) && IS_SUCCESS(cbk->op_ret)) {
                 ec_t *ec = fop->xl->private;
 
                 /* This shouldn't fail because we have the inode locked. */

--- a/xlators/cluster/ec/src/ec-inode-read.c
+++ b/xlators/cluster/ec/src/ec-inode-read.c
@@ -271,7 +271,7 @@ ec_handle_special_xattrs(ec_fop_data_t *fop)
     /* Stime may not be available on all the bricks, so even if some of the
      * subvols succeed the operation, treat it as answer.*/
     if (fop->str[0] && fnmatch(GF_XATTR_STIME_PATTERN, fop->str[0], 0) == 0) {
-        if (!fop->answer || (fop->answer->op_ret < 0)) {
+        if (!fop->answer || IS_ERROR(fop->answer->op_ret)) {
             list_for_each_entry(cbk, &fop->cbk_list, list)
             {
                 if (cbk->op_ret >= 0) {
@@ -1132,7 +1132,7 @@ ec_readv_rebuild(ec_t *ec, ec_fop_data_t *fop, ec_cbk_data_t *cbk)
     uint64_t fsize = 0, size = 0, max = 0;
     int32_t pos, err = -ENOMEM;
 
-    if (cbk->op_ret < 0) {
+    if (IS_ERROR(cbk->op_ret)) {
         err = -cbk->op_errno;
 
         goto out;

--- a/xlators/cluster/ec/src/ec-inode-read.c
+++ b/xlators/cluster/ec/src/ec-inode-read.c
@@ -220,7 +220,7 @@ ec_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_GETXATTR, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (dict != NULL) {
                 cbk->dict = dict_ref(dict);
                 if (cbk->dict == NULL) {
@@ -274,7 +274,7 @@ ec_handle_special_xattrs(ec_fop_data_t *fop)
         if (!fop->answer || IS_ERROR(fop->answer->op_ret)) {
             list_for_each_entry(cbk, &fop->cbk_list, list)
             {
-                if (cbk->op_ret >= 0) {
+                if (IS_SUCCESS(cbk->op_ret)) {
                     fop->answer = cbk;
                     break;
                 }
@@ -398,7 +398,7 @@ ec_getxattr_heal_cbk(call_frame_t *frame, void *cookie, xlator_t *xl,
     char *str;
     char bin1[65], bin2[65];
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         dict = dict_new();
         if (dict == NULL) {
             op_ret = -1;
@@ -538,7 +538,7 @@ ec_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_FGETXATTR, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (dict != NULL) {
                 cbk->dict = dict_ref(dict);
                 if (cbk->dict == NULL) {
@@ -684,7 +684,7 @@ ec_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_OPEN, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (fd != NULL) {
                 cbk->fd = fd_ref(fd);
                 if (cbk->fd == NULL) {
@@ -740,7 +740,7 @@ ec_open_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int32_t error = 0;
 
     fop = fop->data;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         fop->answer->iatt[0] = *postbuf;
     } else {
         error = op_errno;
@@ -970,7 +970,7 @@ ec_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         if (xdata)
             cbk->xdata = dict_ref(xdata);
 
-        if (cbk->op_ret >= 0) {
+        if (IS_SUCCESS(cbk->op_ret)) {
             cbk->iatt[0] = *buf;
             cbk->str = gf_strdup(path);
             if (!cbk->str) {
@@ -1020,7 +1020,7 @@ ec_manager_readlink(ec_fop_data_t *fop, int32_t state)
                 return EC_STATE_DISPATCH;
             }
 
-            if ((cbk != NULL) && (cbk->op_ret >= 0)) {
+            if (IS_SUCCESS((cbk != NULL) && (cbk->op_ret))) {
                 ec_iatt_rebuild(fop->xl->private, &cbk->iatt[0], 1, 1);
             }
 
@@ -1261,7 +1261,7 @@ ec_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_READ, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             cbk->int32 = count;
 
             if (count > 0) {
@@ -1501,7 +1501,7 @@ ec_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_SEEK, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             cbk->offset = offset;
         }
         if (xdata != NULL) {
@@ -1574,7 +1574,7 @@ ec_manager_seek(ec_fop_data_t *fop, int32_t state)
             if (ec_dispatch_one_retry(fop, &cbk)) {
                 return EC_STATE_DISPATCH;
             }
-            if ((cbk != NULL) && (cbk->op_ret >= 0)) {
+            if (IS_SUCCESS((cbk != NULL) && (cbk->op_ret))) {
                 ec_t *ec = fop->xl->private;
 
                 /* This shouldn't fail because we have the inode locked. */
@@ -1719,7 +1719,7 @@ ec_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_STAT, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (buf != NULL) {
                 cbk->iatt[0] = *buf;
             }
@@ -1930,7 +1930,7 @@ ec_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_FSTAT, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (buf != NULL) {
                 cbk->iatt[0] = *buf;
             }

--- a/xlators/cluster/ec/src/ec-inode-write.c
+++ b/xlators/cluster/ec/src/ec-inode-write.c
@@ -1350,7 +1350,7 @@ ec_truncate_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int32_t err;
 
     fop->parent->good &= fop->good;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         fd_bind(fd);
         err = ec_update_truncate_write(fop->parent, fop->answer->mask);
         if (err != 0) {
@@ -1740,7 +1740,7 @@ ec_writev_merge_tail(call_frame_t *frame, void *cookie, xlator_t *this,
     ec_fop_data_t *fop = frame->local;
     uint64_t size, base, tmp;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         tmp = 0;
         size = fop->size - fop->user_size - fop->head;
         base = ec->stripe_size - size;
@@ -1773,7 +1773,7 @@ ec_writev_merge_head(call_frame_t *frame, void *cookie, xlator_t *this,
     ec_fop_data_t *fop = frame->local;
     uint64_t size, base;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         size = fop->head;
         base = 0;
 

--- a/xlators/cluster/ec/src/ec-inode-write.c
+++ b/xlators/cluster/ec/src/ec-inode-write.c
@@ -29,7 +29,7 @@ ec_update_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     ec_trace("UPDATE_WRITEV_CBK", cookie, "ret=%d, errno=%d, parent-fop=%s",
              op_ret, op_errno, ec_fop_name(parent->id));
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         ec_fop_set_error(parent, op_errno);
         goto out;
     }
@@ -133,7 +133,7 @@ ec_inode_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie,
     if (!cbk)
         goto out;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     if (xdata)
@@ -1173,7 +1173,7 @@ ec_manager_discard(ec_fop_data_t *fop, int32_t state)
 
     switch (state) {
         case EC_STATE_INIT:
-            if ((fop->size <= 0) || (fop->offset < 0)) {
+            if ((fop->size <= 0) || IS_ERROR(fop->offset)) {
                 ec_fop_set_error(fop, EINVAL);
                 return EC_STATE_REPORT;
             }

--- a/xlators/cluster/ec/src/ec-locks.c
+++ b/xlators/cluster/ec/src/ec-locks.c
@@ -29,7 +29,7 @@ ec_lock_check(ec_fop_data_t *fop, uintptr_t *mask)
 
     list_for_each_entry(ans, &fop->cbk_list, list)
     {
-        if (ans->op_ret >= 0) {
+        if (IS_SUCCESS(ans->op_ret)) {
             if (locked != 0) {
                 error = EIO;
             }
@@ -893,7 +893,7 @@ ec_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_LK, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (flock != NULL) {
                 cbk->flock.l_type = flock->l_type;
                 cbk->flock.l_whence = flock->l_whence;

--- a/xlators/cluster/ec/src/ec-locks.c
+++ b/xlators/cluster/ec/src/ec-locks.c
@@ -49,7 +49,7 @@ ec_lock_check(ec_fop_data_t *fop, uintptr_t *mask)
         }
     }
 
-    if (error == -1) {
+    if (IS_ERROR(error)) {
         if (gf_bits_count(locked | notlocked) >= ec->fragments) {
             if (notlocked == 0) {
                 if (fop->answer == NULL) {
@@ -75,7 +75,7 @@ ec_lock_check(ec_fop_data_t *fop, uintptr_t *mask)
                 }
             }
         } else {
-            if (fop->answer && fop->answer->op_ret < 0)
+            if (fop->answer && IS_ERROR(fop->answer->op_ret))
                 error = fop->answer->op_errno;
             else
                 error = EIO;
@@ -91,7 +91,7 @@ int32_t
 ec_lock_unlocked(call_frame_t *frame, void *cookie, xlator_t *this,
                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
 {
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, EC_MSG_UNLOCK_FAILED,
                "Failed to unlock an entry/inode");
     }
@@ -104,7 +104,7 @@ ec_lock_lk_unlocked(call_frame_t *frame, void *cookie, xlator_t *this,
                     int32_t op_ret, int32_t op_errno, struct gf_flock *flock,
                     dict_t *xdata)
 {
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, EC_MSG_LK_UNLOCK_FAILED,
                "Failed to unlock an lk");
     }
@@ -207,7 +207,7 @@ ec_manager_entrylk(ec_fop_data_t *fop, int32_t state)
                                         fop->entrylk_type, fop->xdata);
                         }
                     }
-                    if (fop->error < 0) {
+                    if (IS_ERROR(fop->error)) {
                         fop->error = 0;
 
                         fop->entrylk_cmd = ENTRYLK_LOCK;
@@ -582,7 +582,7 @@ ec_manager_inodelk(ec_fop_data_t *fop, int32_t state)
                                         fop->fd, F_SETLK, &flock, fop->xdata);
                         }
                     }
-                    if (fop->error < 0) {
+                    if (IS_ERROR(fop->error)) {
                         fop->error = 0;
 
                         fop->int32 = F_SETLKW;
@@ -979,7 +979,7 @@ ec_manager_lk(ec_fop_data_t *fop, int32_t state)
                               NULL, fop->fd, F_SETLK, &flock, fop->xdata);
                     }
 
-                    if (fop->error < 0) {
+                    if (IS_ERROR(fop->error)) {
                         fop->error = 0;
 
                         fop->int32 = F_SETLKW;

--- a/xlators/cluster/ec/src/ec.c
+++ b/xlators/cluster/ec/src/ec.c
@@ -133,7 +133,7 @@ _subvol_to_subvolid(dict_t *this, char *key, data_t *value, void *data)
         if (ec->xl_list[i] == subvol) {
             ret = dict_set_int32(this, key, i);
             /* -1 stops dict_foreach and returns -1*/
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 ret = -1;
             goto out;
         }
@@ -234,7 +234,7 @@ ec_assign_read_policy(ec_t *ec, char *read_policy)
     int read_policy_idx = -1;
 
     read_policy_idx = gf_get_index_by_elem(ec_read_policies, read_policy);
-    if (read_policy_idx < 0 || read_policy_idx >= EC_READ_POLICY_MAX)
+    if (IS_ERROR(read_policy_idx) || read_policy_idx >= EC_READ_POLICY_MAX)
         return -1;
 
     ec->read_policy = read_policy_idx;
@@ -738,7 +738,7 @@ ec_assign_read_mask(ec_t *ec, char *read_mask_str)
             goto out;
         }
 
-        if ((id < 0) || (id >= ec->nodes)) {
+        if (IS_ERROR((id)) || (id >= ec->nodes)) {
             gf_msg(ec->xl->name, GF_LOG_ERROR, 0, EC_MSG_XLATOR_INIT_FAIL,
                    "In read-mask \"%s\" id %d is not in range [0 - %d]",
                    read_mask_str, id, ec->nodes - 1);
@@ -881,7 +881,7 @@ init(xlator_t *this)
         goto failed;
     }
 
-    if (ec_subvol_to_subvol_id_transform(ec, ec->leaf_to_subvolid) < 0) {
+    if (IS_ERROR(ec_subvol_to_subvol_id_transform(ec, ec->leaf_to_subvolid))) {
         gf_msg(this->name, GF_LOG_ERROR, 0, EC_MSG_SUBVOL_ID_DICT_SET_FAIL,
                "Failed to build subvol-id "
                "dictionary");

--- a/xlators/debug/delay-gen/src/delay-gen.c
+++ b/xlators/debug/delay-gen/src/delay-gen.c
@@ -474,7 +474,7 @@ delay_gen_parse_fill_fops(dg_t *dg, char *enable_fops)
         op_no_str = strtok_r(dup_enable_fops, ",", &saveptr);
         while (op_no_str) {
             op_no = gf_fop_int(op_no_str);
-            if (op_no == -1) {
+            if (IS_ERROR(op_no)) {
                 gf_log(this->name, GF_LOG_WARNING, "Wrong option value %s",
                        op_no_str);
                 ret = -1;

--- a/xlators/debug/error-gen/src/error-gen.c
+++ b/xlators/debug/error-gen/src/error-gen.c
@@ -1361,7 +1361,7 @@ error_gen_parse_fill_fops(eg_t *pvt, char *enable_fops)
         op_no_str = strtok_r(enable_fops, ",", &saveptr);
         while (op_no_str) {
             op_no = gf_fop_int(op_no_str);
-            if (op_no == -1) {
+            if (IS_ERROR(op_no)) {
                 gf_log(this->name, GF_LOG_WARNING, "Wrong option value %s",
                        op_no_str);
             } else

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -322,7 +322,7 @@ ios_fd_ctx_get(fd_t *fd, xlator_t *this, struct ios_fd **iosfd)
 
     ret = fd_ctx_get(fd, this, &iosfd64);
     iosfdlong = iosfd64;
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         *iosfd = (void *)iosfdlong;
 
     return ret;
@@ -559,7 +559,7 @@ ios_inode_ctx_get(inode_t *inode, xlator_t *this, struct ios_stat **iosstat)
 
     ret = inode_ctx_get(inode, this, &iosstat64);
     iosstatlong = iosstat64;
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         *iosstat = (void *)iosstatlong;
 
     return ret;

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -322,7 +322,7 @@ ios_fd_ctx_get(fd_t *fd, xlator_t *this, struct ios_fd **iosfd)
 
     ret = fd_ctx_get(fd, this, &iosfd64);
     iosfdlong = iosfd64;
-    if (ret != -1)
+    if (ret >= 0)
         *iosfd = (void *)iosfdlong;
 
     return ret;
@@ -559,7 +559,7 @@ ios_inode_ctx_get(inode_t *inode, xlator_t *this, struct ios_stat **iosstat)
 
     ret = inode_ctx_get(inode, this, &iosstat64);
     iosstatlong = iosstat64;
-    if (ret != -1)
+    if (ret >= 0)
         *iosstat = (void *)iosstatlong;
 
     return ret;
@@ -813,7 +813,7 @@ io_stats_dump_global_to_json_logfp(xlator_t *this,
         goto out;
     }
 
-    if (interval == -1) {
+    if (IS_ERROR(interval)) {
         str_prefix = "aggr";
 
     } else {
@@ -833,7 +833,7 @@ io_stats_dump_global_to_json_logfp(xlator_t *this,
             rw_unit = "b";
         }
 
-        if (interval == -1) {
+        if (IS_ERROR(interval)) {
             ios_log(this, logfp, "\"%s.%s.read_%d%s\": %" GF_PRI_ATOMIC ",",
                     key_prefix, str_prefix, rw_size, rw_unit,
                     GF_ATOMIC_GET(stats->block_count_read[i]));
@@ -852,7 +852,7 @@ io_stats_dump_global_to_json_logfp(xlator_t *this,
         }
     }
 
-    if (interval == -1) {
+    if (IS_ERROR(interval)) {
         ios_log(this, logfp, "\"%s.%s.fds.open_count\": %" PRId64 ",",
                 key_prefix, str_prefix, conf->cumulative.nr_opens);
         ios_log(this, logfp, "\"%s.%s.fds.max_open_count\": %" PRId64 ",",
@@ -876,7 +876,7 @@ io_stats_dump_global_to_json_logfp(xlator_t *this,
                 fop_lat_max = stats->latency[i].max;
             }
         }
-        if (interval == -1) {
+        if (IS_ERROR(interval)) {
             ios_log(this, logfp, "\"%s.%s.fop.%s.count\": %" GF_PRI_ATOMIC ",",
                     key_prefix, str_prefix, lc_fop_name, fop_hits);
         } else {
@@ -922,7 +922,7 @@ io_stats_dump_global_to_json_logfp(xlator_t *this,
             lc_fop_name[j] = tolower(lc_fop_name[j]);
         }
         fop_hits = GF_ATOMIC_GET(stats->upcall_hits[i]);
-        if (interval == -1) {
+        if (IS_ERROR(interval)) {
             ios_log(this, logfp, "\"%s.%s.fop.%s.count\": %" GF_PRI_ATOMIC ",",
                     key_prefix, str_prefix, lc_fop_name, fop_hits);
         } else {
@@ -955,7 +955,7 @@ io_stats_dump_global_to_json_logfp(xlator_t *this,
                "the io-threads translator!");
     }
 
-    if (interval == -1) {
+    if (IS_ERROR(interval)) {
         ios_log(this, logfp, "\"%s.%s.uptime\": %" PRId64 ",", key_prefix,
                 str_prefix, (uint64_t)(now->tv_sec - stats->started_at.tv_sec));
         ios_log(this, logfp,
@@ -999,7 +999,7 @@ _resolve_username(xlator_t *this, uid_t uid)
 #else
     pwd_buf_len = -1;
 #endif
-    if (pwd_buf_len == -1) {
+    if (IS_ERROR(pwd_buf_len)) {
         pwd_buf_len = DEFAULT_PWD_BUF_SZ; /* per the man page */
     }
 
@@ -1037,7 +1037,7 @@ _resolve_group_name(xlator_t *this, gid_t gid)
 #else
     grp_buf_len = -1;
 #endif
-    if (grp_buf_len == -1) {
+    if (IS_ERROR(grp_buf_len)) {
         grp_buf_len = DEFAULT_GRP_BUF_SZ; /* per the man page */
     }
 
@@ -1228,7 +1228,7 @@ io_stats_dump_global_to_logfp(xlator_t *this, struct ios_global_stats *stats,
 
     conf = this->private;
 
-    if (interval == -1)
+    if (IS_ERROR(interval))
         ios_log(this, logfp, "\n=== Cumulative stats ===");
     else
         ios_log(this, logfp, "\n=== Interval %d stats ===", interval);
@@ -1322,7 +1322,7 @@ io_stats_dump_global_to_logfp(xlator_t *this, struct ios_global_stats *stats,
             "------ ----- ----- ----- ----- ----- ----- ----- "
             " ----- ----- ----- -----\n");
 
-    if (interval == -1) {
+    if (IS_ERROR(interval)) {
         LOCK(&conf->lock);
         {
             gf_time_fmt(timestr, sizeof timestr,
@@ -1395,7 +1395,7 @@ io_stats_dump_global_to_dict(xlator_t *this, struct ios_global_stats *stats,
     GF_ASSERT(dict);
     GF_ASSERT(this);
 
-    if (interval == -1)
+    if (IS_ERROR(interval))
         snprintf(key, sizeof(key), "cumulative");
     else
         snprintf(key, sizeof(key), "interval");
@@ -1961,7 +1961,7 @@ io_stats_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!path)
         goto unwind;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         GF_FREE(path);
         goto unwind;
     }
@@ -2014,7 +2014,7 @@ io_stats_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!path)
         goto unwind;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         GF_FREE(path);
         goto unwind;
     }
@@ -2276,7 +2276,7 @@ io_stats_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto unwind;
 
     UPDATE_PROFILE_STATS(frame, MKDIR);
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     /* allocate a struct ios_stat and set the inode ctx */
@@ -2320,7 +2320,7 @@ io_stats_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int ret = -1;
 
     UPDATE_PROFILE_STATS(frame, OPENDIR);
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     ios_fd_ctx_set(fd, this, 0);
@@ -3716,7 +3716,7 @@ xlator_set_loglevel(xlator_t *this, int log_level)
     active = ctx->active;
     top = active->first;
 
-    if (log_level == -1)
+    if (IS_ERROR(log_level))
         return;
 
     if (ctx->cmd_args.brick_mux) {

--- a/xlators/debug/trace/src/trace.c
+++ b/xlators/debug/trace/src/trace.c
@@ -107,7 +107,7 @@ trace_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
@@ -161,7 +161,7 @@ trace_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 out:
     /* for 'release' log */
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         fd_ctx_set(fd, this, 0);
 
     TRACE_STACK_UNWIND(open, frame, op_ret, op_errno, fd, xdata);
@@ -225,7 +225,7 @@ trace_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             snprintf(
                 string, sizeof(string), "%" PRId64 ": gfid=%s op_ret=%d buf=%s",
@@ -267,7 +267,7 @@ trace_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(prebuf, preopstr);
             TRACE_STAT_TO_STR(postbuf, postopstr);
 
@@ -962,7 +962,7 @@ trace_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 out:
     /* for 'releasedir' log */
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         fd_ctx_set(fd, this, 0);
 
     TRACE_STACK_UNWIND(opendir, frame, op_ret, op_errno, fd, xdata);

--- a/xlators/debug/trace/src/trace.c
+++ b/xlators/debug/trace/src/trace.c
@@ -346,7 +346,7 @@ trace_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         LOG_ELEMENT(conf, string);
     }
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     list_for_each_entry(entry, &buf->list, list)
@@ -3417,7 +3417,7 @@ setloglevel:
     this->private = conf;
     ret = 0;
 out:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         if (history)
             GF_FREE(history);
         if (conf)

--- a/xlators/features/arbiter/src/arbiter.c
+++ b/xlators/features/arbiter/src/arbiter.c
@@ -152,7 +152,7 @@ arbiter_fill_writev_xdata(fd_t *fd, dict_t *xdata, xlator_t *this)
     if (dict_get(xdata, GLUSTERFS_OPEN_FD_COUNT)) {
         ret = dict_set_uint32(rsp_xdata, GLUSTERFS_OPEN_FD_COUNT,
                               fd->inode->fd_count);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg_debug(this->name, 0,
                          "Failed to set dict value"
                          " for GLUSTERFS_OPEN_FD_COUNT");
@@ -160,7 +160,7 @@ arbiter_fill_writev_xdata(fd_t *fd, dict_t *xdata, xlator_t *this)
     }
     if (dict_get(xdata, GLUSTERFS_WRITE_IS_APPEND)) {
         ret = dict_set_uint32(rsp_xdata, GLUSTERFS_WRITE_IS_APPEND, is_append);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg_debug(this->name, 0,
                          "Failed to set dict value"
                          " for GLUSTERFS_WRITE_IS_APPEND");

--- a/xlators/features/barrier/src/barrier.c
+++ b/xlators/features/barrier/src/barrier.c
@@ -477,7 +477,7 @@ notify(xlator_t *this, int event, void *data, ...)
             dict = data;
             barrier_enabled = dict_get_str_boolean(dict, "barrier", -1);
 
-            if (barrier_enabled == -1) {
+            if (IS_ERROR(barrier_enabled)) {
                 gf_log(this->name, GF_LOG_ERROR,
                        "Could not fetch "
                        " barrier key from the dictionary.");
@@ -616,7 +616,7 @@ init(xlator_t *this)
 
     if (priv->barrier_enabled) {
         ret = __barrier_enable(this, priv);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto out;
     }
 

--- a/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot-scrub.c
@@ -53,7 +53,7 @@ bitd_fetch_signature(xlator_t *this, br_child_t *child, fd_t *fd,
 
     ret = syncop_fgetxattr(child->xl, fd, xattr, GLUSTERFS_GET_OBJECT_SIGNATURE,
                            NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         br_log_object(this, "fgetxattr", fd->inode->gfid, -ret);
         goto out;
     }
@@ -96,7 +96,7 @@ bitd_scrub_post_compute_check(xlator_t *this, br_child_t *child, fd_t *fd,
     br_isignature_out_t *signptr = NULL;
 
     ret = bitd_fetch_signature(this, child, fd, &xattr, &signptr);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (!skip_stat)
             br_inc_unsigned_file_count(scrub_stat);
         goto out;
@@ -148,7 +148,7 @@ bitd_signature_staleness(xlator_t *this, br_child_t *child, fd_t *fd,
     br_isignature_out_t *signptr = NULL;
 
     ret = bitd_fetch_signature(this, child, fd, &xattr, &signptr);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (!skip_stat)
             br_inc_unsigned_file_count(scrub_stat);
         goto out;
@@ -1630,7 +1630,7 @@ br_lookup_bad_obj_dir(xlator_t *this, br_child_t *child, uuid_t gfid)
     gf_uuid_copy(loc.gfid, gfid);
 
     ret = syncop_lookup(child->xl, &loc, &statbuf, NULL, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         gf_msg(this->name, GF_LOG_ERROR, 0, BRB_MSG_LOOKUP_FAILED,
                "failed to lookup the bad "
@@ -1666,7 +1666,7 @@ br_read_bad_object_dir(xlator_t *this, br_child_t *child, fd_t *fd,
 
     while ((ret = syncop_readdir(child->xl, fd, 131072, offset, &entries, NULL,
                                  &out_dict))) {
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         list_for_each_entry(entry, &entries.list, list)
@@ -1740,7 +1740,7 @@ br_get_bad_objects_from_child(xlator_t *this, dict_t *dict, br_child_t *child)
     gf_uuid_copy(loc.gfid, inode->gfid);
 
     ret = syncop_opendir(child->xl, &loc, fd, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         fd_unref(fd);
         fd = NULL;
@@ -1754,7 +1754,7 @@ br_get_bad_objects_from_child(xlator_t *this, dict_t *dict, br_child_t *child)
     fd_bind(fd);
 
     ret = br_read_bad_object_dir(this, child, fd, dict);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, BRB_MSG_BAD_OBJ_READDIR_FAIL,
                "readdir of the bad "
                "objects directory (%s) failed ",
@@ -1807,7 +1807,7 @@ br_collect_bad_objects_of_child(xlator_t *this, br_child_t *child, dict_t *dict,
         ret = dict_get_str(child_dict, entry, &path);
         len = snprintf(tmp, PATH_MAX, "%s ==> BRICK: %s\n path: %s", entry,
                        child->brick_path, path);
-        if ((len < 0) || (len >= PATH_MAX)) {
+        if (IS_ERROR((len)) || (len >= PATH_MAX)) {
             continue;
         }
         snprintf(main_key, PATH_MAX, "quarantine-%d", tmp_count);
@@ -1863,7 +1863,7 @@ br_collect_bad_objects_from_children(xlator_t *this, dict_t *dict)
 
         ret = br_collect_bad_objects_of_child(this, child, tmp_dict, child_dict,
                                               total_count);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             dict_unref(child_dict);
             continue;
         }

--- a/xlators/features/bit-rot/src/bitd/bit-rot.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.c
@@ -1775,7 +1775,7 @@ br_init_signer(xlator_t *this, br_private_t *priv)
     return 0;
 
 cleanup_threads:
-    for (IS_SUCCESS(i--; i); i--) {
+    for (i--; i >= 0; i--) {
         (void)gf_thread_cleanup_xint(priv->obj_queue->workers[i]);
     }
     GF_FREE(priv->obj_queue->workers);
@@ -1928,7 +1928,7 @@ br_free_children(xlator_t *this, br_private_t *priv, int count)
 {
     br_child_t *child = NULL;
 
-    for (IS_SUCCESS(--count; count); count--) {
+    for (--count; count >= 0; count--) {
         child = &priv->children[count];
         mem_pool_destroy(child->timer_pool);
         pthread_mutex_destroy(&child->lock);

--- a/xlators/features/bit-rot/src/bitd/bit-rot.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.c
@@ -1775,7 +1775,7 @@ br_init_signer(xlator_t *this, br_private_t *priv)
     return 0;
 
 cleanup_threads:
-    for (i--; i >= 0; i--) {
+    for (IS_SUCCESS(i--; i); i--) {
         (void)gf_thread_cleanup_xint(priv->obj_queue->workers[i]);
     }
     GF_FREE(priv->obj_queue->workers);
@@ -1928,7 +1928,7 @@ br_free_children(xlator_t *this, br_private_t *priv, int count)
 {
     br_child_t *child = NULL;
 
-    for (--count; count >= 0; count--) {
+    for (IS_SUCCESS(--count; count); count--) {
         child = &priv->children[count];
         mem_pool_destroy(child->timer_pool);
         pthread_mutex_destroy(&child->lock);

--- a/xlators/features/bit-rot/src/bitd/bit-rot.c
+++ b/xlators/features/bit-rot/src/bitd/bit-rot.c
@@ -202,7 +202,7 @@ br_object_lookup(xlator_t *this, br_object_t *object, struct iatt *iatt,
     gf_uuid_copy(loc.gfid, object->gfid);
 
     ret = syncop_lookup(object->child->xl, &loc, iatt, NULL, NULL, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     /*
@@ -295,7 +295,7 @@ br_object_read_block_and_sign(xlator_t *this, fd_t *fd, br_child_t *child,
     ret = syncop_readv(child->xl, fd, size, offset, 0, &iovec, &count, &iobref,
                        NULL, NULL, NULL);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, BRB_MSG_READV_FAILED,
                 "gfid=%s", uuid_utoa(fd->inode->gfid), NULL);
         ret = -1;
@@ -346,7 +346,7 @@ br_calculate_obj_checksum(unsigned char *md, br_child_t *child, fd_t *fd,
     while (1) {
         ret = br_object_read_block_and_sign(this, fd, child, offset, block,
                                             &sha256);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_smsg(this->name, GF_LOG_ERROR, 0, BRB_MSG_BLOCK_READ_FAILED,
                     "offset=%" PRIu64, offset, "object-gfid=%s",
                     uuid_utoa(fd->inode->gfid), NULL);
@@ -914,7 +914,7 @@ br_prepare_loc(xlator_t *this, br_child_t *child, loc_t *parent,
     gf_uuid_copy(loc->pargfid, parent->inode->gfid);
 
     ret = inode_path(parent->inode, entry->d_name, (char **)&loc->path);
-    if (ret < 0 || !loc->path) {
+    if (IS_ERROR(ret) || !loc->path) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, BRB_MSG_PATH_FAILED,
                 "inode_path=%s", entry->d_name, "parent-gfid=%s",
                 uuid_utoa(parent->inode->gfid), NULL);
@@ -1016,7 +1016,7 @@ bitd_oneshot_crawl(xlator_t *subvol, gf_dirent_t *entry, loc_t *parent,
 
     ret = syncop_getxattr(child->xl, &loc, &xattr,
                           GLUSTERFS_GET_OBJECT_SIGNATURE, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         br_log_object(this, "getxattr", linked_inode->gfid, op_errno);
 
@@ -1618,7 +1618,7 @@ notify(xlator_t *this, int32_t event, void *data, ...)
 
     switch (event) {
         case GF_EVENT_CHILD_UP:
-            if (idx < 0) {
+            if (IS_ERROR(idx)) {
                 gf_smsg(this->name, GF_LOG_ERROR, 0, BRB_MSG_INVALID_SUBVOL,
                         "event=%d", event, NULL);
                 goto out;
@@ -1647,7 +1647,7 @@ notify(xlator_t *this, int32_t event, void *data, ...)
             break;
 
         case GF_EVENT_CHILD_DOWN:
-            if (idx < 0) {
+            if (IS_ERROR(idx)) {
                 gf_smsg(this->name, GF_LOG_ERROR, 0, BRB_MSG_INVALID_SUBVOL,
                         "event=%d", event, NULL);
                 goto out;

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
@@ -228,7 +228,7 @@ br_stub_check_stub_file(xlator_t *this, char *path)
         if (errno != ENOENT)
             goto error_return;
         fd = sys_creat(path, 0);
-        if (fd < 0)
+        if (IS_ERROR(fd))
             gf_smsg(this->name, GF_LOG_ERROR, errno,
                     BRS_MSG_BAD_OBJECT_DIR_FAIL, "create-path=%s", path, NULL);
     }
@@ -474,7 +474,7 @@ br_stub_fill_readdir(fd_t *fd, br_stub_fd_t *fctx, DIR *dir, off_t off,
     while (filled <= size) {
         in_case = (u_long)telldir(dir);
 
-        if (in_case == -1) {
+        if (IS_ERROR(in_case)) {
             gf_smsg(THIS->name, GF_LOG_ERROR, 0,
                     BRS_MSG_BAD_OBJECT_DIR_TELL_FAIL, "dir=%p", dir, "err=%s",
                     strerror(errno), NULL);
@@ -731,7 +731,7 @@ br_stub_get_path_of_gfid(xlator_t *this, inode_t *parent, inode_t *inode,
 
     ret = syncop_gfid_to_path_hard(parent->table, FIRST_CHILD(this), gfid,
                                    inode, path, _gf_true);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_smsg(this->name, GF_LOG_WARNING, 0, BRS_MSG_PATH_GET_FAILED,
                 "gfid=%s", uuid_utoa_r(gfid, gfid_str), NULL);
 
@@ -750,10 +750,10 @@ br_stub_get_path_of_gfid(xlator_t *this, inode_t *parent, inode_t *inode,
      * found in the inode table and better not to do inode_path() on the
      * inode which has not been linked.
      */
-    if (ret < 0 && inode) {
+    if (IS_ERROR(ret) && inode) {
         ret = syncop_gfid_to_path_hard(parent->table, FIRST_CHILD(this), gfid,
                                        inode, path, _gf_false);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_smsg(this->name, GF_LOG_WARNING, 0, BRS_MSG_PATH_GET_FAILED,
                     "from-memory  gfid=%s", uuid_utoa_r(gfid, gfid_str), NULL);
     }

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
@@ -233,7 +233,7 @@ br_stub_check_stub_file(xlator_t *this, char *path)
                     BRS_MSG_BAD_OBJECT_DIR_FAIL, "create-path=%s", path, NULL);
     }
 
-    if (fd >= 0) {
+    if (IS_SUCCESS(fd)) {
         sys_close(fd);
         ret = 0;
     }

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub.c
@@ -98,7 +98,7 @@ br_stub_bad_object_container_init(xlator_t *this, br_stub_private_t *priv)
 
     INIT_LIST_HEAD(&priv->container.bad_queue);
     ret = br_stub_dir_create(this, priv);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto cleanup_lock;
 
     ret = gf_thread_create(&priv->container.thread, &w_attr, br_stub_worker,
@@ -573,7 +573,7 @@ br_stub_need_versioning(xlator_t *this, fd_t *fd, gf_boolean_t *versioning,
      * applicable.
      */
     ret = br_stub_get_inode_ctx(this, fd->inode, &ctx_addr);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = br_stub_init_inode_versions(this, fd, fd->inode, version,
                                           _gf_true, _gf_false, &ctx_addr);
         if (ret) {
@@ -667,7 +667,7 @@ br_stub_mark_inode_modified(xlator_t *this, br_stub_local_t *local)
     fd = local->u.context.fd;
 
     ret = br_stub_get_inode_ctx(this, fd->inode, &ctx_addr);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = br_stub_init_inode_versions(this, fd, fd->inode, version,
                                           _gf_true, _gf_false, &ctx_addr);
         if (ret)
@@ -711,7 +711,7 @@ br_stub_check_bad_object(xlator_t *this, inode_t *inode, int32_t *op_ret,
         *op_errno = EIO;
     }
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         ret = br_stub_init_inode_versions(this, NULL, inode, version, _gf_true,
                                           _gf_false, NULL);
         if (ret) {
@@ -739,18 +739,18 @@ br_stub_fd_incversioning_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     br_stub_local_t *local = NULL;
 
     local = (br_stub_local_t *)frame->local;
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto done;
     fd = local->u.context.fd;
     inode = local->u.context.inode;
     version = local->u.context.version;
 
     op_ret = br_stub_mod_inode_versions(this, fd, inode, version);
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         op_errno = EINVAL;
 
 done:
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         frame->local = NULL;
         call_unwind_error(local->fopstub, -1, op_errno);
         br_stub_cleanup_local(local);
@@ -1262,7 +1262,7 @@ br_stub_fsetxattr_bad_object_cbk(call_frame_t *frame, void *cookie,
     local = frame->local;
     frame->local = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     /*
@@ -1549,7 +1549,7 @@ int
 br_stub_listxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                       int op_ret, int op_errno, dict_t *xattr, dict_t *xdata)
 {
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     br_stub_remove_vxattrs(xattr, _gf_true);
@@ -1653,7 +1653,7 @@ br_stub_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     BR_STUB_VER_ENABLED_IN_CALLPATH(frame, ver_enabled);
     priv = this->private;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
     BR_STUB_VER_COND_GOTO(priv, (!ver_enabled), delkeys);
 
@@ -1721,7 +1721,7 @@ br_stub_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     op_errno = EINVAL;
     ret = dict_set_bin(xattr, GLUSTERFS_GET_OBJECT_SIGNATURE, (void *)sign,
                        totallen);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         GF_FREE(sign);
         goto delkeys;
     }
@@ -1766,7 +1766,7 @@ br_stub_send_stub_init_time(call_frame_t *frame, xlator_t *this)
 
     op_ret = dict_set_static_bin(xattr, GLUSTERFS_GET_BR_STUB_INIT_TIME,
                                  (void *)&stub, sizeof(br_stub_init_t));
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         op_errno = EINVAL;
         goto unwind;
     }
@@ -1989,7 +1989,7 @@ br_stub_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     frame->local = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     ret = br_stub_mark_inode_modified(this, local);
@@ -2127,7 +2127,7 @@ br_stub_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     frame->local = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     ret = br_stub_mark_inode_modified(this, local);
@@ -2240,7 +2240,7 @@ br_stub_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     frame->local = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     ret = br_stub_mark_inode_modified(this, local);
@@ -2500,14 +2500,14 @@ br_stub_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     priv = this->private;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     if (!priv->do_versioning)
         goto unwind;
 
     ret = br_stub_get_inode_ctx(this, fd->inode, &ctx_addr);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = br_stub_init_inode_versions(this, fd, inode, version, _gf_true,
                                           _gf_false, &ctx_addr);
         if (ret) {
@@ -2557,7 +2557,7 @@ br_stub_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     priv = this->private;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     if (!priv->do_versioning)
@@ -2745,7 +2745,7 @@ br_stub_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     BR_STUB_VER_COND_GOTO(priv, (!ver_enabled), unwind);
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     list_for_each_entry(entry, &entries->list, list)
@@ -2778,7 +2778,7 @@ br_stub_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
          * related xattrs.
          */
         ret = br_stub_get_inode_ctx(this, entry->inode, &ctxaddr);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             ctxaddr = 0;
         if (ctxaddr) { /* already has the context */
             br_stub_remove_vxattrs(entry->dict, _gf_true);
@@ -2928,7 +2928,7 @@ br_stub_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     BR_STUB_VER_ENABLED_IN_CALLPATH(frame, ver_enabled);
     priv = this->private;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         (void)br_stub_handle_lookup_error(this, inode, op_errno);
 
         /*
@@ -2971,7 +2971,7 @@ br_stub_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     ret = br_stub_lookup_version(this, stbuf->ia_gfid, inode, xattr);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = EINVAL;
         goto delkey;
@@ -3032,7 +3032,7 @@ br_stub_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     }
 
     ret = br_stub_get_inode_ctx(this, loc->inode, &ctx_addr);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         ctx_addr = 0;
     if (ctx_addr != 0)
         goto wind;
@@ -3175,7 +3175,7 @@ br_stub_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     frame->local = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     if (!local) {
@@ -3460,7 +3460,7 @@ br_stub_releasedir(xlator_t *this, fd_t *fd)
     int ret = 0;
 
     ret = fd_ctx_del(fd, this, &ctx);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     fctx = (br_stub_fd_t *)(long)ctx;
@@ -3494,14 +3494,14 @@ br_stub_ictxmerge(xlator_t *this, fd_t *fd, inode_t *inode,
     br_stub_fd_t *br_stub_fd = NULL;
 
     ret = br_stub_get_inode_ctx(this, inode, &ctxaddr);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto done;
     ctx = (br_stub_inode_ctx_t *)(uintptr_t)ctxaddr;
 
     LOCK(&linked_inode->lock);
     {
         ret = __br_stub_get_inode_ctx(this, linked_inode, &lctxaddr);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto unblock;
         lctx = (br_stub_inode_ctx_t *)(uintptr_t)lctxaddr;
 

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub.h
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub.h
@@ -311,7 +311,7 @@ br_stub_get_ongoing_version(xlator_t *this, inode_t *inode,
     LOCK(&inode->lock);
     {
         ret = __inode_ctx_get(inode, this, &ctx_addr);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto unblock;
         ctx = (br_stub_inode_ctx_t *)(long)ctx_addr;
         *version = ctx->currentversion;
@@ -336,7 +336,7 @@ __br_stub_get_ongoing_version_ctx(xlator_t *this, inode_t *inode,
     br_stub_inode_ctx_t *ctx = NULL;
 
     ret = __inode_ctx_get(inode, this, &ctx_addr);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return NULL;
     ctx = (br_stub_inode_ctx_t *)(long)ctx_addr;
     if (version)

--- a/xlators/features/changelog/lib/examples/c/get-changes.c
+++ b/xlators/features/changelog/lib/examples/c/get-changes.c
@@ -57,7 +57,7 @@ main(int argc, char **argv)
     while (1) {
         i = 0;
         nr_changes = gf_changelog_scan();
-        if (nr_changes < 0) {
+        if (IS_ERROR(nr_changes)) {
             handle_error("scan(): ");
             break;
         }
@@ -81,7 +81,7 @@ main(int argc, char **argv)
                 handle_error("gf_changelog_done");
         }
 
-        if (changes == -1)
+        if (IS_ERROR(changes))
             handle_error("gf_changelog_next_change");
 
     next:

--- a/xlators/features/changelog/lib/examples/c/get-history.c
+++ b/xlators/features/changelog/lib/examples/c/get-history.c
@@ -59,7 +59,7 @@ main(int argc, char **argv)
     scanf("%d%d", &a, &b);
     ret = gf_history_changelog("/export/z1/zwoop/.glusterfs/changelogs", a, b,
                                3, &end_ts);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         printf("history failed");
         goto out;
     }
@@ -71,7 +71,7 @@ main(int argc, char **argv)
     while (1) {
         nr_changes = gf_history_changelog_scan();
         printf("scanned, nr_changes : %d\n", nr_changes);
-        if (nr_changes < 0) {
+        if (IS_ERROR(nr_changes)) {
             handle_error("scan(): ");
             break;
         }
@@ -98,7 +98,7 @@ main(int argc, char **argv)
                 handle_error("gf_changelog_done");
         }
         /*
-        if (changes == -1)
+        if (IS_ERROR(changes))
                 handle_error ("gf_changelog_next_change");
         if (nr_changes ==1){
                 printf("continue scanning\n");

--- a/xlators/features/changelog/lib/src/gf-changelog-api.c
+++ b/xlators/features/changelog/lib/src/gf-changelog-api.c
@@ -127,7 +127,7 @@ gf_changelog_next_change(char *bufptr, size_t maxlen)
     tracker_fd = jnl->jnl_fd;
 
     size = gf_readline(tracker_fd, buffer, maxlen);
-    if (size < 0) {
+    if (IS_ERROR(size)) {
         size = -1;
         goto out;
     }

--- a/xlators/features/changelog/lib/src/gf-changelog-helpers.c
+++ b/xlators/features/changelog/lib/src/gf-changelog-helpers.c
@@ -66,7 +66,7 @@ my_read(read_line_t *tsd, int fd, char *ptr)
     if (tsd->rl_cnt <= 0) {
         tsd->rl_cnt = sys_read(fd, tsd->rl_buf, MAXLINE);
 
-        if (tsd->rl_cnt < 0)
+        if (IS_ERROR(tsd->rl_cnt))
             return -1;
         else if (tsd->rl_cnt == 0)
             return 0;
@@ -111,7 +111,7 @@ gf_lseek(int fd, off_t offset, int whence)
     read_line_t *tsd = &thread_tsd;
 
     off = sys_lseek(fd, offset, whence);
-    if (off == -1)
+    if (IS_ERROR(off))
         return -1;
 
     tsd->rl_cnt = 0;

--- a/xlators/features/changelog/lib/src/gf-changelog-journal-handler.c
+++ b/xlators/features/changelog/lib/src/gf-changelog-journal-handler.c
@@ -440,13 +440,13 @@ gf_changelog_decode(xlator_t *this, gf_changelog_journal_t *jnl, int from_fd,
 
     CHANGELOG_GET_HEADER_INFO(from_fd, buffer, sizeof(buffer), encoding,
                               major_version, minor_version, elen);
-    if (encoding == -1) /* unknown encoding */
+    if (IS_ERROR(encoding)) /* unknown encoding */
         goto out;
 
-    if (major_version == -1) /* unknown major version */
+    if (IS_ERROR(major_version)) /* unknown major version */
         goto out;
 
-    if (minor_version == -1) /* unknown minor version */
+    if (IS_ERROR(minor_version)) /* unknown minor version */
         goto out;
 
     if (!CHANGELOG_VALID_ENCODING(encoding))
@@ -463,13 +463,13 @@ gf_changelog_decode(xlator_t *this, gf_changelog_journal_t *jnl, int from_fd,
         version_idx = VERSION_1_2;
     }
 
-    if (version_idx == -1) /* unknown version number */
+    if (IS_ERROR(version_idx)) /* unknown version number */
         goto out;
 
     /**
      * start processing after the header
      */
-    if (sys_lseek(from_fd, elen, SEEK_SET) < 0) {
+    if (IS_ERROR(sys_lseek(from_fd, elen, SEEK_SET))) {
         goto out;
     }
     switch (encoding) {
@@ -568,7 +568,7 @@ gf_changelog_consume(xlator_t *this, gf_changelog_journal_t *jnl,
     }
 
     fd1 = open(from_path, O_RDONLY);
-    if (fd1 < 0) {
+    if (IS_ERROR(fd1)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_LIB_MSG_OPEN_FAILED,
                 "path=%s", from_path, NULL);
         goto out;
@@ -576,7 +576,7 @@ gf_changelog_consume(xlator_t *this, gf_changelog_journal_t *jnl,
 
     fd2 = open(to_path, O_CREAT | O_TRUNC | O_RDWR,
                S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-    if (fd2 < 0) {
+    if (IS_ERROR(fd2)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_LIB_MSG_OPEN_FAILED,
                 "path=%s", to_path, NULL);
         goto close_fd;
@@ -869,7 +869,7 @@ gf_changelog_open_dirs(xlator_t *this, gf_changelog_journal_t *jnl)
 
     tracker_fd = open(tracker_path, O_CREAT | O_APPEND | O_RDWR,
                       S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-    if (tracker_fd < 0) {
+    if (IS_ERROR(tracker_fd)) {
         sys_closedir(jnl->jnl_dir);
         ret = -1;
         goto out;

--- a/xlators/features/changelog/lib/src/gf-changelog-reborp.c
+++ b/xlators/features/changelog/lib/src/gf-changelog-reborp.c
@@ -309,7 +309,7 @@ gf_changelog_event_handler(rpcsvc_request_t *req, xlator_t *this,
 
     len = xdr_to_generic(req->msg[0], &rpc_req,
                          (xdrproc_t)xdr_changelog_event_req);
-    if (len < 0) {
+    if (IS_ERROR(len)) {
         gf_msg(this->name, GF_LOG_ERROR, 0,
                CHANGELOG_LIB_MSG_XDR_DECODING_FAILED, "xdr decoding failed");
         req->rpc_err = GARBAGE_ARGS;

--- a/xlators/features/changelog/lib/src/gf-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-changelog.c
@@ -452,7 +452,7 @@ gf_changelog_setup_logging(xlator_t *this, char *logfile, int loglevel)
     if (gf_log_init(this->ctx, logfile, NULL))
         return -1;
 
-    gf_log_set_loglevel(this->ctx, (loglevel == -1) ? GF_LOG_INFO : loglevel);
+    gf_log_set_loglevel(this->ctx, IS_ERROR(loglevel) ? GF_LOG_INFO : loglevel);
     return 0;
 }
 

--- a/xlators/features/changelog/lib/src/gf-history-changelog.c
+++ b/xlators/features/changelog/lib/src/gf-history-changelog.c
@@ -181,7 +181,7 @@ gf_history_changelog_next_change(char *bufptr, size_t maxlen)
     tracker_fd = hist_jnl->jnl_fd;
 
     size = gf_readline(tracker_fd, buffer, maxlen);
-    if (size < 0) {
+    if (IS_ERROR(size)) {
         size = -1;
         goto out;
     }
@@ -256,7 +256,7 @@ retry:
         is_last_scan = 1;
 
     errno = EINVAL;
-    if (hist_jnl->hist_done == -1)
+    if (IS_ERROR(hist_jnl->hist_done))
         goto out;
 
     tracker_fd = hist_jnl->jnl_fd;
@@ -333,7 +333,7 @@ gf_history_get_timestamp(int fd, int index, int len, unsigned long *ts)
     }
 
     n_read = sys_pread(fd, path_buf, len, offset);
-    if (n_read < 0) {
+    if (IS_ERROR(n_read)) {
         ret = -1;
         gf_msg(this->name, GF_LOG_ERROR, errno, CHANGELOG_LIB_MSG_READ_ERROR,
                "could not read from htime file");
@@ -360,7 +360,7 @@ gf_history_check(int fd, int target_index, unsigned long value, int len)
 
     if (target_index == 0) {
         ret = gf_history_get_timestamp(fd, target_index, len, &ts1);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto out;
         if (value <= ts1)
             goto out;
@@ -371,10 +371,10 @@ gf_history_check(int fd, int target_index, unsigned long value, int len)
     }
 
     ret = gf_history_get_timestamp(fd, target_index, len, &ts1);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
     ret = gf_history_get_timestamp(fd, target_index - 1, len, &ts2);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     if ((value <= ts1) && (value > ts2)) {
@@ -419,7 +419,7 @@ gf_history_b_search(int fd, unsigned long value, unsigned long from,
              * return accordingly
              */
             ret = gf_history_get_timestamp(fd, from, len, &ts1);
-            if (ret == -1)
+            if (IS_ERROR(ret))
                 goto out;
             if (ts1 >= value) {
                 /* actually compatision should be
@@ -435,13 +435,13 @@ gf_history_b_search(int fd, unsigned long value, unsigned long from,
     }
 
     ret = gf_history_get_timestamp(fd, m_index, len, &cur_value);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
     if (cur_value == value) {
         return m_index;
     } else if (value > cur_value) {
         ret = gf_history_get_timestamp(fd, m_index + 1, len, &cur_value);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto out;
         if (value < cur_value)
             return m_index + 1;
@@ -455,7 +455,7 @@ gf_history_b_search(int fd, unsigned long value, unsigned long from,
             return 0;
         } else {
             ret = gf_history_get_timestamp(fd, m_index - 1, len, &cur_value);
-            if (ret == -1)
+            if (IS_ERROR(ret))
                 goto out;
             if (value > cur_value) {
                 return m_index;
@@ -510,7 +510,7 @@ gf_changelog_consume_wrap(void *data)
     ccd->retval = -1;
 
     nread = sys_pread(ccd->fd, ccd->changelog, PATH_MAX - 1, ccd->offset);
-    if (nread < 0) {
+    if (IS_ERROR(nread)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, CHANGELOG_LIB_MSG_READ_ERROR,
                "cannot read from history metadata file");
         goto out;
@@ -732,7 +732,7 @@ gf_changelog_extract_min_max(const char *dname, const char *htime_dir, int *fd,
     }
 
     *fd = open(htime_file, O_RDONLY);
-    if (*fd < 0) {
+    if (IS_ERROR(*fd)) {
         ret = -1;
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_LIB_MSG_HTIME_ERROR,
                 "op=open", "path=%s", htime_file, NULL);
@@ -741,7 +741,7 @@ gf_changelog_extract_min_max(const char *dname, const char *htime_dir, int *fd,
 
     /* Looks good, extract max timestamp */
     ret = sys_fgetxattr(*fd, HTIME_KEY, x_value, sizeof(x_value));
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -1;
         gf_smsg(this->name, GF_LOG_ERROR, errno,
                 CHANGELOG_LIB_MSG_GET_XATTR_FAILED, "path=%s", htime_file,
@@ -885,7 +885,7 @@ gf_history_changelog(char *changelog_dir, unsigned long start,
              * TODO: handle short reads later...
              */
             n_read = sys_read(fd, buffer, PATH_MAX);
-            if (n_read < 0) {
+            if (IS_ERROR(n_read)) {
                 ret = -1;
                 gf_msg(this->name, GF_LOG_ERROR, errno,
                        CHANGELOG_LIB_MSG_READ_ERROR,
@@ -943,11 +943,11 @@ gf_history_changelog(char *changelog_dir, unsigned long start,
             }
 
             ret = gf_history_get_timestamp(fd, from, len, &ts1);
-            if (ret == -1)
+            if (IS_ERROR(ret))
                 goto out;
 
             ret = gf_history_get_timestamp(fd, to, len, &ts2);
-            if (ret == -1)
+            if (IS_ERROR(ret))
                 goto out;
 
             gf_smsg(this->name, GF_LOG_INFO, 0, CHANGELOG_LIB_MSG_FINAL_INFO,
@@ -1000,7 +1000,7 @@ out:
     if (dirp != NULL)
         (void)sys_closedir(dirp);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (fd != -1)
             (void)sys_close(fd);
         GF_FREE(hist_data);

--- a/xlators/features/changelog/src/changelog-helpers.c
+++ b/xlators/features/changelog/src/changelog-helpers.c
@@ -255,7 +255,7 @@ htime_update(xlator_t *this, changelog_priv_t *priv, unsigned long ts,
     /* time stamp(10) + : (1) + rolltime (12 ) + buffer (2) */
     int ret = 0;
 
-    if (priv->htime_fd == -1) {
+    if (IS_ERROR(priv->htime_fd)) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, CHANGELOG_MSG_HTIME_ERROR,
                 "reason=fd not available", NULL);
         ret = -1;
@@ -266,7 +266,8 @@ htime_update(xlator_t *this, changelog_priv_t *priv, unsigned long ts,
         ret = -1;
         goto out;
     }
-    if (changelog_write(priv->htime_fd, (void *)changelog_path, len + 1) < 0) {
+    if (IS_ERROR(
+            changelog_write(priv->htime_fd, (void *)changelog_path, len + 1))) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, CHANGELOG_MSG_HTIME_ERROR,
                 "reason=write failed", NULL);
         ret = -1;
@@ -331,7 +332,7 @@ cl_is_empty(xlator_t *this, int fd)
     }
 
     ret = sys_lseek(fd, 0, SEEK_SET);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_MSG_LSEEK_OP_FAILED,
                 NULL);
         goto out;
@@ -405,14 +406,14 @@ changelog_rollover_changelog(xlator_t *this, changelog_priv_t *priv,
 
     if (priv->changelog_fd != -1) {
         ret = sys_fsync(priv->changelog_fd);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_smsg(this->name, GF_LOG_ERROR, errno,
                     CHANGELOG_MSG_FSYNC_OP_FAILED, NULL);
         }
         ret = cl_is_empty(this, priv->changelog_fd);
         if (ret == 1) {
             cl_empty_flag = 1;
-        } else if (ret == -1) {
+        } else if (IS_ERROR(ret)) {
             /* Log error but proceed as usual */
             gf_smsg(this->name, GF_LOG_WARNING, 0,
                     CHANGELOG_MSG_DETECT_EMPTY_CHANGELOG_FAILED, NULL);
@@ -450,7 +451,7 @@ changelog_rollover_changelog(xlator_t *this, changelog_priv_t *priv,
         if (errno == ENOENT) {
             ret = mkdir_p(nfile_dir, 0600, _gf_true);
 
-            if ((ret == -1) && (EEXIST != errno)) {
+            if (IS_ERROR(ret) && (EEXIST != errno)) {
                 gf_smsg(this->name, GF_LOG_ERROR, errno,
                         CHANGELOG_MSG_MKDIR_ERROR, "%s", nfile_dir, NULL);
                 goto out;
@@ -478,7 +479,7 @@ changelog_rollover_changelog(xlator_t *this, changelog_priv_t *priv,
             update_path(this, nfile);
         }
         ret = htime_update(this, priv, ts, nfile);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_smsg(this->name, GF_LOG_ERROR, 0, CHANGELOG_MSG_HTIME_ERROR,
                     NULL);
             goto out;
@@ -553,7 +554,7 @@ find_current_htime(int ht_dir_fd, const char *ht_dir_path, char *ht_file_bname)
     GF_ASSERT(ht_dir_path);
 
     cnt = scandir(ht_dir_path, &namelist, filter_cur_par_dirs, alphasort);
-    if (cnt < 0) {
+    if (IS_ERROR(cnt)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_MSG_SCAN_DIR_FAILED,
                 NULL);
     } else if (cnt > 0) {
@@ -570,7 +571,7 @@ find_current_htime(int ht_dir_fd, const char *ht_dir_path, char *ht_file_bname)
             goto out;
         }
 
-        if (sys_fsync(ht_dir_fd) < 0) {
+        if (IS_ERROR(sys_fsync(ht_dir_fd))) {
             gf_smsg(this->name, GF_LOG_ERROR, errno,
                     CHANGELOG_MSG_FSYNC_OP_FAILED, NULL);
             ret = -1;
@@ -627,7 +628,7 @@ htime_open(xlator_t *this, changelog_priv_t *priv, unsigned long ts)
 
     /* Open htime directory to get HTIME_CURRENT */
     ht_dir_fd = open(ht_dir_path, O_RDONLY);
-    if (ht_dir_fd == -1) {
+    if (IS_ERROR(ht_dir_fd)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_MSG_OPEN_FAILED,
                 "path=%s", ht_dir_path, NULL);
         ret = -1;
@@ -636,7 +637,7 @@ htime_open(xlator_t *this, changelog_priv_t *priv, unsigned long ts)
 
     size = sys_fgetxattr(ht_dir_fd, HTIME_CURRENT, ht_file_bname,
                          sizeof(ht_file_bname));
-    if (size < 0) {
+    if (IS_ERROR(size)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_MSG_FGETXATTR_FAILED,
                 "name=HTIME_CURRENT", NULL);
 
@@ -659,7 +660,7 @@ htime_open(xlator_t *this, changelog_priv_t *priv, unsigned long ts)
     gf_smsg(this->name, GF_LOG_INFO, 0, CHANGELOG_MSG_HTIME_CURRENT, "path=%s",
             ht_file_bname, NULL);
     len = snprintf(ht_file_path, PATH_MAX, "%s/%s", ht_dir_path, ht_file_bname);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         ret = -1;
         goto out;
     }
@@ -668,7 +669,7 @@ htime_open(xlator_t *this, changelog_priv_t *priv, unsigned long ts)
     flags |= (O_RDWR | O_SYNC | O_APPEND);
     ht_file_fd = open(ht_file_path, flags,
                       S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-    if (ht_file_fd < 0) {
+    if (IS_ERROR(ht_file_fd)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_MSG_OPEN_FAILED,
                 "path=%s", ht_file_path, NULL);
         ret = -1;
@@ -679,7 +680,7 @@ htime_open(xlator_t *this, changelog_priv_t *priv, unsigned long ts)
     priv->htime_fd = ht_file_fd;
 
     ret = sys_fstat(ht_file_fd, &stat_buf);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_MSG_HTIME_STAT_ERROR,
                 "path=%s", ht_file_path, NULL);
         ret = -1;
@@ -688,7 +689,7 @@ htime_open(xlator_t *this, changelog_priv_t *priv, unsigned long ts)
 
     /* Initialize rollover-number in priv to current number */
     size = sys_fgetxattr(ht_file_fd, HTIME_KEY, x_value, sizeof(x_value));
-    if (size < 0) {
+    if (IS_ERROR(size)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_MSG_FGETXATTR_FAILED,
                 "name=%s", HTIME_KEY, "path=%s", ht_file_path, NULL);
         ret = -1;
@@ -748,7 +749,7 @@ htime_create(xlator_t *this, changelog_priv_t *priv, unsigned long ts)
     /* get the htime file name in ht_file_path */
     len = snprintf(ht_file_path, PATH_MAX, "%s/%s.%lu", ht_dir_path,
                    HTIME_FILE_NAME, ts);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         ret = -1;
         goto out;
     }
@@ -756,7 +757,7 @@ htime_create(xlator_t *this, changelog_priv_t *priv, unsigned long ts)
     flags |= (O_CREAT | O_RDWR | O_SYNC);
     ht_file_fd = open(ht_file_path, flags,
                       S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-    if (ht_file_fd < 0) {
+    if (IS_ERROR(ht_file_fd)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_MSG_OPEN_FAILED,
                 "path=%s", ht_file_path, NULL);
         ret = -1;
@@ -772,7 +773,7 @@ htime_create(xlator_t *this, changelog_priv_t *priv, unsigned long ts)
     }
 
     ret = sys_fsync(ht_file_fd);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_MSG_FSYNC_OP_FAILED,
                 NULL);
         goto out;
@@ -785,7 +786,7 @@ htime_create(xlator_t *this, changelog_priv_t *priv, unsigned long ts)
 
     /* Set xattr HTIME_CURRENT on htime directory to htime filename */
     ht_dir_fd = open(ht_dir_path, O_RDONLY);
-    if (ht_dir_fd == -1) {
+    if (IS_ERROR(ht_dir_fd)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_MSG_OPEN_FAILED,
                 "path=%s", ht_dir_path, NULL);
         ret = -1;
@@ -803,7 +804,7 @@ htime_create(xlator_t *this, changelog_priv_t *priv, unsigned long ts)
     }
 
     ret = sys_fsync(ht_dir_fd);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_MSG_FSYNC_OP_FAILED,
                 NULL);
         goto out;
@@ -849,7 +850,7 @@ changelog_snap_open(xlator_t *this, changelog_priv_t *priv)
 
     len = snprintf(c_snap_path, PATH_MAX, "%s/" CSNAP_FILE_NAME,
                    csnap_dir_path);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         ret = -1;
         goto out;
     }
@@ -857,7 +858,7 @@ changelog_snap_open(xlator_t *this, changelog_priv_t *priv)
     flags |= (O_CREAT | O_RDWR | O_TRUNC);
 
     fd = open(c_snap_path, flags, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-    if (fd < 0) {
+    if (IS_ERROR(fd)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_MSG_OPEN_FAILED,
                 "path=%s", c_snap_path, NULL);
         ret = -1;
@@ -868,7 +869,7 @@ changelog_snap_open(xlator_t *this, changelog_priv_t *priv)
     (void)snprintf(buffer, 1024, CHANGELOG_HEADER, CHANGELOG_VERSION_MAJOR,
                    CHANGELOG_VERSION_MINOR, priv->ce->encoder);
     ret = changelog_snap_write_change(priv, buffer, strlen(buffer));
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         sys_close(priv->c_snap_fd);
         priv->c_snap_fd = -1;
         goto out;
@@ -939,7 +940,7 @@ changelog_open_journal(xlator_t *this, changelog_priv_t *priv)
         flags |= O_SYNC;
 
     fd = open(changelog_path, flags, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-    if (fd < 0) {
+    if (IS_ERROR(fd)) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, CHANGELOG_MSG_OPEN_FAILED,
                 "path=%s", changelog_path, NULL);
         goto out;
@@ -1056,7 +1057,7 @@ changelog_snap_handle_ascii_change(xlator_t *this, changelog_log_data_t *cld)
 
     ret = changelog_snap_write_change(priv, buffer, off);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, CHANGELOG_MSG_WRITE_FAILED,
                 "csnap", NULL);
     }
@@ -1086,12 +1087,12 @@ changelog_handle_change(xlator_t *this, changelog_priv_t *priv,
      * case when there is reconfigure done (disabling changelog) and there
      * are still fops that have updates in prgress.
      */
-    if (priv->changelog_fd == -1)
+    if (IS_ERROR(priv->changelog_fd))
         return 0;
 
     if (CHANGELOG_TYPE_IS_FSYNC(cld->cld_type)) {
         ret = sys_fsync(priv->changelog_fd);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_smsg(this->name, GF_LOG_ERROR, errno,
                     CHANGELOG_MSG_FSYNC_OP_FAILED, NULL);
         }
@@ -1463,7 +1464,7 @@ __changelog_inode_ctx_get(xlator_t *this, inode_t *inode, unsigned long **iver,
     changelog_inode_ctx_t *ctx = NULL;
 
     ret = __inode_ctx_get(inode, this, &ctx_addr);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         ctx_addr = 0;
     if (ctx_addr != 0) {
         ctx = (changelog_inode_ctx_t *)(long)ctx_addr;
@@ -1950,13 +1951,13 @@ resolve_pargfid_to_path(xlator_t *this, const uuid_t pgfid, char **path,
     while (!(__is_root_gfid(pargfid))) {
         len = snprintf(dir_handle, PATH_MAX, "%s/%02x/%02x/%s", gpath,
                        pargfid[0], pargfid[1], uuid_utoa(pargfid));
-        if ((len < 0) || (len >= PATH_MAX)) {
+        if (IS_ERROR(len) || (len >= PATH_MAX)) {
             ret = -1;
             goto out;
         }
 
         len = sys_readlink(dir_handle, linkname, PATH_MAX);
-        if (len < 0) {
+        if (IS_ERROR(len)) {
             gf_smsg(this->name, GF_LOG_ERROR, errno,
                     CHANGELOG_MSG_READLINK_OP_FAILED,
                     "could not read the "
@@ -1972,7 +1973,7 @@ resolve_pargfid_to_path(xlator_t *this, const uuid_t pgfid, char **path,
         dir_name = strtok_r(NULL, "/", &saveptr);
 
         len = snprintf(result, PATH_MAX, "%s/%s", dir_name, pre_dir_name);
-        if ((len < 0) || (len >= PATH_MAX)) {
+        if (IS_ERROR(len) || (len >= PATH_MAX)) {
             ret = -1;
             goto out;
         }

--- a/xlators/features/changelog/src/changelog-rpc-common.c
+++ b/xlators/features/changelog/src/changelog-rpc-common.c
@@ -129,7 +129,7 @@ changelog_rpc_sumbit_req(struct rpc_clnt *rpc, void *req, call_frame_t *frame,
 
         /* Create the xdr payload */
         ret = xdr_serialize_generic(iov, req, xdrproc);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -202,7 +202,7 @@ __changelog_rpc_serialize_reply(rpcsvc_request_t *req, void *arg,
     iobuf_to_iovec(iob, outmsg);
 
     retlen = xdr_serialize_generic(*outmsg, arg, xdrproc);
-    if (retlen == -1)
+    if (IS_ERROR(retlen))
         goto unref_iob;
 
     outmsg->iov_len = retlen;

--- a/xlators/features/changelog/src/changelog-rpc.c
+++ b/xlators/features/changelog/src/changelog-rpc.c
@@ -386,7 +386,7 @@ changelog_handle_probe(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &rpc_req,
                          (xdrproc_t)xdr_changelog_probe_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg("", GF_LOG_ERROR, 0, CHANGELOG_MSG_HANDLE_PROBE_ERROR, NULL);
         req->rpc_err = GARBAGE_ARGS;
         goto handle_xdr_error;

--- a/xlators/features/changelog/src/changelog-rpc.c
+++ b/xlators/features/changelog/src/changelog-rpc.c
@@ -18,7 +18,7 @@ static struct rpcsvc_program *changelog_programs[];
 static void
 changelog_cleanup_dispatchers(xlator_t *this, changelog_priv_t *priv, int count)
 {
-    for (count--; count >= 0; count--) {
+    for (IS_SUCCESS(count--; count); count--) {
         (void)changelog_thread_cleanup(this, priv->ev_dispatcher[count]);
         priv->ev_dispatcher[count] = 0;
     }

--- a/xlators/features/changelog/src/changelog-rpc.c
+++ b/xlators/features/changelog/src/changelog-rpc.c
@@ -18,7 +18,7 @@ static struct rpcsvc_program *changelog_programs[];
 static void
 changelog_cleanup_dispatchers(xlator_t *this, changelog_priv_t *priv, int count)
 {
-    for (IS_SUCCESS(count--; count); count--) {
+    for (count--; count >= 0; count--) {
         (void)changelog_thread_cleanup(this, priv->ev_dispatcher[count]);
         priv->ev_dispatcher[count] = 0;
     }

--- a/xlators/features/changelog/src/changelog.c
+++ b/xlators/features/changelog/src/changelog.c
@@ -61,7 +61,7 @@ changelog_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -182,7 +182,7 @@ changelog_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -331,7 +331,7 @@ changelog_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     priv = this->private;
     local = frame->local;
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 unwind:
     changelog_dec_fop_cnt(this, priv, local);
@@ -449,7 +449,7 @@ changelog_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -559,7 +559,7 @@ changelog_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -688,7 +688,7 @@ changelog_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -809,7 +809,7 @@ changelog_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -959,7 +959,7 @@ changelog_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     /* fill the event structure.. similar to open() */
     ev.ev_type = CHANGELOG_OP_TYPE_CREATE;
@@ -1115,7 +1115,7 @@ changelog_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA);
 
@@ -1171,7 +1171,7 @@ changelog_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA);
 
@@ -1238,7 +1238,7 @@ changelog_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1289,7 +1289,7 @@ changelog_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1342,7 +1342,7 @@ changelog_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1455,7 +1455,7 @@ changelog_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1508,7 +1508,7 @@ changelog_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA);
 
@@ -1565,7 +1565,7 @@ changelog_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1629,7 +1629,7 @@ changelog_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_DATA);
 
@@ -1677,7 +1677,7 @@ changelog_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_DATA);
 
@@ -1789,7 +1789,7 @@ changelog_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         logopen = _gf_true;
     }
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !logopen), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !logopen), unwind);
 
     /* fill the event structure */
     ev.ev_type = CHANGELOG_OP_TYPE_OPEN;
@@ -2090,7 +2090,7 @@ notify(xlator_t *this, int event, void *data, ...)
                 }
                 UNLOCK(&priv->bflags.lock);
 
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     gf_smsg(this->name, GF_LOG_ERROR, 0,
                             CHANGELOG_MSG_BARRIER_ERROR, NULL);
                     goto out;
@@ -2145,7 +2145,7 @@ notify(xlator_t *this, int event, void *data, ...)
                 }
                 UNLOCK(&priv->bflags.lock);
 
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     gf_smsg(this->name, GF_LOG_ERROR, 0,
                             CHANGELOG_MSG_BARRIER_ON_ERROR, NULL);
                     goto out;
@@ -2165,7 +2165,7 @@ notify(xlator_t *this, int event, void *data, ...)
                     ret = __chlog_barrier_enable(this, priv);
                 }
                 UNLOCK(&priv->lock);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     changelog_barrier_cleanup(this, priv, &queue);
                     goto out;
                 }

--- a/xlators/features/cloudsync/src/cloudsync-fops-c.py
+++ b/xlators/features/cloudsync/src/cloudsync-fops-c.py
@@ -133,7 +133,7 @@ cs_@NAME@_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
         /* Do we need lock here? */
         local->call_cnt++;
 
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
                 ret = dict_get_uint64 (xdata, GF_CS_OBJECT_STATUS, &val);
                 if (ret == 0) {
                         if (val == GF_CS_ERROR) {

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
@@ -108,7 +108,7 @@ aws_init(xlator_t *this)
 unlock:
     pthread_spin_unlock(&(priv->lock));
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         GF_FREE(priv->awskeyid);
         GF_FREE(priv->awssekey);
         GF_FREE(priv->bucketid);
@@ -337,7 +337,7 @@ aws_dlwritev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 {
     aws_private_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, op_errno,
                "write failed "
                ". Aborting Download");

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/libcvlt.c
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/libcvlt.c
@@ -416,7 +416,7 @@ cvlt_readv_complete(archstore_desc_t *desc, app_callback_info_t *cbkinfo,
                  " op : %d ret : %" PRId64 " errno : %d",
                  req->offset, req->bytes, req->op_type, op_ret, op_errno);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -510,7 +510,7 @@ cvlt_init(xlator_t *this)
            "product id is : %s.",
            priv->store_id, priv->product_id);
 out:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         cvlt_term_xlator(priv);
         return (NULL);
     }
@@ -609,7 +609,7 @@ cvlt_download(call_frame_t *frame, void *config)
      * about data management store.
      */
     op_ret = cvlt_init_store_info(parch, &(req->store_info));
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(plugin, GF_LOG_ERROR, 0, CVLT_EXTRACTION_FAILED,
                " failed to extract store info for gfid=%s",
                uuid_utoa(locxattr->gfid));
@@ -617,7 +617,7 @@ cvlt_download(call_frame_t *frame, void *config)
     }
 
     op_ret = cvlt_init_file_info(locxattr, &(req->file_info));
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(plugin, GF_LOG_ERROR, 0, CVLT_EXTRACTION_FAILED,
                " failed to extract file info for gfid=%s",
                uuid_utoa(locxattr->gfid));
@@ -629,7 +629,7 @@ cvlt_download(call_frame_t *frame, void *config)
      * store to gusterfs volume.
      */
     op_ret = cvlt_init_gluster_store_info(locxattr, &dest_storeinfo);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(plugin, GF_LOG_ERROR, 0, CVLT_EXTRACTION_FAILED,
                " failed to extract destination store info for gfid=%s",
                uuid_utoa(locxattr->gfid));
@@ -637,7 +637,7 @@ cvlt_download(call_frame_t *frame, void *config)
     }
 
     op_ret = cvlt_init_gluster_file_info(locxattr, &dest_fileinfo);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(plugin, GF_LOG_ERROR, 0, CVLT_EXTRACTION_FAILED,
                " failed to extract file info for gfid=%s",
                uuid_utoa(locxattr->gfid));
@@ -651,7 +651,7 @@ cvlt_download(call_frame_t *frame, void *config)
                                  &(req->file_info), &dest_storeinfo,
                                  &dest_fileinfo, &op_errno,
                                  cvlt_download_complete, req);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(plugin, GF_LOG_ERROR, 0, CVLT_RESTORE_FAILED,
                " failed to restore file gfid=%s from data management store",
                uuid_utoa(locxattr->gfid));
@@ -663,7 +663,7 @@ cvlt_download(call_frame_t *frame, void *config)
      */
     sem_wait(&(req->sem));
 
-    if (req->op_ret < 0) {
+    if (IS_ERROR(req->op_ret)) {
         gf_msg(plugin, GF_LOG_ERROR, 0, CVLT_RESTORE_FAILED,
                " restored failed for gfid=%s", uuid_utoa(locxattr->gfid));
         goto err;
@@ -781,7 +781,7 @@ cvlt_read(call_frame_t *frame, void *config)
      * about data management store.
      */
     op_ret = cvlt_init_store_info(parch, &(req->store_info));
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(plugin, GF_LOG_ERROR, 0, CVLT_EXTRACTION_FAILED,
                " failed to extract store info for gfid=%s"
                " offset=%" PRIu64 " size=%" GF_PRI_SIZET
@@ -792,7 +792,7 @@ cvlt_read(call_frame_t *frame, void *config)
     }
 
     op_ret = cvlt_init_file_info(locxattr, &(req->file_info));
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(plugin, GF_LOG_ERROR, 0, CVLT_EXTRACTION_FAILED,
                " failed to extract file info for gfid=%s"
                " offset=%" PRIu64 " size=%" GF_PRI_SIZET
@@ -809,7 +809,7 @@ cvlt_read(call_frame_t *frame, void *config)
                               &(req->file_info), off, req->iobuf->ptr, size,
                               &op_errno, cvlt_readv_complete, req);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(plugin, GF_LOG_ERROR, 0, CVLT_EXTRACTION_FAILED,
                " read failed on gfid=%s"
                " offset=%" PRIu64 " size=%" GF_PRI_SIZET

--- a/xlators/features/cloudsync/src/cloudsync.c
+++ b/xlators/features/cloudsync/src/cloudsync.c
@@ -102,7 +102,7 @@ cs_init(xlator_t *this)
         }
 
         ret = gf_asprintf(&libpath, "%s/%s", CS_PLUGINDIR, libname);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -199,7 +199,7 @@ cs_init(xlator_t *this)
     ret = 0;
 
 out:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         if (this->local_pool) {
             mem_pool_destroy(this->local_pool);
             this->local_pool = NULL;
@@ -328,7 +328,7 @@ cs_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local->call_cnt++;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, 0, "truncate failed");
         ret = dict_get_uint64(xdata, GF_CS_OBJECT_STATUS, &val);
         if (ret == 0) {
@@ -1169,7 +1169,7 @@ cs_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     local->call_cnt++;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         ret = dict_get_uint64(xdata, GF_CS_OBJECT_STATUS, &val);
         if (ret == 0) {
             if (val == GF_CS_ERROR) {
@@ -1416,7 +1416,7 @@ cs_stat_check_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     local = frame->local;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
         gf_msg(this->name, GF_LOG_ERROR, 0, op_errno, "stat check failed");

--- a/xlators/features/compress/src/cdc-helper.c
+++ b/xlators/features/compress/src/cdc-helper.c
@@ -153,7 +153,7 @@ cdc_dump_iovec_to_disk(xlator_t *this, cdc_info_t *ci, const char *file)
     size_t total_written = 0;
 
     fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0777);
-    if (fd < 0) {
+    if (IS_ERROR(fd)) {
         gf_log(this->name, GF_LOG_ERROR, "Cannot open file: %s", file);
         return;
     }

--- a/xlators/features/gfid-access/src/gfid-access.c
+++ b/xlators/features/gfid-access/src/gfid-access.c
@@ -22,7 +22,7 @@ ga_valid_inode_loc_copy(loc_t *dst, loc_t *src, xlator_t *this)
     /* directory inode as parent, we need to handle */
     /* it properly */
     ret = loc_copy(dst, src);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     /*
@@ -30,7 +30,7 @@ ga_valid_inode_loc_copy(loc_t *dst, loc_t *src, xlator_t *this)
      */
     if (dst->parent) {
         ret = inode_ctx_get(dst->parent, this, &value);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             ret = 0;  // real-inode
             goto out;
         }
@@ -41,7 +41,7 @@ ga_valid_inode_loc_copy(loc_t *dst, loc_t *src, xlator_t *this)
 
     if (dst->inode) {
         ret = inode_ctx_get(dst->inode, this, &value);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             ret = 0;  // real-inode
             goto out;
         }
@@ -161,7 +161,7 @@ ga_newfile_parse_args(xlator_t *this, data_t *data)
         }
         args->args.mkdir.umask = ntoh32(*(uint32_t *)blob);
         blob_len -= sizeof(uint32_t);
-        if (blob_len < 0) {
+        if (IS_ERROR(blob_len)) {
             gf_log(this->name, GF_LOG_ERROR, "gfid: %s. Invalid length",
                    args->gfid);
             goto err;
@@ -313,7 +313,7 @@ ga_fill_tmp_loc(loc_t *loc, xlator_t *this, uuid_t gfid, char *bname,
     }
     gf_uuid_copy(gfid_ptr, gfid);
     ret = dict_set_gfuuid(xdata, "gfid-req", gfid_ptr, false);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = 0;
@@ -411,7 +411,7 @@ ga_newentry_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if ((op_ret < 0) && ((op_errno != ENOENT) && (op_errno != ESTALE)))
+    if (IS_ERROR((op_ret)) && ((op_errno != ENOENT) && (op_errno != ESTALE)))
         goto err;
 
     STACK_WIND(frame, ga_newentry_cbk, FIRST_CHILD(this),
@@ -617,7 +617,7 @@ ga_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
     // If the inode is a virtual inode change the inode otherwise perform
     // the operation on same inode
     ret = ga_valid_inode_loc_copy(&ga_loc, loc, this);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     STACK_WIND(frame, ga_setxattr_cbk, FIRST_CHILD(this),
@@ -999,7 +999,7 @@ ga_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flag,
     GFID_ACCESS_ENTRY_OP_CHECK(loc, op_errno, err);
 
     ret = ga_valid_inode_loc_copy(&ga_loc, loc, this);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     STACK_WIND(frame, default_rmdir_cbk, FIRST_CHILD(this),
@@ -1026,7 +1026,7 @@ ga_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t xflag,
     GFID_ACCESS_ENTRY_OP_CHECK(loc, op_errno, err);
 
     ret = ga_valid_inode_loc_copy(&ga_loc, loc, this);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     STACK_WIND(frame, default_unlink_cbk, FIRST_CHILD(this),
@@ -1057,11 +1057,11 @@ ga_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     GFID_ACCESS_ENTRY_OP_CHECK(newloc, op_errno, err);
 
     ret = ga_valid_inode_loc_copy(&ga_oldloc, oldloc, this);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     ret = ga_valid_inode_loc_copy(&ga_newloc, newloc, this);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         loc_wipe(&ga_oldloc);
         goto err;
     }
@@ -1096,11 +1096,11 @@ ga_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     GFID_ACCESS_ENTRY_OP_CHECK(newloc, op_errno, err);
 
     ret = ga_valid_inode_loc_copy(&ga_oldloc, oldloc, this);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     ret = ga_valid_inode_loc_copy(&ga_newloc, newloc, this);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         loc_wipe(&ga_oldloc);
         goto err;
     }
@@ -1156,7 +1156,7 @@ ga_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
 
     GFID_ACCESS_INODE_OP_CHECK(loc, op_errno, err);
     ret = ga_valid_inode_loc_copy(&ga_loc, loc, this);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     STACK_WIND(frame, default_getxattr_cbk, FIRST_CHILD(this),
@@ -1189,7 +1189,7 @@ ga_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         goto out;
 
     ret = ga_valid_inode_loc_copy(&ga_loc, loc, this);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     STACK_WIND(frame, default_stat_cbk, FIRST_CHILD(this),
@@ -1220,7 +1220,7 @@ ga_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc, struct iatt *stbuf,
 
     GFID_ACCESS_INODE_OP_CHECK(loc, op_errno, err);
     ret = ga_valid_inode_loc_copy(&ga_loc, loc, this);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     STACK_WIND(frame, default_setattr_cbk, FIRST_CHILD(this),
@@ -1246,7 +1246,7 @@ ga_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     GFID_ACCESS_INODE_OP_CHECK(loc, op_errno, err);
     ret = ga_valid_inode_loc_copy(&ga_loc, loc, this);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     STACK_WIND(frame, default_removexattr_cbk, FIRST_CHILD(this),

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -53,7 +53,7 @@ index_get_type_from_vgfid(index_priv_t *priv, uuid_t vgfid)
 gf_boolean_t
 index_is_virtual_gfid(index_priv_t *priv, uuid_t vgfid)
 {
-    if (index_get_type_from_vgfid(priv, vgfid) < 0)
+    if (IS_ERROR(index_get_type_from_vgfid(priv, vgfid)))
         return _gf_false;
     return _gf_true;
 }
@@ -154,7 +154,7 @@ index_is_fop_on_internal_inode(xlator_t *this, inode_t *inode, uuid_t gfid)
 static gf_boolean_t
 index_is_vgfid_xattr(const char *name)
 {
-    if (index_get_type_from_vgfid_xattr(name) < 0)
+    if (IS_ERROR(index_get_type_from_vgfid_xattr(name)))
         return _gf_false;
     return _gf_true;
 }
@@ -287,17 +287,17 @@ index_dir_create(xlator_t *this, const char *subdir)
     }
     ret = 0;
 out:
-    if (ret == -1) {
-        gf_msg(this->name, GF_LOG_ERROR, errno,
-               INDEX_MSG_INDEX_DIR_CREATE_FAILED,
-               "%s/%s: Failed to "
-               "create",
-               priv->index_basepath, subdir);
-    } else if (ret == -2) {
+    if (ret == -2) {
         gf_msg(this->name, GF_LOG_ERROR, ENOTDIR,
                INDEX_MSG_INDEX_DIR_CREATE_FAILED,
                "%s/%s: Failed to "
                "create, path exists, not a directory ",
+               priv->index_basepath, subdir);
+    } else if (IS_ERROR(ret)) {
+        gf_msg(this->name, GF_LOG_ERROR, errno,
+               INDEX_MSG_INDEX_DIR_CREATE_FAILED,
+               "%s/%s: Failed to "
+               "create",
                priv->index_basepath, subdir);
     }
     return ret;
@@ -494,7 +494,7 @@ index_fill_readdir(fd_t *fd, index_fd_ctx_t *fctx, DIR *dir, off_t off,
     while (filled <= size) {
         in_case = (u_long)telldir(dir);
 
-        if (in_case == -1) {
+        if (IS_ERROR(in_case)) {
             gf_msg(THIS->name, GF_LOG_ERROR, errno,
                    INDEX_MSG_INDEX_READDIR_FAILED, "telldir failed on dir=%p",
                    dir);
@@ -616,7 +616,7 @@ index_link_to_base(xlator_t *this, char *fpath, const char *subdir)
 
     op_errno = 0;
     fd = sys_creat(base, 0);
-    if ((fd < 0) && (errno != EEXIST)) {
+    if (IS_ERROR(fd) && (errno != EEXIST)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, INDEX_MSG_INDEX_ADD_FAILED,
                "%s: Not able to "
@@ -775,7 +775,7 @@ index_fill_zero_array(dict_t *d, char *k, data_t *v, void *adata)
     // corresponding xattr directory or not.
 
     idx = index_find_xattr_type(d, k, v);
-    if (idx == -1)
+    if (IS_ERROR(idx))
         return 0;
     zfilled[idx] = 0;
     return 0;
@@ -788,7 +788,7 @@ _check_key_is_zero_filled(dict_t *d, char *k, data_t *v, void *tmp)
     int idx = -1;
 
     idx = index_find_xattr_type(d, k, v);
-    if (idx == -1)
+    if (IS_ERROR(idx))
         return 0;
 
     /* Along with checking that the value of a key is zero filled
@@ -859,7 +859,7 @@ index_entry_create(xlator_t *this, inode_t *inode, char *filename)
 
     len = snprintf(entry_path, sizeof(entry_path), "%s/%s", pgfid_path,
                    filename);
-    if ((len < 0) || (len >= sizeof(entry_path))) {
+    if (IS_ERROR(len) || (len >= sizeof(entry_path))) {
         op_errno = EINVAL;
         goto out;
     }
@@ -902,7 +902,7 @@ index_entry_delete(xlator_t *this, uuid_t pgfid, char *filename)
 
     len = snprintf(entry_path, sizeof(entry_path), "%s/%s", pgfid_path,
                    filename);
-    if ((len < 0) || (len >= sizeof(entry_path))) {
+    if (IS_ERROR(len) || (len >= sizeof(entry_path))) {
         op_errno = EINVAL;
         goto out;
     }
@@ -1231,7 +1231,7 @@ xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     local = frame->local;
     inode = inode_ref(local->inode);
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     xattrop_index_action(this, local, xattr, match, matchdata);
@@ -1307,7 +1307,7 @@ index_xattrop_do(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
     if (xdata)
         ret = index_entry_action(this, local->inode, xdata,
                                  GF_XATTROP_ENTRY_IN_KEY);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         x_cbk(frame, NULL, this, -1, -ret, NULL, NULL);
         return;
     }
@@ -1581,14 +1581,14 @@ index_lookup_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
     if (index_is_fop_on_internal_inode(this, loc->parent, loc->pargfid)) {
         subdir = index_get_subdir_from_vgfid(priv, loc->pargfid);
         ret = index_inode_path(this, loc->parent, path, sizeof(path));
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             op_errno = -ret;
             goto done;
         }
         ret = snprintf(path + strlen(path), PATH_MAX - strlen(path), "/%s",
                        loc->name);
 
-        if ((ret < 0) || (ret > (PATH_MAX - strlen(path)))) {
+        if (IS_ERROR(ret) || (ret > (PATH_MAX - strlen(path)))) {
             op_errno = EINVAL;
             op_ret = -1;
             goto done;
@@ -1611,7 +1611,7 @@ index_lookup_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
             iloc.inode = inode_find(loc->inode->table, loc->gfid);
         }
         ret = index_inode_path(this, iloc.inode, path, sizeof(path));
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             op_errno = -ret;
             goto done;
         }
@@ -1728,7 +1728,7 @@ index_readdir_wrapper(call_frame_t *frame, xlator_t *this, fd_t *fd,
     INIT_LIST_HEAD(&entries.list);
 
     ret = index_fd_ctx_get(fd, this, &fctx);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         gf_msg(this->name, GF_LOG_WARNING, op_errno, INDEX_MSG_FD_OP_FAILED,
                "pfd is NULL, fd=%p", fd);
@@ -1804,7 +1804,7 @@ index_get_parent_iatt(struct iatt *parent, char *path, loc_t *loc,
     };
 
     ret = sys_lstat(path, &lstatbuf);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         *op_ret = -1;
         *op_errno = errno;
         return;
@@ -1844,7 +1844,7 @@ index_rmdir_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flag,
                         sizeof(index_dir));
 
     index_get_parent_iatt(&preparent, index_dir, loc, &op_ret, &op_errno);
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto done;
 
     gf_uuid_parse(loc->name, gfid);
@@ -1853,7 +1853,7 @@ index_rmdir_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flag,
 
     if (flag == 0) {
         ret = index_del(this, gfid, subdir, type);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             op_ret = -1;
             op_errno = -ret;
             goto done;
@@ -1865,7 +1865,7 @@ index_rmdir_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flag,
     }
 
     index_get_parent_iatt(&postparent, index_dir, loc, &op_ret, &op_errno);
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto done;
 
 done:
@@ -1894,14 +1894,14 @@ index_unlink_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flag,
     priv = this->private;
     type = index_get_type_from_vgfid(priv, loc->pargfid);
     ret = index_inode_path(this, loc->parent, index_dir, sizeof(index_dir));
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = -ret;
         goto done;
     }
 
     index_get_parent_iatt(&preparent, index_dir, loc, &op_ret, &op_errno);
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto done;
 
     if (type <= XATTROP_TYPE_UNSET) {
@@ -1922,14 +1922,14 @@ index_unlink_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flag,
         gf_uuid_parse(loc->name, gfid);
         ret = index_del(this, gfid, subdir, type);
     }
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = -ret;
         goto done;
     }
 
     index_get_parent_iatt(&postparent, index_dir, loc, &op_ret, &op_errno);
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto done;
 done:
     INDEX_STACK_UNWIND(unlink, frame, op_ret, op_errno, &preparent, &postparent,
@@ -1997,7 +1997,7 @@ index_fetch_link_count(xlator_t *this, index_xattrop_type_t type)
         errno = 0;
         entry = sys_readdir(dirp, scratch);
         if (!entry || errno != 0) {
-            if (count == -1)
+            if (IS_ERROR(count))
                 count = 0;
             goto out;
         }
@@ -2009,7 +2009,7 @@ index_fetch_link_count(xlator_t *this, index_xattrop_type_t type)
                        sizeof(index_path));
 
         ret = sys_lstat(index_path, &lstatbuf);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             count = -2;
             continue;
         } else {
@@ -2039,19 +2039,19 @@ index_fill_link_count(xlator_t *this, dict_t *xdata)
         goto out;
 
     index_get_link_count(priv, &count, XATTROP);
-    if (count < 0) {
+    if (IS_ERROR(count)) {
         count = index_fetch_link_count(this, XATTROP);
         index_set_link_count(priv, count, XATTROP);
     }
 
     if (count == 0) {
         ret = dict_set_int8(xdata, "link-count", 0);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg(this->name, GF_LOG_ERROR, EINVAL, INDEX_MSG_DICT_SET_FAILED,
                    "Unable to set link-count");
     } else {
         ret = dict_set_int8(xdata, "link-count", 1);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg(this->name, GF_LOG_ERROR, EINVAL, INDEX_MSG_DICT_SET_FAILED,
                    "Unable to set link-count");
     }
@@ -2431,17 +2431,17 @@ init(xlator_t *this)
     this->private = priv;
 
     ret = index_dir_create(this, XATTROP_SUBDIR);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (priv->dirty_watchlist) {
         ret = index_dir_create(this, DIRTY_SUBDIR);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 
     ret = index_dir_create(this, ENTRY_CHANGES_SUBDIR);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     /*init indices files counts*/
@@ -2539,7 +2539,7 @@ index_releasedir(xlator_t *this, fd_t *fd)
     int ret = 0;
 
     ret = fd_ctx_del(fd, this, &ctx);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     fctx = (index_fd_ctx_t *)(long)ctx;
@@ -2563,7 +2563,7 @@ index_release(xlator_t *this, fd_t *fd)
     int ret = 0;
 
     ret = fd_ctx_del(fd, this, &ctx);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     fctx = (index_fd_ctx_t *)(long)ctx;

--- a/xlators/features/index/src/index.c
+++ b/xlators/features/index/src/index.c
@@ -625,7 +625,7 @@ index_link_to_base(xlator_t *this, char *fpath, const char *subdir)
         goto out;
     }
 
-    if (fd >= 0)
+    if (IS_SUCCESS(fd))
         sys_close(fd);
 
     ret = sys_link(base, fpath);
@@ -1470,7 +1470,7 @@ index_getxattr_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 
     vgfid_type = index_get_type_from_vgfid_xattr(name);
-    if (vgfid_type >= 0) {
+    if (IS_SUCCESS(vgfid_type)) {
         ret = dict_set_static_bin(xattr, (char *)name,
                                   priv->internal_vgfid[vgfid_type],
                                   sizeof(priv->internal_vgfid[vgfid_type]));

--- a/xlators/features/leases/src/leases-internal.c
+++ b/xlators/features/leases/src/leases-internal.c
@@ -171,13 +171,13 @@ __lease_ctx_get(inode_t *inode, xlator_t *this)
     GF_VALIDATE_OR_GOTO("leases", this, out);
 
     ret = __inode_ctx_get(inode, this, &ctx);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = __lease_ctx_set(inode, this);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = __inode_ctx_get(inode, this, &ctx);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, 0, LEASE_MSG_INVAL_INODE_CTX,
                    "failed to get inode ctx (%p)", inode);
             goto out;
@@ -719,7 +719,7 @@ __is_lease_grantable(xlator_t *this, lease_inode_ctx_t *lease_ctx,
         list_for_each_entry(iter_fd, &inode->fd_list, inode_list)
         {
             ret = fd_ctx_get(iter_fd, this, &ctx);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 grant = _gf_false;
                 UNLOCK(&inode->lock);
                 gf_msg(this->name, GF_LOG_ERROR, 0, LEASE_MSG_INVAL_FD_CTX,
@@ -907,7 +907,7 @@ __recall_lease(xlator_t *this, lease_inode_ctx_t *lease_ctx)
         up_req.data = &recall_req;
 
         notify_ret = this->notify(this, GF_EVENT_UPCALL, &up_req);
-        if (notify_ret < 0) {
+        if (IS_ERROR(notify_ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, LEASE_MSG_RECALL_FAIL,
                    "Recall notification to client: %s failed",
                    lease_entry->client_uid);
@@ -1077,7 +1077,7 @@ __check_lease_conflict(call_frame_t *frame, lease_inode_ctx_t *lease_ctx,
      *
      * @todo: like for locks, even lease state has to be handled by
      * rebalance or self-heal daemon process. */
-    if (frame->root->pid < 0) {
+    if (IS_ERROR(frame->root->pid)) {
         conflicts = _gf_false;
         goto recall;
     }

--- a/xlators/features/leases/src/leases-internal.c
+++ b/xlators/features/leases/src/leases-internal.c
@@ -1024,7 +1024,7 @@ process_lease_req(call_frame_t *frame, xlator_t *this, inode_t *inode,
                 break;
             case GF_UNLK_LEASE:
                 ret = __remove_lease(this, inode, lease_ctx, client_uid, lease);
-                if ((ret >= 0) && (lease_ctx->lease_cnt == 0)) {
+                if (IS_SUCCESS((ret)) && (lease_ctx->lease_cnt == 0)) {
                     pthread_mutex_unlock(&lease_ctx->lock);
                     goto unblock;
                 }

--- a/xlators/features/leases/src/leases.c
+++ b/xlators/features/leases/src/leases.c
@@ -63,7 +63,7 @@ leases_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     }
 
     ret = check_lease_conflict(frame, fd->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -116,7 +116,7 @@ leases_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
     GET_FLAGS(frame->root->op, fd->flags);
 
     ret = check_lease_conflict(frame, fd->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -165,7 +165,7 @@ leases_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     GET_FLAGS(frame->root->op, fd->flags);
 
     ret = check_lease_conflict(frame, fd->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -211,7 +211,7 @@ leases_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
     GET_FLAGS_LK(cmd, flock->l_type, fd->flags);
 
     ret = check_lease_conflict(frame, fd->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -247,7 +247,7 @@ leases_lease(call_frame_t *frame, xlator_t *this, loc_t *loc,
     EXIT_IF_INTERNAL_FOP(frame, xdata, out);
 
     ret = process_lease_req(frame, this, loc->inode, lease);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         op_ret = -1;
     }
@@ -293,7 +293,7 @@ leases_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     GET_FLAGS(frame->root->op, 0);
 
     ret = check_lease_conflict(frame, loc->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -340,7 +340,7 @@ leases_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     GET_FLAGS(frame->root->op, 0);
 
     ret = check_lease_conflict(frame, loc->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -390,7 +390,7 @@ leases_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     GET_FLAGS(frame->root->op, 0);
 
     ret = check_lease_conflict(frame, oldloc->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -438,7 +438,7 @@ leases_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     GET_FLAGS(frame->root->op, 0);
 
     ret = check_lease_conflict(frame, loc->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -485,7 +485,7 @@ leases_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     GET_FLAGS(frame->root->op, 0);
 
     ret = check_lease_conflict(frame, oldloc->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -532,7 +532,7 @@ leases_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     GET_FLAGS(frame->root->op, flags);
 
     ret = check_lease_conflict(frame, fd->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -580,7 +580,7 @@ leases_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
     GET_FLAGS(frame->root->op, fd->flags);
 
     ret = check_lease_conflict(frame, fd->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -625,7 +625,7 @@ leases_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     GET_FLAGS(frame->root->op, 0); /* TODO:fd->flags?*/
 
     ret = check_lease_conflict(frame, fd->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -671,7 +671,7 @@ leases_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     GET_FLAGS(frame->root->op, fd->flags);
 
     ret = check_lease_conflict(frame, fd->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -717,7 +717,7 @@ leases_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
     GET_FLAGS(frame->root->op, fd->flags);
 
     ret = check_lease_conflict(frame, fd->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -765,7 +765,7 @@ leases_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     GET_FLAGS(frame->root->op, fd->flags);
 
     ret = check_lease_conflict(frame, fd->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -811,7 +811,7 @@ leases_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     GET_FLAGS(frame->root->op, fd->flags);
 
     ret = check_lease_conflict(frame, fd->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;
@@ -857,7 +857,7 @@ leases_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     GET_FLAGS(frame->root->op, fd->flags);
 
     ret = check_lease_conflict(frame, fd->inode, lease_id, fop_flags);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
     else if (ret == BLOCK_FOP)
         goto block;

--- a/xlators/features/leases/src/leases.h
+++ b/xlators/features/leases/src/leases.h
@@ -47,7 +47,7 @@
 
 #define EXIT_IF_INTERNAL_FOP(frame, xdata, label)                              \
     do {                                                                       \
-        if (frame->root->pid < 0)                                              \
+        if (IS_ERROR(frame->root->pid))                                        \
             goto label;                                                        \
         if (xdata && dict_get(xdata, GLUSTERFS_INTERNAL_FOP_KEY))              \
             goto label;                                                        \
@@ -139,7 +139,7 @@
         pthread_mutex_unlock(&lease_ctx->lock);                                \
                                                                                \
     __out:                                                                     \
-        if (ret < 0) {                                                         \
+        if (IS_ERROR(ret)) {                                                   \
             gf_msg(this->name, GF_LOG_WARNING, ENOMEM, LEASE_MSG_NO_MEM,       \
                    "Unable to create stub for blocking the fop:%s (%s)",       \
                    gf_fop_list[frame->root->op], strerror(ENOMEM));            \

--- a/xlators/features/locks/src/common.c
+++ b/xlators/features/locks/src/common.c
@@ -407,7 +407,7 @@ pl_fetch_mlock_info_from_disk(xlator_t *this, pl_inode_t *pl_inode,
 
     pthread_mutex_lock(&pl_inode->mutex);
     {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             pl_inode->mlock_enforced = _gf_true;
             pl_inode->check_mlock_info = _gf_false;
         } else {

--- a/xlators/features/locks/src/entrylk.c
+++ b/xlators/features/locks/src/entrylk.c
@@ -288,7 +288,7 @@ entrylk_contention_notify(xlator_t *this, struct list_head *contend)
             up.event_type = GF_UPCALL_ENTRYLK_CONTENTION;
             up.data = &lc;
 
-            if (this->notify(this, GF_EVENT_UPCALL, &up) < 0) {
+            if (IS_ERROR(this->notify(this, GF_EVENT_UPCALL, &up))) {
                 gf_msg_debug(this->name, 0,
                              "Entrylk contention notification "
                              "failed");

--- a/xlators/features/locks/src/inodelk.c
+++ b/xlators/features/locks/src/inodelk.c
@@ -312,7 +312,7 @@ inodelk_contention_notify(xlator_t *this, struct list_head *contend)
             up.event_type = GF_UPCALL_INODELK_CONTENTION;
             up.data = &lc;
 
-            if (this->notify(this, GF_EVENT_UPCALL, &up) < 0) {
+            if (IS_ERROR(this->notify(this, GF_EVENT_UPCALL, &up))) {
                 gf_msg_debug(this->name, 0,
                              "Inodelk contention notification "
                              "failed");
@@ -982,7 +982,7 @@ pl_common_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
     VALIDATE_OR_GOTO(inode, unwind);
     VALIDATE_OR_GOTO(flock, unwind);
 
-    if ((flock->l_start < 0) || (flock->l_len < 0)) {
+    if (IS_ERROR(flock->l_start) || IS_ERROR(flock->l_len)) {
         op_errno = EINVAL;
         goto unwind;
     }
@@ -1036,7 +1036,7 @@ pl_common_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
             ret = pl_inode_setlk(this, ctx, pinode, reqlock, can_block, dom,
                                  inode);
 
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 if ((can_block) && (F_UNLCK != lock_type)) {
                     goto out;
                 }

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -339,7 +339,7 @@ pl_parent_entrylk_xattr_fill(xlator_t *this, inode_t *parent, char *basename,
         goto out;
     if (keep_max) {
         ret = dict_get_int32_sizen(dict, GLUSTERFS_PARENT_ENTRYLK, &maxcount);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0, " Failed to fetch the value for key %s",
                          GLUSTERFS_PARENT_ENTRYLK);
     }
@@ -348,7 +348,7 @@ pl_parent_entrylk_xattr_fill(xlator_t *this, inode_t *parent, char *basename,
         return;
 out:
     ret = dict_set_int32_sizen(dict, GLUSTERFS_PARENT_ENTRYLK, entrylk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, 0, " dict_set failed on key %s",
                      GLUSTERFS_PARENT_ENTRYLK);
     }
@@ -364,7 +364,7 @@ pl_entrylk_xattr_fill(xlator_t *this, inode_t *inode, dict_t *dict,
 
     if (keep_max) {
         ret = dict_get_int32_sizen(dict, GLUSTERFS_ENTRYLK_COUNT, &maxcount);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0, " Failed to fetch the value for key %s",
                          GLUSTERFS_ENTRYLK_COUNT);
     }
@@ -373,7 +373,7 @@ pl_entrylk_xattr_fill(xlator_t *this, inode_t *inode, dict_t *dict,
         return;
 
     ret = dict_set_int32_sizen(dict, GLUSTERFS_ENTRYLK_COUNT, count);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, 0, " dict_set failed on key %s",
                      GLUSTERFS_ENTRYLK_COUNT);
     }
@@ -389,7 +389,7 @@ pl_inodelk_xattr_fill(xlator_t *this, inode_t *inode, dict_t *dict,
 
     if (keep_max) {
         ret = dict_get_int32_sizen(dict, GLUSTERFS_INODELK_COUNT, &maxcount);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0, " Failed to fetch the value for key %s",
                          GLUSTERFS_INODELK_COUNT);
     }
@@ -398,7 +398,7 @@ pl_inodelk_xattr_fill(xlator_t *this, inode_t *inode, dict_t *dict,
         return;
 
     ret = dict_set_int32_sizen(dict, GLUSTERFS_INODELK_COUNT, count);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, 0,
                      "Failed to set count for "
                      "key %s",
@@ -418,7 +418,7 @@ pl_posixlk_xattr_fill(xlator_t *this, inode_t *inode, dict_t *dict,
 
     if (keep_max) {
         ret = dict_get_int32_sizen(dict, GLUSTERFS_POSIXLK_COUNT, &maxcount);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0, " Failed to fetch the value for key %s",
                          GLUSTERFS_POSIXLK_COUNT);
     }
@@ -427,7 +427,7 @@ pl_posixlk_xattr_fill(xlator_t *this, inode_t *inode, dict_t *dict,
         return;
 
     ret = dict_set_int32_sizen(dict, GLUSTERFS_POSIXLK_COUNT, count);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, 0, " dict_set failed on key %s",
                      GLUSTERFS_POSIXLK_COUNT);
     }
@@ -443,7 +443,7 @@ pl_inodelk_xattr_fill_each(xlator_t *this, inode_t *inode, dict_t *dict,
 
     if (keep_max) {
         ret = dict_get_int32(dict, key, &maxcount);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0, " Failed to fetch the value for key %s",
                          GLUSTERFS_INODELK_COUNT);
     }
@@ -452,7 +452,7 @@ pl_inodelk_xattr_fill_each(xlator_t *this, inode_t *inode, dict_t *dict,
         return;
 
     ret = dict_set_int32(dict, key, count);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, 0,
                      "Failed to set count for "
                      "key %s",
@@ -675,7 +675,7 @@ pl_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         goto unwind;
     }
 
-    if (frame->root->pid < 0)
+    if (IS_ERROR(frame->root->pid))
         enabled = _gf_false;
     else
         enabled = pl_is_mandatory_locking_enabled(pl_inode);
@@ -732,7 +732,7 @@ pl_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         STACK_WIND(frame, pl_discard_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->discard, fd, offset, len, xdata);
 unwind:
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         PL_STACK_UNWIND(discard, xdata, frame, op_ret, op_errno, NULL, NULL,
                         NULL);
 
@@ -801,7 +801,7 @@ pl_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         goto unwind;
     }
 
-    if (frame->root->pid < 0)
+    if (IS_ERROR(frame->root->pid))
         enabled = _gf_false;
     else
         enabled = pl_is_mandatory_locking_enabled(pl_inode);
@@ -858,7 +858,7 @@ pl_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         STACK_WIND(frame, pl_zerofill_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->zerofill, fd, offset, len, xdata);
 unwind:
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         PL_STACK_UNWIND(zerofill, xdata, frame, op_ret, op_errno, NULL, NULL,
                         NULL);
 
@@ -947,7 +947,7 @@ truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto unwind;
     }
 
-    if (frame->root->pid < 0)
+    if (IS_ERROR(frame->root->pid))
         enabled = _gf_false;
     else
         enabled = pl_is_mandatory_locking_enabled(pl_inode);
@@ -1023,7 +1023,7 @@ truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 unwind:
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this ? this->name : "locks", GF_LOG_ERROR,
                "truncate failed with "
                "ret: %d, error: %s",
@@ -1070,7 +1070,7 @@ pl_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     ret = 0;
 
 unwind:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(this ? this->name : "locks", GF_LOG_ERROR,
                "truncate on %s failed with"
                " ret: %d, error: %s",
@@ -1103,7 +1103,7 @@ pl_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
                FIRST_CHILD(this)->fops->fstat, fd, xdata);
     ret = 0;
 unwind:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(this ? this->name : "locks", GF_LOG_ERROR,
                "ftruncate failed with"
                " ret: %d, error: %s",
@@ -1283,7 +1283,7 @@ pl_getxattr_clrlk(xlator_t *this, const char *name, inode_t *inode,
     }
 
     if (!gcount && !bcount) {
-        if (gf_asprintf(&lk_summary, "No locks cleared.") == -1) {
+        if (IS_ERROR(gf_asprintf(&lk_summary, "No locks cleared."))) {
             op_ret = -1;
             *op_errno = ENOMEM;
             goto out;
@@ -1400,7 +1400,7 @@ fetch_pathinfo(xlator_t *this, inode_t *inode, int32_t *op_errno,
 
     ret = syncop_getxattr(FIRST_CHILD(this), &loc, &dict, GF_XATTR_PATHINFO_KEY,
                           NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         *op_errno = -ret;
         ret = -1;
         goto out;
@@ -1468,7 +1468,7 @@ pl_lockinfo_key(xlator_t *this, inode_t *inode, int32_t *op_errno)
 
     if (priv->brickname == NULL) {
         ret = pl_lockinfo_get_brickname(this, inode, op_errno);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(this->name, GF_LOG_WARNING, "cannot get brickname");
             goto out;
         }
@@ -1519,7 +1519,7 @@ pl_fgetxattr_handle_lockinfo(xlator_t *this, fd_t *fd, dict_t *dict,
     }
 
     op_ret = dict_set_uint64(tmp, key, fdnum);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         *op_errno = -op_ret;
         op_ret = -1;
         gf_log(this->name, GF_LOG_WARNING,
@@ -1542,7 +1542,7 @@ pl_fgetxattr_handle_lockinfo(xlator_t *this, fd_t *fd, dict_t *dict,
     }
 
     op_ret = dict_set_dynptr(dict, GF_XATTR_LOCKINFO_KEY, buf, len);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         *op_errno = -op_ret;
         op_ret = -1;
         gf_log(this->name, GF_LOG_WARNING,
@@ -1585,7 +1585,7 @@ pl_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
         }
 
         op_ret = pl_fgetxattr_handle_lockinfo(this, fd, dict, &op_errno);
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             gf_log(this->name, GF_LOG_WARNING,
                    "getting lockinfo on fd (ptr:%p inode-gfid:%s) "
                    "failed (%s)",
@@ -1664,7 +1664,7 @@ pl_fsetxattr_handle_lockinfo(call_frame_t *frame, fd_t *fd, char *lockinfo_buf,
     }
 
     op_ret = dict_unserialize(lockinfo_buf, len, &lockinfo);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         *op_errno = -op_ret;
         op_ret = -1;
         goto out;
@@ -1684,7 +1684,7 @@ pl_fsetxattr_handle_lockinfo(call_frame_t *frame, fd_t *fd, char *lockinfo_buf,
     }
 
     op_ret = pl_migrate_locks(frame, fd, oldfd_num, op_errno);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_log(frame->this->name, GF_LOG_WARNING,
                "migration of locks from oldfd (ptr:%p) to newfd "
                "(ptr:%p) (inode-gfid:%s)",
@@ -1706,7 +1706,7 @@ pl_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     pl_inode_t *pl_inode = NULL;
 
     local = frame->local;
-    if (local && local->update_mlock_enforced_flag && op_ret != -1) {
+    if (local && local->update_mlock_enforced_flag && op_ret >= 0) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
             op_ret = -1;
@@ -1746,7 +1746,7 @@ pl_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
 
     op_ret = pl_fsetxattr_handle_lockinfo(frame, fd, lockinfo_buf, len,
                                           &op_errno);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -1772,7 +1772,7 @@ pl_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 {
     pl_fdctx_t *fdctx = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     fdctx = pl_check_n_create_fdctx(this, fd);
@@ -1862,7 +1862,7 @@ pl_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 {
     pl_fdctx_t *fdctx = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     fdctx = pl_check_n_create_fdctx(this, fd);
@@ -1936,7 +1936,7 @@ pl_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     }
 
 unwind:
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         STACK_UNWIND_STRICT(open, frame, op_ret, op_errno, NULL, NULL);
     else
         STACK_WIND(frame, pl_open_cbk, FIRST_CHILD(this),
@@ -1951,7 +1951,7 @@ pl_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 {
     pl_fdctx_t *fdctx = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     fdctx = pl_check_n_create_fdctx(this, fd);
@@ -2171,7 +2171,7 @@ pl_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         goto unwind;
     }
 
-    if (frame->root->pid < 0)
+    if (IS_ERROR(frame->root->pid))
         enabled = _gf_false;
     else
         enabled = pl_is_mandatory_locking_enabled(pl_inode);
@@ -2230,7 +2230,7 @@ pl_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
                    xdata);
     }
 unwind:
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         PL_STACK_UNWIND(readv, xdata, frame, op_ret, op_errno, NULL, 0, NULL,
                         NULL, NULL);
 
@@ -2289,7 +2289,7 @@ pl_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
         goto unwind;
     }
 
-    if (frame->root->pid < 0)
+    if (IS_ERROR(frame->root->pid))
         enabled = _gf_false;
     else
         enabled = pl_is_mandatory_locking_enabled(pl_inode);
@@ -2353,7 +2353,7 @@ pl_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
                    flags, iobref, xdata);
     }
 unwind:
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         PL_STACK_UNWIND(writev, xdata, frame, op_ret, op_errno, NULL, NULL,
                         NULL);
 
@@ -2565,7 +2565,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
                    "continuing");
     }
 
-    if ((flock->l_start < 0) || ((flock->l_start + flock->l_len) < 0)) {
+    if (IS_ERROR(flock->l_start) || IS_ERROR((flock->l_start + flock->l_len))) {
         op_ret = -1;
         op_errno = EINVAL;
         goto unwind;
@@ -2576,7 +2576,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
      * considered for the range starting at 'l_start+l_len'
      * and ending at 'l_start-1'. Update the fields accordingly.
      */
-    if (flock->l_len < 0) {
+    if (IS_ERROR(flock->l_len)) {
         flock->l_start += flock->l_len;
         flock->l_len = labs(flock->l_len);
     }
@@ -2619,7 +2619,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
             reqlock->this = this;
 
             ret = pl_reserve_setlk(this, pl_inode, reqlock, can_block);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 if (can_block)
                     goto out;
 
@@ -2638,7 +2638,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
             reqlock->frame = frame;
             reqlock->this = this;
             ret = pl_reserve_unlock(this, pl_inode, reqlock);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 op_ret = -1;
                 op_errno = -ret;
             }
@@ -2654,7 +2654,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
             GF_ASSERT(ret >= 0);
 
             ret = pl_getlk_fd(this, pl_inode, fd, reqlock);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_log(this->name, GF_LOG_DEBUG, "getting locks on fd failed");
                 op_ret = -1;
                 op_errno = ENOLCK;
@@ -2711,7 +2711,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
             pthread_mutex_unlock(&pl_inode->mutex);
 
             ret = pl_verify_reservelk(this, pl_inode, reqlock, can_block);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_log(this->name, GF_LOG_TRACE,
                        "Lock blocked due to conflicting reserve lock");
                 goto out;
@@ -2719,7 +2719,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 
             if (reqlock->fl_type != F_UNLCK && pl_inode->mlock_enforced) {
                 ret = pl_lock_preempt(pl_inode, reqlock);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     gf_log(this->name, GF_LOG_ERROR, "lock preempt failed");
                     op_ret = -1;
                     op_errno = EAGAIN;
@@ -2732,7 +2732,9 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
             }
 
             ret = pl_setlk(this, pl_inode, reqlock, can_block);
-            if (ret == -1) {
+            if (ret == -2) {
+                goto out;
+            } else if (IS_ERROR(ret)) {
                 if ((can_block) && (F_UNLCK != lock_type)) {
                     goto out;
                 }
@@ -2740,8 +2742,6 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
                 op_ret = -1;
                 op_errno = EAGAIN;
                 __destroy_lock(reqlock);
-            } else if (ret == -2) {
-                goto out;
             } else if ((0 == ret) && (F_UNLCK == flock->l_type)) {
                 /* For NLM's last "unlock on fd" detection */
                 if (pl_locks_by_fd(pl_inode, fd))
@@ -3256,7 +3256,7 @@ pl_metalk(call_frame_t *frame, xlator_t *this, inode_t *inode)
     }
     pthread_mutex_unlock(&pl_inode->mutex);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, EINVAL, 0,
                "More than one meta-lock cannot be granted on"
                " the inode");
@@ -3287,7 +3287,7 @@ pl_metalk(call_frame_t *frame, xlator_t *this, inode_t *inode)
     }
 
     ret = pl_insert_metalk(pl_inode, ctx, reqlk);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         pl_metalk_unref(reqlk);
     }
 
@@ -3428,7 +3428,7 @@ pl_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     pl_local_t *local = NULL;
     pl_inode_t *pl_inode = NULL;
     local = frame->local;
-    if (local && local->update_mlock_enforced_flag && op_ret != -1) {
+    if (local && local->update_mlock_enforced_flag && op_ret >= 0) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
             op_ret = -1;
@@ -4492,7 +4492,7 @@ pl_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     pl_inode_t *pl_inode = NULL;
 
     local = frame->local;
-    if (local && local->update_mlock_enforced_flag && op_ret != -1) {
+    if (local && local->update_mlock_enforced_flag && op_ret >= 0) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
             op_ret = -1;
@@ -4547,7 +4547,7 @@ pl_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     pl_inode_t *pl_inode = NULL;
 
     local = frame->local;
-    if (local && local->update_mlock_enforced_flag && op_ret != -1) {
+    if (local && local->update_mlock_enforced_flag && op_ret >= 0) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
             op_ret = -1;

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -70,7 +70,7 @@ fetch_pathinfo(xlator_t *, inode_t *, int32_t *, char **);
         dict_t *__unref = NULL;                                                \
         int __i = 0;                                                           \
         __local = frame->local;                                                \
-        if (op_ret >= 0 && pl_needs_xdata_response(frame->local)) {            \
+        if (IS_SUCCESS(op_ret) && pl_needs_xdata_response(frame->local)) {            \
             if (xdata)                                                         \
                 dict_ref(xdata);                                               \
             else                                                               \
@@ -1706,7 +1706,7 @@ pl_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     pl_inode_t *pl_inode = NULL;
 
     local = frame->local;
-    if (local && local->update_mlock_enforced_flag && op_ret >= 0) {
+    if (IS_SUCCESS(local && local->update_mlock_enforced_flag && op_ret)) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
             op_ret = -1;
@@ -2651,7 +2651,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
             reqlock->frame = frame;
             reqlock->this = this;
             ret = pl_verify_reservelk(this, pl_inode, reqlock, can_block);
-            GF_ASSERT(ret >= 0);
+            GF_ASSERT(IS_SUCCESS(ret));
 
             ret = pl_getlk_fd(this, pl_inode, fd, reqlock);
             if (IS_ERROR(ret)) {
@@ -3428,7 +3428,7 @@ pl_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     pl_local_t *local = NULL;
     pl_inode_t *pl_inode = NULL;
     local = frame->local;
-    if (local && local->update_mlock_enforced_flag && op_ret >= 0) {
+    if (IS_SUCCESS(local && local->update_mlock_enforced_flag && op_ret)) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
             op_ret = -1;
@@ -4492,7 +4492,7 @@ pl_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     pl_inode_t *pl_inode = NULL;
 
     local = frame->local;
-    if (local && local->update_mlock_enforced_flag && op_ret >= 0) {
+    if (IS_SUCCESS(local && local->update_mlock_enforced_flag && op_ret)) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
             op_ret = -1;
@@ -4547,7 +4547,7 @@ pl_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     pl_inode_t *pl_inode = NULL;
 
     local = frame->local;
-    if (local && local->update_mlock_enforced_flag && op_ret >= 0) {
+    if (IS_SUCCESS(local && local->update_mlock_enforced_flag && op_ret)) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
             op_ret = -1;

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -1706,7 +1706,7 @@ pl_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     pl_inode_t *pl_inode = NULL;
 
     local = frame->local;
-    if (IS_SUCCESS(local && local->update_mlock_enforced_flag && op_ret)) {
+    if (local && local->update_mlock_enforced_flag && IS_SUCCESS(op_ret)) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
             op_ret = -1;
@@ -3428,7 +3428,7 @@ pl_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     pl_local_t *local = NULL;
     pl_inode_t *pl_inode = NULL;
     local = frame->local;
-    if (IS_SUCCESS(local && local->update_mlock_enforced_flag && op_ret)) {
+    if (local && local->update_mlock_enforced_flag && IS_SUCCESS(op_ret)) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
             op_ret = -1;
@@ -4492,7 +4492,7 @@ pl_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     pl_inode_t *pl_inode = NULL;
 
     local = frame->local;
-    if (IS_SUCCESS(local && local->update_mlock_enforced_flag && op_ret)) {
+    if (local && local->update_mlock_enforced_flag && IS_SUCCESS(op_ret)) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
             op_ret = -1;
@@ -4547,7 +4547,7 @@ pl_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     pl_inode_t *pl_inode = NULL;
 
     local = frame->local;
-    if (IS_SUCCESS(local && local->update_mlock_enforced_flag && op_ret)) {
+    if (local && local->update_mlock_enforced_flag && IS_SUCCESS(op_ret)) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
             op_ret = -1;

--- a/xlators/features/locks/src/reservelk.c
+++ b/xlators/features/locks/src/reservelk.c
@@ -310,7 +310,7 @@ grant_blocked_lock_calls(xlator_t *this, pl_inode_t *pl_inode)
 
         lock->blocked = 0;
         ret = pl_setlk(this, pl_inode, lock, can_block);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             if (can_block) {
                 continue;
             } else {
@@ -366,7 +366,7 @@ pl_reserve_setlk(xlator_t *this, pl_inode_t *pl_inode, posix_lock_t *lock,
     }
     pthread_mutex_unlock(&pl_inode->mutex);
 
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_log(this->name, GF_LOG_TRACE,
                "%s (pid=%d) (lk-owner=%s) %" PRId64 " - %" PRId64 " => NOK",
                lock->fl_type == F_UNLCK ? "Unlock" : "Lock", lock->client_pid,

--- a/xlators/features/marker/src/marker-common.c
+++ b/xlators/features/marker/src/marker-common.c
@@ -43,7 +43,7 @@ marker_force_inode_ctx_get(inode_t *inode, xlator_t *this,
                 goto unlock;
 
             ret = __inode_ctx_put(inode, this, (uint64_t)(unsigned long)*ctx);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 GF_FREE(*ctx);
                 goto unlock;
             }

--- a/xlators/features/marker/src/marker-quota-helper.c
+++ b/xlators/features/marker/src/marker-quota-helper.c
@@ -50,7 +50,7 @@ mq_loc_fill(loc_t *loc, inode_t *inode, inode_t *parent, char *path)
     ret = 0;
 
 out:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         loc_wipe(loc);
 
     return ret;
@@ -95,18 +95,18 @@ mq_inode_loc_fill(const char *parent_gfid, inode_t *inode, loc_t *loc)
 
 ignore_parent:
     ret = inode_path(inode, NULL, &resolvedpath);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log("marker", GF_LOG_ERROR, "failed to resolve path for %s",
                uuid_utoa(inode->gfid));
         goto err;
     }
 
     ret = mq_loc_fill(loc, inode, parent, resolvedpath);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     ret = mq_inode_ctx_get(inode, this, &ctx);
-    if (ret < 0 || ctx == NULL)
+    if (IS_ERROR(ret) || ctx == NULL)
         ctx = mq_inode_ctx_new(inode, this);
     if (ctx == NULL) {
         gf_log(this->name, GF_LOG_WARNING,
@@ -134,7 +134,7 @@ mq_alloc_inode_ctx()
     quota_inode_ctx_t *ctx = NULL;
 
     QUOTA_ALLOC(ctx, quota_inode_ctx_t, ret);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     ctx->size = 0;
@@ -160,7 +160,7 @@ mq_contri_init(inode_t *inode)
     int32_t ret = 0;
 
     QUOTA_ALLOC(contri, inode_contribution_t, ret);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     GF_REF_INIT(contri, mq_contri_fini);
@@ -286,11 +286,11 @@ mq_dict_set_contribution(xlator_t *this, dict_t *dict, loc_t *loc, uuid_t gfid,
         GET_CONTRI_KEY(this, key, NULL, ret);
     }
 
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_set_int64(dict, key, 0);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (contri_key)
@@ -300,7 +300,7 @@ mq_dict_set_contribution(xlator_t *this, dict_t *dict, loc_t *loc, uuid_t gfid,
         }
 
 out:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_log_callingfn(this ? this->name : "Marker", GF_LOG_ERROR,
                          "dict set failed");
 
@@ -319,7 +319,7 @@ mq_inode_ctx_get(inode_t *inode, xlator_t *this, quota_inode_ctx_t **ctx)
     GF_VALIDATE_OR_GOTO("marker", ctx, out);
 
     ret = inode_ctx_get(inode, this, &ctx_int);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -1;
         *ctx = NULL;
         goto out;
@@ -347,7 +347,7 @@ __mq_inode_ctx_new(inode_t *inode, xlator_t *this)
     marker_inode_ctx_t *mark_ctx = NULL;
 
     ret = marker_force_inode_ctx_get(inode, this, &mark_ctx);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_ERROR, "marker_force_inode_ctx_get() failed");
         goto out;
     }

--- a/xlators/features/marker/src/marker-quota.c
+++ b/xlators/features/marker/src/marker-quota.c
@@ -1359,7 +1359,7 @@ mq_reduce_parent_size_task(void *opaque)
         goto out;
     locked = _gf_true;
 
-    if (contri.size >= 0) {
+    if (IS_SUCCESS(contri.size)) {
         /* contri parameter is supplied only for rename operation.
          * remove xattr is alreday performed, we need to skip
          * removexattr for rename operation
@@ -1438,7 +1438,7 @@ out:
     if (locked)
         ret = mq_lock(this, &parent_loc, F_UNLCK);
 
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         ret = mq_initiate_quota_blocking_txn(this, &parent_loc, NULL);
 
     loc_wipe(&parent_loc);

--- a/xlators/features/marker/src/marker.c
+++ b/xlators/features/marker/src/marker.c
@@ -65,11 +65,11 @@ marker_key_replace_with_ver(xlator_t *this, dict_t *dict)
     for (i = 0; mq_ext_xattrs[i]; i++) {
         if (dict_get(dict, mq_ext_xattrs[i])) {
             GET_QUOTA_KEY(this, key, mq_ext_xattrs[i], ret);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
 
             ret = dict_set(dict, key, dict_get(dict, mq_ext_xattrs[i]));
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
 
             dict_del(dict, mq_ext_xattrs[i]);
@@ -101,7 +101,7 @@ marker_key_set_ver(xlator_t *this, dict_t *dict)
 
     for (i = 0; mq_ext_xattrs[i]; i++) {
         GET_QUOTA_KEY(this, key, mq_ext_xattrs[i], ret);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         if (dict_get(dict, key))
@@ -161,7 +161,7 @@ marker_loc_fill(loc_t *loc, inode_t *inode, inode_t *parent, char *path)
 
     ret = 0;
 loc_wipe:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         loc_wipe(loc);
 
     return ret;
@@ -181,7 +181,7 @@ _marker_inode_loc_fill(inode_t *inode, inode_t *parent, char *name, loc_t *loc)
         ret = inode_path(parent, name, &resolvedpath);
     else
         ret = inode_path(inode, NULL, &resolvedpath);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     if (parent == NULL) {
@@ -190,7 +190,7 @@ _marker_inode_loc_fill(inode_t *inode, inode_t *parent, char *name, loc_t *loc)
     }
 
     ret = marker_loc_fill(loc, inode, parent, resolvedpath);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
 err:
@@ -227,7 +227,7 @@ marker_trav_parent(marker_local_t *local)
 
     ret = marker_inode_loc_fill(parent, &loc);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -1;
         goto out;
     }
@@ -434,11 +434,11 @@ marker_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                     dict_t *xdata)
 {
     int32_t ret = -1;
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     ret = marker_key_set_ver(this, dict);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = ENOMEM;
         goto unwind;
@@ -499,7 +499,7 @@ marker_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                 continue;
 
             GET_QUOTA_KEY(this, key, mq_ext_xattrs[i], ret);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
             name = key;
             break;
@@ -513,7 +513,7 @@ marker_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     MARKER_INIT_LOCAL(frame, local);
 
-    if ((loc_copy(&local->loc, loc)) < 0)
+    if (IS_ERROR((loc_copy(&local->loc, loc))))
         goto out;
 
     gf_log(this->name, GF_LOG_DEBUG, "USER:PID = %d", frame->root->pid);
@@ -567,7 +567,7 @@ marker_specific_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = (marker_local_t *)frame->local;
 
-    if (op_ret == -1 && op_errno == ENOSPC) {
+    if (IS_ERROR(op_ret) && op_errno == ENOSPC) {
         marker_error_handler(this, local, op_errno);
         goto out;
     }
@@ -583,7 +583,7 @@ marker_specific_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     ret = (local) ? marker_trav_parent(local) : -1;
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_DEBUG,
                "Error occurred "
                "while traversing to the parent, stopping marker");
@@ -710,7 +710,7 @@ marker_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "error occurred "
                "while creating directory %s",
@@ -737,7 +737,7 @@ marker_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(mkdir, frame, op_ret, op_errno, inode, buf, preparent,
                         postparent, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     if (gf_uuid_is_null(local->loc.gfid))
@@ -774,7 +774,7 @@ marker_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     ret = loc_copy(&local->loc, loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_mkdir_cbk, FIRST_CHILD(this),
@@ -797,7 +797,7 @@ marker_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_conf_t *priv = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "error occurred "
                "while creating file %s",
@@ -824,7 +824,7 @@ marker_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(create, frame, op_ret, op_errno, fd, inode, buf,
                         preparent, postparent, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     if (gf_uuid_is_null(local->loc.gfid))
@@ -861,7 +861,7 @@ marker_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
     ret = loc_copy(&local->loc, loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_create_cbk, FIRST_CHILD(this),
@@ -883,7 +883,7 @@ marker_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_conf_t *priv = NULL;
     marker_local_t *local = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "error occurred "
                "while write, %s",
@@ -897,7 +897,7 @@ marker_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -934,7 +934,7 @@ marker_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     ret = marker_inode_loc_fill(fd->inode, &local->loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_writev_cbk, FIRST_CHILD(this),
@@ -956,7 +956,7 @@ marker_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     call_stub_t *stub = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "error occurred "
                "rmdir %s",
@@ -968,7 +968,7 @@ marker_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     priv = this->private;
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     if (priv->feature_enabled & GF_XTIME)
@@ -1023,7 +1023,7 @@ marker_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     ret = loc_copy(&local->loc, loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_rmdir_cbk, FIRST_CHILD(this),
@@ -1046,7 +1046,7 @@ marker_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_UNUSED int32_t ret = 0;
     call_stub_t *stub = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE, "%s occurred in unlink",
                strerror(op_errno));
     }
@@ -1056,7 +1056,7 @@ marker_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     priv = this->private;
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     if (priv->feature_enabled & GF_XTIME)
@@ -1125,7 +1125,7 @@ marker_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
 
     ret = loc_copy(&local->loc, loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 
     if (xdata && dict_get(xdata, GLUSTERFS_MARKER_DONT_ACCOUNT_KEY)) {
@@ -1139,7 +1139,7 @@ marker_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     }
 
     ret = dict_set_int32(xdata, GF_REQUEST_LINK_COUNT_XDATA, 1);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
 unlink_wind:
@@ -1165,7 +1165,7 @@ marker_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred while "
                "linking a file ",
@@ -1179,7 +1179,7 @@ marker_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(link, frame, op_ret, op_errno, inode, buf, preparent,
                         postparent, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -1216,7 +1216,7 @@ marker_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     ret = loc_copy(&local->loc, newloc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 
     if (xdata && dict_get(xdata, GLUSTERFS_MARKER_DONT_ACCOUNT_KEY))
@@ -1248,7 +1248,7 @@ marker_rename_done(call_frame_t *frame, void *cookie, xlator_t *this,
 
     frame->local = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_WARNING,
                "inodelk (UNLOCK) failed on path:%s (gfid:%s) (%s)",
                oplocal->parent_loc.path,
@@ -1345,7 +1345,7 @@ marker_rename_unwind(call_frame_t *frame, void *cookie, xlator_t *this,
     if (cookie == (void *)_GF_UID_GID_CHANGED)
         MARKER_RESET_UID_GID(frame, frame->root, local);
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         local->err = op_errno ? op_errno : EINVAL;
 
     if (local->stub != NULL) {
@@ -1412,7 +1412,7 @@ marker_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     priv = this->private;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if (local != NULL) {
             local->err = op_errno;
         }
@@ -1424,7 +1424,7 @@ marker_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     if (priv->feature_enabled & GF_QUOTA) {
-        if ((op_ret < 0) || (local == NULL)) {
+        if (IS_ERROR((op_ret)) || (local == NULL)) {
             goto quota_err;
         }
 
@@ -1445,7 +1445,7 @@ marker_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->stub = stub;
 
         GET_CONTRI_KEY(this, contri_key, oplocal->loc.parent->gfid, ret);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             local->err = ENOMEM;
             goto quota_err;
         }
@@ -1474,7 +1474,7 @@ marker_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         STACK_UNWIND_STRICT(rename, frame, op_ret, op_errno, buf, preoldparent,
                             postoldparent, prenewparent, postnewparent, xdata);
 
-        if ((op_ret < 0) || (local == NULL)) {
+        if (IS_ERROR((op_ret)) || (local == NULL)) {
             goto out;
         }
 
@@ -1522,7 +1522,7 @@ marker_do_rename(call_frame_t *frame, void *cookie, xlator_t *this,
     if (cookie == (void *)_GF_UID_GID_CHANGED)
         MARKER_RESET_UID_GID(frame, frame->root, local);
 
-    if ((op_ret < 0) && (op_errno != ENOATTR) && (op_errno != ENODATA)) {
+    if (IS_ERROR((op_ret)) && (op_errno != ENOATTR) && (op_errno != ENODATA)) {
         local->err = op_errno ? op_errno : EINVAL;
         gf_log(this->name, GF_LOG_WARNING,
                "fetching contribution values from %s (gfid:%s) "
@@ -1533,7 +1533,7 @@ marker_do_rename(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     GET_CONTRI_KEY(this, contri_key, oplocal->loc.parent->gfid, keylen);
-    if (keylen < 0) {
+    if (IS_ERROR(keylen)) {
         local->err = errno ? errno : ENOMEM;
         goto err;
     }
@@ -1568,7 +1568,7 @@ marker_get_oldpath_contribution(call_frame_t *lk_frame, void *cookie,
     oplocal = local->oplocal;
     frame = local->frame;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->err = op_errno ? op_errno : EINVAL;
         gf_log(this->name, GF_LOG_WARNING,
                "cannot hold inodelk on %s (gfid:%s) (%s)", oplocal->loc.path,
@@ -1581,7 +1581,7 @@ marker_get_oldpath_contribution(call_frame_t *lk_frame, void *cookie,
     }
 
     GET_CONTRI_KEY(this, contri_key, oplocal->loc.parent->gfid, ret);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->err = errno ? errno : ENOMEM;
         goto err;
     }
@@ -1720,11 +1720,11 @@ marker_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     local->oplocal = marker_local_ref(oplocal);
 
     ret = loc_copy(&local->loc, newloc);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     ret = loc_copy(&oplocal->loc, oldloc);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     if (!(priv->feature_enabled & GF_QUOTA)) {
@@ -1732,11 +1732,11 @@ marker_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 
     ret = mq_inode_loc_fill(NULL, newloc->parent, &local->parent_loc);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     ret = mq_inode_loc_fill(NULL, oldloc->parent, &oplocal->parent_loc);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     lock.l_len = 0;
@@ -1746,7 +1746,7 @@ marker_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     local->xdata = xdata ? dict_ref(xdata) : dict_new();
     ret = dict_set_int32(local->xdata, GF_REQUEST_LINK_COUNT_XDATA, 1);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     local->frame = frame;
@@ -1787,7 +1787,7 @@ marker_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred while "
                "truncating a file ",
@@ -1801,7 +1801,7 @@ marker_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(truncate, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -1852,7 +1852,7 @@ marker_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
 
     ret = loc_copy(&local->loc, loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_truncate_cbk, FIRST_CHILD(this),
@@ -1872,7 +1872,7 @@ marker_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred while "
                "truncating a file ",
@@ -1886,7 +1886,7 @@ marker_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(ftruncate, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -1925,7 +1925,7 @@ marker_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     ret = marker_inode_loc_fill(fd->inode, &local->loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_ftruncate_cbk, FIRST_CHILD(this),
@@ -1947,7 +1947,7 @@ marker_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred while "
                "creating symlinks ",
@@ -1974,7 +1974,7 @@ marker_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(symlink, frame, op_ret, op_errno, inode, buf, preparent,
                         postparent, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     if (gf_uuid_is_null(local->loc.gfid))
@@ -2011,7 +2011,7 @@ marker_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
 
     ret = loc_copy(&local->loc, loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_symlink_cbk, FIRST_CHILD(this),
@@ -2034,7 +2034,7 @@ marker_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_conf_t *priv = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred with "
                "mknod ",
@@ -2061,7 +2061,7 @@ marker_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(mknod, frame, op_ret, op_errno, inode, buf, preparent,
                         postparent, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     if (gf_uuid_is_null(local->loc.gfid))
@@ -2100,7 +2100,7 @@ marker_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     local->mode = mode;
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_mknod_cbk, FIRST_CHILD(this),
@@ -2120,7 +2120,7 @@ marker_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred while "
                "fallocating a file ",
@@ -2134,7 +2134,7 @@ marker_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(fallocate, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2169,7 +2169,7 @@ marker_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
 
     ret = marker_inode_loc_fill(fd->inode, &local->loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_fallocate_cbk, FIRST_CHILD(this),
@@ -2190,7 +2190,7 @@ marker_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE, "%s occurred during discard",
                strerror(op_errno));
     }
@@ -2202,7 +2202,7 @@ marker_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(discard, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2237,7 +2237,7 @@ marker_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     ret = marker_inode_loc_fill(fd->inode, &local->loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_discard_cbk, FIRST_CHILD(this),
@@ -2257,7 +2257,7 @@ marker_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE, "%s occurred during zerofill",
                strerror(op_errno));
     }
@@ -2269,7 +2269,7 @@ marker_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(zerofill, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2304,7 +2304,7 @@ marker_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     ret = marker_inode_loc_fill(fd->inode, &local->loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_zerofill_cbk, FIRST_CHILD(this),
@@ -2382,7 +2382,7 @@ marker_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred in "
                "setxattr ",
@@ -2395,7 +2395,7 @@ marker_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     STACK_UNWIND_STRICT(setxattr, frame, op_ret, op_errno, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2455,7 +2455,7 @@ quota_xattr_cleaner_cbk(int ret, call_frame_t *frame, void *args)
     int op_ret = -1;
     int op_errno = 0;
 
-    op_ret = (ret < 0) ? -1 : 0;
+    op_ret = (IS_ERROR(ret)) ? -1 : 0;
     op_errno = -ret;
 
     MARKER_STACK_UNWIND(setxattr, frame, op_ret, op_errno, xdata);
@@ -2481,20 +2481,20 @@ quota_xattr_cleaner(void *args)
     local = frame->local;
 
     ret = syncop_listxattr(FIRST_CHILD(this), &local->loc, &xdata, NULL, NULL);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         ret = -errno;
         goto out;
     }
 
     ret = dict_foreach_fnmatch(xdata, "trusted.glusterfs.quota.*",
                                remove_quota_keys, frame);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         ret = -errno;
         goto out;
     }
     ret = dict_foreach_fnmatch(xdata, PGFID_XATTR_KEY_PREFIX "*",
                                remove_quota_keys, frame);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         ret = -errno;
         goto out;
     }
@@ -2570,7 +2570,7 @@ marker_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
     }
 
     ret = marker_key_replace_with_ver(this, dict);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     if (priv->feature_enabled == 0)
@@ -2586,7 +2586,7 @@ marker_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
 
     ret = loc_copy(&local->loc, loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_setxattr_cbk, FIRST_CHILD(this),
@@ -2605,7 +2605,7 @@ marker_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred in "
                "fsetxattr",
@@ -2618,7 +2618,7 @@ marker_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     STACK_UNWIND_STRICT(fsetxattr, frame, op_ret, op_errno, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2654,7 +2654,7 @@ marker_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
 
     ret = marker_inode_loc_fill(fd->inode, &local->loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_fsetxattr_cbk, FIRST_CHILD(this),
@@ -2674,7 +2674,7 @@ marker_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred in "
                "fsetattr ",
@@ -2688,7 +2688,7 @@ marker_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(fsetattr, frame, op_ret, op_errno, statpre, statpost,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2720,7 +2720,7 @@ marker_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     ret = marker_inode_loc_fill(fd->inode, &local->loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_fsetattr_cbk, FIRST_CHILD(this),
@@ -2744,7 +2744,7 @@ marker_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     frame->local = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE, "%s occurred during setattr of %s",
                strerror(op_errno), (local ? local->loc.path : "<nul>"));
     }
@@ -2752,7 +2752,7 @@ marker_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(setattr, frame, op_ret, op_errno, statpre, statpost,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2784,7 +2784,7 @@ marker_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     ret = loc_copy(&local->loc, loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_setattr_cbk, FIRST_CHILD(this),
@@ -2803,7 +2803,7 @@ marker_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred while "
                "removing extended attribute",
@@ -2816,7 +2816,7 @@ marker_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     STACK_UNWIND_STRICT(removexattr, frame, op_ret, op_errno, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2849,7 +2849,7 @@ marker_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                 continue;
 
             GET_QUOTA_KEY(this, key, mq_ext_xattrs[i], ret);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto err;
             name = key;
             break;
@@ -2865,7 +2865,7 @@ marker_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     ret = loc_copy(&local->loc, loc);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 wind:
     STACK_WIND(frame, marker_removexattr_cbk, FIRST_CHILD(this),
@@ -2902,14 +2902,14 @@ marker_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = (marker_local_t *)frame->local;
     frame->local = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE, "lookup failed with %s",
                strerror(op_errno));
         goto unwind;
     }
 
     ret = marker_key_set_ver(this, dict);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = ENOMEM;
         goto unwind;
@@ -2943,7 +2943,7 @@ unwind:
     STACK_UNWIND_STRICT(lookup, frame, op_ret, op_errno, inode, buf, xattrs,
                         postparent);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR((op_ret)) || local == NULL)
         goto out;
 
     /* copy the gfid from the stat structure instead of inode,
@@ -2981,7 +2981,7 @@ marker_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc,
         goto err;
 
     ret = marker_key_replace_with_ver(this, xattr_req);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     if (priv->feature_enabled == 0)
@@ -2994,7 +2994,7 @@ marker_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc,
     MARKER_INIT_LOCAL(frame, local);
 
     ret = loc_copy(&local->loc, loc);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 
     if ((priv->feature_enabled & GF_QUOTA))
@@ -3035,7 +3035,7 @@ marker_build_ancestry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             continue;
 
         ret = marker_key_set_ver(this, entry->dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             op_ret = -1;
             op_errno = ENOMEM;
             break;
@@ -3088,7 +3088,7 @@ marker_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         loc.parent = inode_ref(local->loc.inode);
         loc.inode = inode_ref(entry->inode);
         ret = inode_path(loc.parent, entry->d_name, &resolvedpath);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(this->name, GF_LOG_ERROR,
                    "failed to get the "
                    "path for the entry %s",
@@ -3111,7 +3111,7 @@ marker_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         loc_wipe(&loc);
 
         ret = marker_key_set_ver(this, entry->dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             op_ret = -1;
             op_errno = ENOMEM;
             goto unwind;
@@ -3142,7 +3142,7 @@ marker_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         goto unwind;
 
     ret = marker_key_replace_with_ver(this, dict);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto unwind;
 
     if (dict_get(dict, GET_ANCESTRY_DENTRY_KEY)) {
@@ -3219,7 +3219,7 @@ init_xtime_priv(xlator_t *this, dict_t *options)
 
     ret = gf_uuid_parse(priv->volume_uuid, priv->volume_uuid_bin);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_ERROR, "invalid volume uuid %s",
                priv->volume_uuid);
         goto out;
@@ -3228,7 +3228,7 @@ init_xtime_priv(xlator_t *this, dict_t *options)
     ret = gf_asprintf(&(priv->marker_xattr), "%s.%s.%s", MARKER_XATTR_PREFIX,
                       priv->volume_uuid, XTIME);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         priv->marker_xattr = NULL;
         goto out;
     }
@@ -3248,7 +3248,7 @@ init_xtime_priv(xlator_t *this, dict_t *options)
     }
 
     ret = gf_asprintf(&priv->timestamp_file, "%s", tmp_opt);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         priv->timestamp_file = NULL;
         goto out;
     }
@@ -3360,7 +3360,7 @@ reconfigure(xlator_t *this, dict_t *options)
             marker_xtime_priv_cleanup(this);
 
             ret = init_xtime_priv(this, options);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_log(this->name, GF_LOG_WARNING,
                        "failed to initialize xtime private, "
                        "xtime updation will fail");
@@ -3428,7 +3428,7 @@ init(xlator_t *this)
     if (data)
         ret = gf_string2int32(data->data, &priv->version);
 
-    if ((ret == 0) && priv->feature_enabled && priv->version < 0) {
+    if ((ret == 0) && priv->feature_enabled && IS_ERROR(priv->version)) {
         gf_log(this->name, GF_LOG_ERROR, "Invalid quota version %d",
                priv->version);
         goto err;
@@ -3439,7 +3439,7 @@ init(xlator_t *this)
         ret = gf_string2boolean(data->data, &flag);
         if (ret == 0 && flag == _gf_true) {
             ret = init_xtime_priv(this, options);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto err;
 
             priv->feature_enabled |= GF_XTIME;

--- a/xlators/features/marker/src/marker.c
+++ b/xlators/features/marker/src/marker.c
@@ -722,7 +722,7 @@ marker_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     priv = this->private;
 
-    if (op_ret >= 0 && inode && (priv->feature_enabled & GF_QUOTA)) {
+    if (IS_SUCCESS(op_ret) && inode && (priv->feature_enabled & GF_QUOTA)) {
         ctx = mq_inode_ctx_new(inode, this);
         if (ctx == NULL) {
             gf_log(this->name, GF_LOG_WARNING,
@@ -809,7 +809,7 @@ marker_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     priv = this->private;
 
-    if (op_ret >= 0 && inode && (priv->feature_enabled & GF_QUOTA)) {
+    if (IS_SUCCESS(op_ret) && inode && (priv->feature_enabled & GF_QUOTA)) {
         ctx = mq_inode_ctx_new(inode, this);
         if (ctx == NULL) {
             gf_log(this->name, GF_LOG_WARNING,
@@ -1959,7 +1959,7 @@ marker_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     priv = this->private;
 
-    if (op_ret >= 0 && inode && (priv->feature_enabled & GF_QUOTA)) {
+    if (IS_SUCCESS(op_ret) && inode && (priv->feature_enabled & GF_QUOTA)) {
         ctx = mq_inode_ctx_new(inode, this);
         if (ctx == NULL) {
             gf_log(this->name, GF_LOG_WARNING,
@@ -2046,7 +2046,7 @@ marker_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     priv = this->private;
 
-    if (op_ret >= 0 && inode && (priv->feature_enabled & GF_QUOTA)) {
+    if (IS_SUCCESS(op_ret) && inode && (priv->feature_enabled & GF_QUOTA)) {
         ctx = mq_inode_ctx_new(inode, this);
         if (ctx == NULL) {
             gf_log(this->name, GF_LOG_WARNING,
@@ -2927,7 +2927,7 @@ marker_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         xattrs = dict_ref(dict);
     }
 
-    if (op_ret >= 0 && inode && (priv->feature_enabled & GF_QUOTA)) {
+    if (IS_SUCCESS(op_ret) && inode && (priv->feature_enabled & GF_QUOTA)) {
         ctx = mq_inode_ctx_new(inode, this);
         if (ctx == NULL) {
             gf_log(this->name, GF_LOG_WARNING,
@@ -3344,7 +3344,7 @@ reconfigure(xlator_t *this, dict_t *options)
         ret = gf_string2int32(data->data, &version);
 
     if (priv->feature_enabled) {
-        if (version >= 0)
+        if (IS_SUCCESS(version))
             priv->version = version;
         else
             gf_log(this->name, GF_LOG_ERROR,

--- a/xlators/features/namespace/src/namespace.c
+++ b/xlators/features/namespace/src/namespace.c
@@ -307,7 +307,7 @@ set_ns_from_loc(const char *fn, call_frame_t *frame, xlator_t *this, loc_t *loc)
             gf_uuid_copy(loc->inode->gfid, loc->gfid);
         }
 
-        if (inode_path(loc->inode, NULL, &path) >= 0 && path) {
+        if (IS_SUCCESS(inode_path(loc->inode, NULL, &path)) && path) {
             ret = parse_path(info, loc->path);
             gf_log(this->name, GF_LOG_DEBUG, "%s: LOC retrieved path %s", fn,
                    path);
@@ -367,7 +367,7 @@ set_ns_from_fd(const char *fn, call_frame_t *frame, xlator_t *this, fd_t *fd)
         ret = PATH_PARSE_RESULT_NO_PATH;
     } else if (!ns_inode_ctx_get(fd->inode, this, info)) {
         ret = PATH_PARSE_RESULT_FOUND;
-    } else if (inode_path(fd->inode, NULL, &path) >= 0 && path) {
+    } else if (IS_SUCCESS(inode_path(fd->inode, NULL, &path)) && path) {
         ret = parse_path(info, path);
         gf_log(this->name, GF_LOG_DEBUG, "%s: FD  retrieved path %s", fn, path);
 

--- a/xlators/features/quiesce/src/quiesce.c
+++ b/xlators/features/quiesce/src/quiesce.c
@@ -123,7 +123,7 @@ gf_quiesce_failover_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 {
     quiesce_priv_t *priv = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         /* Failure here doesn't mean the failover to another host didn't
          * succeed, we will know if failover succeeds or not by the
          * CHILD_UP/CHILD_DOWN event. A failure here indicates something
@@ -274,7 +274,7 @@ gf_quiesce_timeout(void *data)
     }
     UNLOCK(&priv->lock);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         priv->pass_through = _gf_true;
         gf_quiesce_dequeue_start(this);
     }
@@ -317,7 +317,7 @@ quiesce_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_lookup_stub(frame, default_lookup_resume, &local->loc,
                                local->dict);
@@ -349,7 +349,7 @@ quiesce_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_stat_stub(frame, default_stat_resume, &local->loc, xdata);
         if (!stub) {
@@ -377,7 +377,7 @@ quiesce_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_access_stub(frame, default_access_resume, &local->loc,
                                local->flag, xdata);
@@ -407,7 +407,7 @@ quiesce_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_readlink_stub(frame, default_readlink_resume, &local->loc,
                                  local->size, xdata);
@@ -436,7 +436,7 @@ quiesce_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_open_stub(frame, default_open_resume, &local->loc,
                              local->flag, local->fd, xdata);
@@ -467,7 +467,7 @@ quiesce_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_readv_stub(frame, default_readv_resume, local->fd,
                               local->size, local->offset, local->io_flag,
@@ -499,7 +499,7 @@ quiesce_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_flush_stub(frame, default_flush_resume, local->fd, xdata);
         if (!stub) {
@@ -528,7 +528,7 @@ quiesce_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_fsync_stub(frame, default_fsync_resume, local->fd,
                               local->flag, xdata);
@@ -558,7 +558,7 @@ quiesce_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_fstat_stub(frame, default_fstat_resume, local->fd, xdata);
         if (!stub) {
@@ -586,7 +586,7 @@ quiesce_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_opendir_stub(frame, default_opendir_resume, &local->loc,
                                 local->fd, xdata);
@@ -615,7 +615,7 @@ quiesce_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_fsyncdir_stub(frame, default_fsyncdir_resume, local->fd,
                                  local->flag, xdata);
@@ -645,7 +645,7 @@ quiesce_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_statfs_stub(frame, default_statfs_resume, &local->loc,
                                xdata);
@@ -675,7 +675,7 @@ quiesce_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_fgetxattr_stub(frame, default_fgetxattr_resume, local->fd,
                                   local->name, xdata);
@@ -705,7 +705,7 @@ quiesce_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_getxattr_stub(frame, default_getxattr_resume, &local->loc,
                                  local->name, xdata);
@@ -735,7 +735,7 @@ quiesce_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_rchecksum_stub(frame, default_rchecksum_resume, local->fd,
                                   local->offset, local->flag, xdata);
@@ -766,7 +766,7 @@ quiesce_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_readdir_stub(frame, default_readdir_resume, local->fd,
                                 local->size, local->offset, xdata);
@@ -796,7 +796,7 @@ quiesce_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_readdirp_stub(frame, default_readdirp_resume, local->fd,
                                  local->size, local->offset, local->dict);
@@ -831,7 +831,7 @@ quiesce_writev_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_writev_stub (frame, default_writev_resume,
                                         local->fd, local->vector, local->flag,
@@ -866,7 +866,7 @@ quiesce_xattrop_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_xattrop_stub (frame, default_xattrop_resume,
                                          &local->loc, local->xattrop_flags,
@@ -900,7 +900,7 @@ quiesce_fxattrop_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_fxattrop_stub (frame, default_fxattrop_resume,
                                           local->fd, local->xattrop_flags,
@@ -934,7 +934,7 @@ quiesce_lk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_lk_stub (frame, default_lk_resume,
                                     local->fd, local->flag, &local->flock, xdata);
@@ -967,7 +967,7 @@ quiesce_inodelk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_inodelk_stub (frame, default_inodelk_resume,
                                          local->volname, &local->loc,
@@ -1001,7 +1001,7 @@ quiesce_finodelk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_finodelk_stub (frame, default_finodelk_resume,
                                          local->volname, local->fd,
@@ -1034,7 +1034,7 @@ quiesce_entrylk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_entrylk_stub (frame, default_entrylk_resume,
                                          local->volname, &local->loc,
@@ -1067,7 +1067,7 @@ quiesce_fentrylk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_fentrylk_stub (frame, default_fentrylk_resume,
                                           local->volname, local->fd,
@@ -1101,7 +1101,7 @@ quiesce_setattr_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_setattr_stub (frame, default_setattr_resume,
                                          &local->loc, &local->stbuf, local->flag, xdata);
@@ -1137,7 +1137,7 @@ quiesce_fsetattr_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
         local = frame->local;
         frame->local = NULL;
 
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_fsetattr_stub (frame, default_fsetattr_resume,
                                           local->fd, &local->stbuf, local->flag, xdata);
@@ -2423,7 +2423,7 @@ quiesce_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_seek_stub(frame, default_seek_resume, local->fd,
                              local->offset, local->what, xdata);

--- a/xlators/features/quota/src/quota.c
+++ b/xlators/features/quota/src/quota.c
@@ -1055,7 +1055,7 @@ quota_check_limit_continuation(struct list_head *parents, inode_t *inode,
         par_local = local;
 
     if (IS_ERROR(op_ret) || list_empty(parents)) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             gf_msg(this->name, GF_LOG_WARNING, EIO, Q_MSG_ANCESTRY_BUILD_FAILED,
                    "Couldn't build ancestry for inode (gfid:%s). "
                    "Without knowing ancestors till root, quota"
@@ -1123,7 +1123,7 @@ quota_check_object_limit(call_frame_t *frame, quota_inode_ctx_t *ctx,
             timeout = priv->soft_timeout;
 
             object_aggr_count = ctx->file_count + ctx->dir_count + 1;
-            if (((ctx->object_soft_lim >= 0) &&
+            if (IS_SUCCESS(((ctx->object_soft_lim)) &&
                  (object_aggr_count) > ctx->object_soft_lim)) {
                 timeout = priv->hard_timeout;
             }
@@ -1191,7 +1191,7 @@ quota_check_size_limit(call_frame_t *frame, quota_inode_ctx_t *ctx,
         {
             timeout = priv->soft_timeout;
 
-            if ((ctx->soft_lim >= 0) && (wouldbe_size > ctx->soft_lim)) {
+            if (IS_SUCCESS((ctx->soft_lim)) && (wouldbe_size > ctx->soft_lim)) {
                 timeout = priv->hard_timeout;
             }
 
@@ -1613,7 +1613,7 @@ quota_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     frame->local = NULL;
 
-    if (op_ret >= 0 && inode) {
+    if (IS_SUCCESS(op_ret) && inode) {
         this_inode = inode_ref(inode);
 
         op_ret = quota_fill_inodectx(this, inode, dict, &local->loc, buf,
@@ -3980,7 +3980,7 @@ quota_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
     if (xdata && dict_get_sizen(xdata, GLUSTERFS_INTERNAL_FOP_KEY))
         internal_fop = _gf_true;
 
-    if (frame->root->pid >= 0 && internal_fop == _gf_false) {
+    if (IS_SUCCESS(frame->root->pid) && internal_fop == _gf_false) {
         GF_IF_INTERNAL_XATTR_GOTO("trusted.glusterfs.quota*", dict, op_errno,
                                   err);
         GF_IF_INTERNAL_XATTR_GOTO("trusted.pgfid*", dict, op_errno, err);
@@ -4143,7 +4143,7 @@ quota_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     /* all quota xattrs can be cleaned up by doing setxattr on special key.
      * Hence its ok that we don't allow removexattr on quota keys here.
      */
-    if (frame->root->pid >= 0) {
+    if (IS_SUCCESS(frame->root->pid)) {
         GF_IF_NATIVE_XATTR_GOTO("trusted.glusterfs.quota*", name, op_errno,
                                 err);
         GF_IF_NATIVE_XATTR_GOTO("trusted.pgfid*", name, op_errno, err);
@@ -4190,7 +4190,7 @@ quota_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     VALIDATE_OR_GOTO(this, err);
     VALIDATE_OR_GOTO(fd, err);
 
-    if (frame->root->pid >= 0) {
+    if (IS_SUCCESS(frame->root->pid)) {
         GF_IF_NATIVE_XATTR_GOTO("trusted.glusterfs.quota*", name, op_errno,
                                 err);
         GF_IF_NATIVE_XATTR_GOTO("trusted.pgfid*", name, op_errno, err);
@@ -4379,7 +4379,7 @@ quota_get_limit_dir_continuation(struct list_head *parents, inode_t *inode,
     this = THIS;
 
     if (IS_ERROR((op_ret)) || list_empty(parents)) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             gf_msg(this->name, GF_LOG_WARNING, EIO, Q_MSG_ANCESTRY_BUILD_FAILED,
                    "Couldn't build ancestry for inode (gfid:%s). "
                    "Without knowing ancestors till root, quota "

--- a/xlators/features/quota/src/quota.c
+++ b/xlators/features/quota/src/quota.c
@@ -1123,8 +1123,8 @@ quota_check_object_limit(call_frame_t *frame, quota_inode_ctx_t *ctx,
             timeout = priv->soft_timeout;
 
             object_aggr_count = ctx->file_count + ctx->dir_count + 1;
-            if (IS_SUCCESS(((ctx->object_soft_lim)) &&
-                 (object_aggr_count) > ctx->object_soft_lim)) {
+            if (IS_SUCCESS(ctx->object_soft_lim) &&
+		(object_aggr_count > ctx->object_soft_lim)) {
                 timeout = priv->hard_timeout;
             }
 
@@ -1191,7 +1191,7 @@ quota_check_size_limit(call_frame_t *frame, quota_inode_ctx_t *ctx,
         {
             timeout = priv->soft_timeout;
 
-            if (IS_SUCCESS((ctx->soft_lim)) && (wouldbe_size > ctx->soft_lim)) {
+            if (IS_SUCCESS(ctx->soft_lim) && (wouldbe_size > ctx->soft_lim)) {
                 timeout = priv->hard_timeout;
             }
 

--- a/xlators/features/quota/src/quota.c
+++ b/xlators/features/quota/src/quota.c
@@ -130,7 +130,7 @@ quota_inode_loc_fill(inode_t *inode, loc_t *loc)
 
 ignore_parent:
     ret = inode_path(inode, NULL, &resolvedpath);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, 0,
                      "cannot construct path for "
                      "inode (gfid:%s)",
@@ -138,7 +138,7 @@ ignore_parent:
     }
 
     ret = quota_loc_fill(loc, inode, parent, resolvedpath);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "cannot fill loc");
         goto err;
@@ -322,11 +322,11 @@ quota_find_common_ancestor(inode_t *inode1, inode_t *inode2,
     inode_t *cur_inode2 = NULL;
 
     depth1 = quota_inode_depth(inode1);
-    if (depth1 < 0)
+    if (IS_ERROR(depth1))
         goto out;
 
     depth2 = quota_inode_depth(inode2);
-    if (depth2 < 0)
+    if (IS_ERROR(depth2))
         goto out;
 
     cur_inode1 = inode_ref(inode1);
@@ -387,7 +387,7 @@ check_ancestory_continue(struct list_head *parents, inode_t *inode,
     LOCK(&local->lock);
     {
         link_count = --local->link_count;
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             local->op_ret = op_ret;
             local->op_errno = op_errno;
         }
@@ -433,7 +433,7 @@ check_ancestory_2_cbk(struct list_head *parents, inode_t *inode, int32_t op_ret,
 
     this_inode = data;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     if (parents == NULL || list_empty(parents)) {
@@ -560,7 +560,7 @@ quota_handle_validate_error(call_frame_t *frame, int32_t op_ret,
     if (local == NULL)
         goto out;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         LOCK(&local->lock);
         {
             local->op_ret = op_ret;
@@ -592,7 +592,7 @@ quota_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -604,7 +604,7 @@ quota_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     ret = inode_ctx_get(local->validate_loc.inode, this, &value);
 
     ctx = (quota_inode_ctx_t *)(unsigned long)value;
-    if ((ret == -1) || (ctx == NULL)) {
+    if (IS_ERROR(ret) || (ctx == NULL)) {
         gf_msg(this->name, GF_LOG_WARNING, EINVAL, Q_MSG_INODE_CTX_GET_FAILED,
                "quota context is"
                " not present in  inode (gfid:%s)",
@@ -615,7 +615,7 @@ quota_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     ret = quota_dict_get_meta(xdata, QUOTA_SIZE_KEY, SLEN(QUOTA_SIZE_KEY),
                               &size);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, EINVAL, Q_MSG_SIZE_KEY_MISSING,
                "quota size key not present "
                "in dict");
@@ -724,14 +724,14 @@ quota_add_parents_from_ctx(quota_inode_ctx_t *ctx, struct list_head *list)
             ret = quota_add_parent(list, dentry->name, dentry->par);
             if (ret == 1)
                 count++;
-            else if (ret == -1)
+            else if (IS_ERROR(ret))
                 break;
         }
     }
     UNLOCK(&ctx->lock);
 
 out:
-    return (ret == -1) ? -1 : count;
+    return (IS_ERROR(ret)) ? ret : count;
 }
 
 int32_t
@@ -759,7 +759,7 @@ quota_build_ancestry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     frame->local = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto err;
 
     if ((op_ret > 0) && (entries != NULL)) {
@@ -828,7 +828,7 @@ quota_build_ancestry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_inode_ctx_get(local->loc.inode, this, &ctx, 0);
 
     ret = quota_add_parents_from_ctx(ctx, &parents);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         op_errno = errno;
         goto err;
     }
@@ -847,7 +847,7 @@ quota_build_ancestry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         */
 
         ret = quota_add_parent(&parents, entry->d_name, parent->gfid);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             op_errno = errno;
             goto err;
         }
@@ -915,19 +915,19 @@ quota_build_ancestry(inode_t *inode, quota_ancestry_built_t ancestry_cbk,
     local->loc.inode = inode_ref(inode);
 
     op_ret = dict_set_int8(xdata_req, QUOTA_LIMIT_KEY, 1);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         op_errno = -op_ret;
         goto err;
     }
 
     op_ret = dict_set_int8(xdata_req, QUOTA_LIMIT_OBJECTS_KEY, 1);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         op_errno = -op_ret;
         goto err;
     }
 
     op_ret = dict_set_int8(xdata_req, GET_ANCESTRY_DENTRY_KEY, 1);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         op_errno = -op_ret;
         goto err;
     }
@@ -950,7 +950,7 @@ err:
     if (xdata_req)
         dict_unref(xdata_req);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         ancestry_cbk(NULL, NULL, -1, op_errno, data);
 
         if (new_frame) {
@@ -983,7 +983,7 @@ quota_validate(call_frame_t *frame, inode_t *inode, xlator_t *this,
         loc_wipe(&local->validate_loc);
 
         ret = quota_inode_loc_fill(inode, &local->validate_loc);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENFORCEMENT_FAILED,
                    "cannot fill loc for inode (gfid:%s), hence "
                    "aborting quota-checks and continuing with fop",
@@ -992,7 +992,7 @@ quota_validate(call_frame_t *frame, inode_t *inode, xlator_t *this,
     }
     UNLOCK(&local->lock);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -ENOMEM;
         goto err;
     }
@@ -1004,7 +1004,7 @@ quota_validate(call_frame_t *frame, inode_t *inode, xlator_t *this,
     }
 
     ret = dict_set_int8(xdata, QUOTA_SIZE_KEY, 1);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "dict set failed");
         ret = -ENOMEM;
@@ -1012,7 +1012,7 @@ quota_validate(call_frame_t *frame, inode_t *inode, xlator_t *this,
     }
 
     ret = dict_set_str(xdata, "volume-uuid", priv->volume_uuid);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "dict set failed");
         ret = -ENOMEM;
@@ -1020,7 +1020,7 @@ quota_validate(call_frame_t *frame, inode_t *inode, xlator_t *this,
     }
 
     ret = quota_enforcer_lookup(frame, this, xdata, cbk_fn);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = -ENOTCONN;
         goto err;
     }
@@ -1054,7 +1054,7 @@ quota_check_limit_continuation(struct list_head *parents, inode_t *inode,
     else
         par_local = local;
 
-    if ((op_ret < 0) || list_empty(parents)) {
+    if (IS_ERROR(op_ret) || list_empty(parents)) {
         if (op_ret >= 0) {
             gf_msg(this->name, GF_LOG_WARNING, EIO, Q_MSG_ANCESTRY_BUILD_FAILED,
                    "Couldn't build ancestry for inode (gfid:%s). "
@@ -1139,7 +1139,7 @@ quota_check_object_limit(call_frame_t *frame, quota_inode_ctx_t *ctx,
         if (need_validate && *skip_check != _gf_true) {
             *skip_check = _gf_true;
             ret = quota_validate(frame, _inode, this, quota_validate_cbk);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 *op_errno = -ret;
                 *skip_check = _gf_false;
             }
@@ -1206,7 +1206,7 @@ quota_check_size_limit(call_frame_t *frame, quota_inode_ctx_t *ctx,
         if (need_validate && *skip_check != _gf_true) {
             *skip_check = _gf_true;
             ret = quota_validate(frame, _inode, this, quota_validate_cbk);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 *op_errno = -ret;
                 *skip_check = _gf_false;
             }
@@ -1219,10 +1219,10 @@ quota_check_size_limit(call_frame_t *frame, quota_inode_ctx_t *ctx,
 
             space_available = ctx->hard_lim - ctx->size;
 
-            if (space_available < 0)
+            if (IS_ERROR(space_available))
                 space_available = 0;
 
-            if ((local->space_available < 0) ||
+            if (IS_ERROR(local->space_available) ||
                 (local->space_available > space_available)) {
                 local->space_available = space_available;
             }
@@ -1354,7 +1354,7 @@ quota_check_limit(call_frame_t *frame, inode_t *inode, xlator_t *this)
         if (parent == NULL) {
             ret = quota_build_ancestry(_inode, quota_check_limit_continuation,
                                        frame);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 op_errno = -ret;
                 goto err;
             }
@@ -1419,7 +1419,7 @@ do_quota_check_limit(call_frame_t *frame, inode_t *inode, xlator_t *this,
 
     ret = 0;
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (parent) {
             /* Caller should decrement link_count, in case parent is
              * NULL
@@ -1462,7 +1462,7 @@ quota_get_limits(xlator_t *this, dict_t *dict, int64_t *hard_lim,
         soft_lim_percent = ntoh64(limit->sl);
     }
 
-    if (soft_lim_percent < 0) {
+    if (IS_ERROR(soft_lim_percent)) {
         soft_lim_percent = priv->default_soft_lim;
     }
 
@@ -1480,7 +1480,7 @@ quota_get_limits(xlator_t *this, dict_t *dict, int64_t *hard_lim,
         soft_lim_percent = ntoh64(object_limit->sl);
     }
 
-    if (soft_lim_percent < 0) {
+    if (IS_ERROR(soft_lim_percent)) {
         soft_lim_percent = priv->default_soft_lim;
     }
 
@@ -1512,14 +1512,15 @@ quota_fill_inodectx(xlator_t *this, inode_t *inode, dict_t *dict, loc_t *loc,
     inode_ctx_get(inode, this, &value);
     ctx = (quota_inode_ctx_t *)(unsigned long)value;
 
-    if ((((ctx == NULL) || (ctx->hard_lim == hard_lim)) && (hard_lim < 0) &&
-         !QUOTA_REG_OR_LNK_FILE(buf->ia_type))) {
+    if ((((ctx == NULL) || (ctx->hard_lim == hard_lim)) &&
+         IS_ERROR(hard_lim)) &&
+        !QUOTA_REG_OR_LNK_FILE(buf->ia_type)) {
         ret = 0;
         goto out;
     }
 
     ret = quota_inode_ctx_get(inode, this, &ctx, 1);
-    if ((ret == -1) || (ctx == NULL)) {
+    if (IS_ERROR(ret) || (ctx == NULL)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_INODE_CTX_GET_FAILED,
                "cannot create quota "
                "context in inode(gfid:%s)",
@@ -1617,14 +1618,15 @@ quota_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         op_ret = quota_fill_inodectx(this, inode, dict, &local->loc, buf,
                                      &op_errno);
-        if (op_ret < 0)
+        if (IS_ERROR(op_ret))
             op_errno = ENOMEM;
     }
 
     QUOTA_STACK_UNWIND(lookup, frame, op_ret, op_errno, inode, buf, dict,
                        postparent);
 
-    if (op_ret < 0 || this_inode == NULL || gf_uuid_is_null(this_inode->gfid))
+    if (IS_ERROR(op_ret) || this_inode == NULL ||
+        gf_uuid_is_null(this_inode->gfid))
         goto out;
 
     check_ancestory_2(this, local, this_inode);
@@ -1662,7 +1664,7 @@ quota_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
     loc_copy(&local->loc, loc);
 
     ret = dict_set_int8(xattr_req, QUOTA_LIMIT_KEY, 1);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "dict set of key for "
                "hard-limit failed");
@@ -1670,7 +1672,7 @@ quota_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
     }
 
     ret = dict_set_int8(xattr_req, QUOTA_LIMIT_OBJECTS_KEY, 1);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "dict set of key for quota object limit failed");
         goto err;
@@ -1685,7 +1687,7 @@ err:
     if (xattr_req)
         dict_unref(xattr_req);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         QUOTA_STACK_UNWIND(lookup, frame, -1, ENOMEM, NULL, NULL, NULL, NULL);
     }
 
@@ -1709,7 +1711,7 @@ quota_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if ((op_ret < 0) || (local == NULL) || (postbuf == NULL)) {
+    if (IS_ERROR(op_ret) || (local == NULL) || (postbuf == NULL)) {
         goto out;
     }
 
@@ -1759,13 +1761,13 @@ quota_writev_helper(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     GF_VALIDATE_OR_GOTO("quota", local, unwind);
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
 
         if ((op_errno == EDQUOT) && (local->space_available > 0)) {
             new_count = iov_subset(vector, count, 0, local->space_available,
                                    &new_vector, 0);
-            if (new_count < 0) {
+            if (IS_ERROR(new_count)) {
                 local->op_ret = -1;
                 local->op_errno = ENOMEM;
                 goto unwind;
@@ -1883,7 +1885,7 @@ quota_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
     GF_VALIDATE_OR_GOTO(this->name, priv, unwind);
 
     parents = quota_add_parents_from_ctx(ctx, &head);
-    if (parents == -1) {
+    if (IS_ERROR(parents)) {
         op_errno = errno;
         goto unwind;
     }
@@ -1973,7 +1975,7 @@ quota_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     op_errno = local->op_errno;
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         goto unwind;
     }
 
@@ -2065,12 +2067,12 @@ quota_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_dentry_t *dentry = NULL;
 
     local = frame->local;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
     ret = quota_inode_ctx_get(inode, this, &ctx, 1);
-    if ((ret == -1) || (ctx == NULL)) {
+    if (IS_ERROR(ret) || (ctx == NULL)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_INODE_CTX_GET_FAILED,
                "cannot create quota "
                "context in inode(gfid:%s)",
@@ -2117,7 +2119,7 @@ quota_create_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     GF_VALIDATE_OR_GOTO("quota", local, unwind);
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         goto unwind;
     }
@@ -2202,7 +2204,7 @@ quota_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_inode_ctx_t *ctx = NULL;
     uint64_t value = 0;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -2258,7 +2260,7 @@ quota_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     ret = 0;
 
 err:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         QUOTA_STACK_UNWIND(unlink, frame, -1, 0, NULL, NULL, NULL);
     }
 
@@ -2282,14 +2284,14 @@ quota_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_dentry_t *dentry = NULL;
     char found = 0;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
     local = (quota_local_t *)frame->local;
 
     ret = quota_inode_ctx_get(inode, this, &ctx, 0);
-    if ((ret == -1) || (ctx == NULL)) {
+    if (IS_ERROR(ret) || (ctx == NULL)) {
         gf_msg_debug(this->name, 0,
                      "quota context is NULL on inode"
                      " (%s). If quota is not enabled recently and "
@@ -2355,7 +2357,7 @@ quota_link_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
 
     op_errno = local->op_errno;
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         goto unwind;
     }
 
@@ -2383,7 +2385,7 @@ quota_link_continue(call_frame_t *frame)
     local = frame->local;
     this = THIS;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         goto err;
     }
@@ -2393,7 +2395,7 @@ quota_link_continue(call_frame_t *frame)
          */
         ret = quota_find_common_ancestor(
             local->oldloc.inode, local->newloc.parent, &common_ancestor);
-        if (ret < 0 || gf_uuid_is_null(common_ancestor)) {
+        if (IS_ERROR(ret) || gf_uuid_is_null(common_ancestor)) {
             gf_msg(this->name, GF_LOG_ERROR, ESTALE,
                    Q_MSG_ANCESTRY_BUILD_FAILED,
                    "failed to get "
@@ -2483,21 +2485,21 @@ quota_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
         local->xdata = dict_ref(xdata);
 
     ret = loc_copy(&local->loc, newloc);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "loc_copy failed");
         goto err;
     }
 
     ret = loc_copy(&local->oldloc, oldloc);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "loc_copy failed");
         goto err;
     }
 
     ret = loc_copy(&local->newloc, newloc);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "loc_copy failed");
         goto err;
@@ -2564,7 +2566,7 @@ quota_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_dentry_t *old_dentry = NULL, *dentry = NULL;
     char new_dentry_found = 0;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -2576,7 +2578,7 @@ quota_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
 
     ret = quota_inode_ctx_get(local->oldloc.inode, this, &ctx, 0);
-    if ((ret == -1) || (ctx == NULL)) {
+    if (IS_ERROR(ret) || (ctx == NULL)) {
         gf_msg_debug(this->name, 0,
                      "quota context is NULL on inode"
                      " (%s). If quota is not enabled recently and "
@@ -2660,7 +2662,7 @@ quota_rename_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
 
     op_errno = local->op_errno;
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         goto unwind;
     }
 
@@ -2692,11 +2694,11 @@ quota_rename_get_size_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_ASSERT(local);
     local->link_count = 1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     ret = dict_get_bin(xdata, QUOTA_SIZE_KEY, (void **)&size);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, EINVAL, Q_MSG_SIZE_KEY_MISSING,
                "size key not present in dict");
         op_errno = EINVAL;
@@ -2725,14 +2727,14 @@ quota_rename_continue(call_frame_t *frame)
     local = frame->local;
     this = THIS;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         goto err;
     }
 
     ret = quota_find_common_ancestor(local->oldloc.parent, local->newloc.parent,
                                      &common_ancestor);
-    if (ret < 0 || gf_uuid_is_null(common_ancestor)) {
+    if (IS_ERROR(ret) || gf_uuid_is_null(common_ancestor)) {
         gf_msg(this->name, GF_LOG_ERROR, ESTALE, Q_MSG_ANCESTRY_BUILD_FAILED,
                "failed to get "
                "common_ancestor for %s and %s",
@@ -2817,14 +2819,14 @@ quota_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     frame->local = local;
 
     ret = loc_copy(&local->oldloc, oldloc);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "loc_copy failed");
         goto err;
     }
 
     ret = loc_copy(&local->newloc, newloc);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "loc_copy failed");
         goto err;
@@ -2887,14 +2889,14 @@ quota_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_dentry_t *dentry = NULL;
     int32_t ret = -1;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
     local = frame->local;
 
     ret = quota_inode_ctx_get(local->loc.inode, this, &ctx, 1);
-    if ((ret == -1) || (ctx == NULL)) {
+    if (IS_ERROR(ret) || (ctx == NULL)) {
         gf_msg_debug(this->name, 0,
                      "quota context is NULL on inode"
                      " (%s). If quota is not enabled recently and "
@@ -2939,7 +2941,7 @@ quota_symlink_helper(call_frame_t *frame, xlator_t *this, const char *linkpath,
 
     GF_VALIDATE_OR_GOTO("quota", local, unwind);
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         goto unwind;
     }
@@ -2976,7 +2978,7 @@ quota_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
     frame->local = local;
 
     ret = loc_copy(&local->loc, loc);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "loc_copy failed");
         goto err;
@@ -3020,7 +3022,7 @@ quota_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3070,7 +3072,7 @@ quota_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     frame->local = local;
 
     ret = loc_copy(&local->loc, loc);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "loc_copy failed");
         goto err;
@@ -3099,7 +3101,7 @@ quota_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3185,7 +3187,7 @@ quota_send_dir_limit_to_cli(call_frame_t *frame, xlator_t *this, inode_t *inode,
     }
 
     ret = inode_ctx_get(inode, this, &value);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ctx = (quota_inode_ctx_t *)(unsigned long)value;
@@ -3200,7 +3202,7 @@ dict_set:
     }
 
     ret = dict_set_nstrn(dict, (char *)name, namelen, dir_limit, dir_limit_len);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     gf_msg_debug(this->name, 0, "str = %s", dir_limit);
@@ -3262,7 +3264,7 @@ quota_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3312,7 +3314,7 @@ quota_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
     frame->local = local;
     ret = loc_copy(&local->loc, loc);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "loc_copy failed");
         goto unwind;
@@ -3340,7 +3342,7 @@ quota_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3413,7 +3415,7 @@ quota_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3462,7 +3464,7 @@ quota_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
     frame->local = local;
 
     ret = loc_copy(&local->loc, loc);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "loc_copy failed");
         goto unwind;
@@ -3491,7 +3493,7 @@ quota_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3563,7 +3565,7 @@ quota_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3634,7 +3636,7 @@ quota_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3687,7 +3689,7 @@ quota_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     frame->local = local;
 
     ret = loc_copy(&local->loc, loc);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "loc_copy failed");
         goto unwind;
@@ -3715,7 +3717,7 @@ quota_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3794,12 +3796,12 @@ quota_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_dentry_t *dentry = NULL;
 
     local = frame->local;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
     ret = quota_inode_ctx_get(inode, this, &ctx, 1);
-    if ((ret == -1) || (ctx == NULL)) {
+    if (IS_ERROR((ret)) || (ctx == NULL)) {
         gf_msg(this->name, GF_LOG_WARNING, 0, Q_MSG_INODE_CTX_GET_FAILED,
                "cannot create quota context in "
                "inode(gfid:%s)",
@@ -3845,7 +3847,7 @@ quota_mknod_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     GF_VALIDATE_OR_GOTO("quota", local, unwind);
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         goto unwind;
     }
@@ -3925,7 +3927,7 @@ quota_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_inode_ctx_t *ctx = NULL;
     int ret = 0;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3934,7 +3936,7 @@ quota_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
 
     ret = quota_inode_ctx_get(local->loc.inode, this, &ctx, 1);
-    if ((ret < 0) || (ctx == NULL)) {
+    if (IS_ERROR((ret)) || (ctx == NULL)) {
         op_errno = -1;
         goto out;
     }
@@ -4027,7 +4029,7 @@ quota_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_inode_ctx_t *ctx = NULL;
     quota_local_t *local = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     local = frame->local;
@@ -4035,7 +4037,7 @@ quota_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
 
     op_ret = quota_inode_ctx_get(local->loc.inode, this, &ctx, 1);
-    if ((op_ret < 0) || (ctx == NULL)) {
+    if (IS_ERROR((op_ret)) || (ctx == NULL)) {
         op_errno = ENOMEM;
         goto out;
     }
@@ -4223,7 +4225,7 @@ quota_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     /* This fop will fail mostly in case of client disconnect,
      * which is already logged. Hence, not logging here */
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto unwind;
     /*
      * We should never get here unless quota_statfs (below) sent us a
@@ -4264,7 +4266,7 @@ quota_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto unwind;
 
     ret = dict_set_int8(xdata, "quota-deem-statfs", 1);
-    if (-1 == ret)
+    if (IS_ERROR(ret))
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, Q_MSG_ENOMEM,
                "Dict set failed, deem-statfs option may "
                "have no effect");
@@ -4287,7 +4289,7 @@ quota_statfs_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     GF_VALIDATE_OR_GOTO("quota", local, err);
 
-    if (-1 == local->op_ret) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         goto err;
     }
@@ -4320,7 +4322,7 @@ quota_statfs_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto resume;
 
     GF_ASSERT(local);
@@ -4331,7 +4333,7 @@ quota_statfs_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     ret = inode_ctx_get(local->validate_loc.inode, this, &value);
 
     ctx = (quota_inode_ctx_t *)(unsigned long)value;
-    if ((ret == -1) || (ctx == NULL)) {
+    if (IS_ERROR((ret)) || (ctx == NULL)) {
         gf_msg(this->name, GF_LOG_WARNING, EINVAL, Q_MSG_INODE_CTX_GET_FAILED,
                "quota context is not present in inode (gfid:%s)",
                uuid_utoa(local->validate_loc.inode->gfid));
@@ -4341,7 +4343,7 @@ quota_statfs_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     ret = quota_dict_get_meta(xdata, QUOTA_SIZE_KEY, SLEN(QUOTA_SIZE_KEY),
                               &size);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, EINVAL, Q_MSG_SIZE_KEY_MISSING,
                "size key not present in "
                "dict");
@@ -4376,7 +4378,7 @@ quota_get_limit_dir_continuation(struct list_head *parents, inode_t *inode,
     frame = data;
     this = THIS;
 
-    if ((op_ret < 0) || list_empty(parents)) {
+    if (IS_ERROR((op_ret)) || list_empty(parents)) {
         if (op_ret >= 0) {
             gf_msg(this->name, GF_LOG_WARNING, EIO, Q_MSG_ANCESTRY_BUILD_FAILED,
                    "Couldn't build ancestry for inode (gfid:%s). "
@@ -4502,7 +4504,7 @@ quota_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         frame->local = local;
 
         ret = loc_copy(&local->loc, loc);
-        if (-1 == ret) {
+        if (IS_ERROR(ret)) {
             op_errno = ENOMEM;
             goto err;
         }
@@ -4624,7 +4626,7 @@ quota_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     if (dict) {
         ret = dict_set_int8(dict, QUOTA_LIMIT_KEY, 1);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                    "dict set of key for hard-limit");
             goto err;
@@ -4633,7 +4635,7 @@ quota_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     if (dict) {
         ret = dict_set_int8(dict, QUOTA_LIMIT_OBJECTS_KEY, 1);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                    "dict set of key for hard-limit "
                    "failed");
@@ -4676,7 +4678,7 @@ quota_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if ((op_ret < 0) || (local == NULL)) {
+    if (IS_ERROR((op_ret)) || (local == NULL)) {
         goto out;
     }
 
@@ -4720,7 +4722,7 @@ quota_fallocate_helper(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     GF_VALIDATE_OR_GOTO("quota", local, unwind);
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         if (op_errno == ENOENT || op_errno == ESTALE) {
             /* We may get ENOENT/ESTALE in case of below scenario
@@ -4809,7 +4811,7 @@ quota_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
     GF_VALIDATE_OR_GOTO(this->name, priv, unwind);
 
     parents = quota_add_parents_from_ctx(ctx, &head);
-    if (parents == -1) {
+    if (IS_ERROR(parents)) {
         op_errno = errno;
         goto unwind;
     }
@@ -4986,7 +4988,7 @@ quota_forget(xlator_t *this, inode_t *inode)
 
     ret = inode_ctx_del(inode, this, &ctx_int);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         return 0;
     }
 

--- a/xlators/features/quota/src/quota.h
+++ b/xlators/features/quota/src/quota.h
@@ -123,14 +123,14 @@
 #define GET_CONTRI_KEY_OR_GOTO(var, _vol_name, _gfid, label)                   \
     do {                                                                       \
         GET_CONTRI_KEY(var, _vol_name, _gfid, ret);                            \
-        if (ret == -1)                                                         \
+        if (IS_ERROR(ret))                                                     \
             goto label;                                                        \
     } while (0)
 
 #define GET_DIRTY_KEY_OR_GOTO(var, _vol_name, label)                           \
     do {                                                                       \
         ret = gf_asprintf(var, QUOTA_XATTR_PREFIX "%s." DIRTY, _vol_name);     \
-        if (ret == -1)                                                         \
+        if (IS_ERROR(ret))                                                     \
             goto label;                                                        \
     } while (0)
 

--- a/xlators/features/quota/src/quotad-aggregator.c
+++ b/xlators/features/quota/src/quotad-aggregator.c
@@ -53,7 +53,7 @@ quotad_serialize_reply(rpcsvc_request_t *req, void *arg, struct iovec *outmsg,
          */
 
         retlen = xdr_serialize_generic(*outmsg, arg, xdrproc);
-        if (retlen == -1) {
+        if (IS_ERROR(retlen)) {
             /* Failed to Encode 'GlusterFS' msg in RPC is not exactly
                failure of RPC return values.. Client should get
                notified about this, so there are no missing frames */
@@ -139,7 +139,7 @@ quotad_aggregator_getlimit_cbk(xlator_t *this, call_frame_t *frame,
     int ret = -1;
     int type = 0;
 
-    if (!rsp || (rsp->op_ret == -1))
+    if (!rsp || IS_ERROR(rsp->op_ret))
         goto reply;
 
     GF_PROTOCOL_DICT_UNSERIALIZE(frame->this, xdata, (rsp->xdata.xdata_val),
@@ -149,11 +149,11 @@ quotad_aggregator_getlimit_cbk(xlator_t *this, call_frame_t *frame,
     if (xdata) {
         state = frame->root->state;
         ret = dict_get_int32n(state->req_xdata, "type", SLEN("type"), &type);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = dict_set_int32_sizen(xdata, "type", type);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 
@@ -208,7 +208,7 @@ quotad_aggregator_getlimit(rpcsvc_request_t *req)
     cli_req.dict.dict_val = alloca(req->msg[0].iov_len);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg("this->name", GF_LOG_ERROR, 0, Q_MSG_XDR_DECODE_ERROR,
                "xdr decoding error");
@@ -220,7 +220,7 @@ quotad_aggregator_getlimit(rpcsvc_request_t *req)
         dict = dict_new();
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, Q_MSG_DICT_UNSERIALIZE_FAIL,
                    "Failed to unserialize req-buffer to "
                    "dictionary");
@@ -326,7 +326,7 @@ quotad_aggregator_lookup(rpcsvc_request_t *req)
     args.xdata.xdata_val = alloca(req->msg[0].iov_len);
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_gfs3_lookup_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         rsp.op_errno = EINVAL;
         goto err;
     }
@@ -352,7 +352,7 @@ quotad_aggregator_lookup(rpcsvc_request_t *req)
     for (i = 0; qd_ext_xattrs[i]; i++) {
         if (dict_get(dict, qd_ext_xattrs[i])) {
             ret = dict_set_uint32(state->xdata, qd_ext_xattrs[i], 1);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto err;
         }
     }

--- a/xlators/features/quota/src/quotad.c
+++ b/xlators/features/quota/src/quotad.c
@@ -89,7 +89,7 @@ qd_find_subvol(xlator_t *this, char *volume_uuid)
     for (child = this->children; child; child = child->next) {
         keylen = snprintf(key, sizeof(key), "%s.volume-id",
                           child->xlator->name);
-        if (dict_get_strn(this->options, key, keylen, &optstr) < 0)
+        if (IS_ERROR(dict_get_strn(this->options, key, keylen, &optstr)))
             continue;
 
         if (strcmp(optstr, volume_uuid) == 0) {
@@ -130,7 +130,7 @@ qd_nameless_lookup(xlator_t *this, call_frame_t *frame, char *gfid,
     memcpy(loc.gfid, gfid, 16);
 
     ret = dict_set_int8(xdata, QUOTA_READ_ONLY_KEY, 1);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, ENOMEM, Q_MSG_ENOMEM,
                "dict set failed");
         ret = -ENOMEM;

--- a/xlators/features/read-only/src/worm-helper.c
+++ b/xlators/features/read-only/src/worm-helper.c
@@ -135,7 +135,7 @@ worm_get_state(xlator_t *this, gf_boolean_t fop_with_fd, void *file_ptr,
     else
         ret = syncop_getxattr(this, (loc_t *)file_ptr, &dict,
                               "trusted.reten_state", NULL, NULL);
-    if (ret < 0 || !dict) {
+    if (IS_ERROR(ret) || !dict) {
         ret = -1;
         goto out;
     }
@@ -306,7 +306,7 @@ gf_worm_state_transition(xlator_t *this, gf_boolean_t fop_with_fd,
     else
         ret = syncop_getxattr(this, (loc_t *)file_ptr, &dict,
                               "trusted.start_time", NULL, NULL);
-    if (ret < 0 || !dict) {
+    if (IS_ERROR(ret) || !dict) {
         op_errno = ret;
         gf_msg(this->name, GF_LOG_ERROR, -ret, 0, "Error getting xattr");
         goto out;
@@ -337,7 +337,7 @@ gf_worm_state_transition(xlator_t *this, gf_boolean_t fop_with_fd,
         goto out;
     }
 
-    if (ret == -1 && (time(NULL) - start_time) >= com_period) {
+    if (IS_ERROR(ret) && (time(NULL) - start_time) >= com_period) {
         if ((time(NULL) - stbuf.ia_mtime) >= com_period) {
             ret = worm_set_state(this, fop_with_fd, file_ptr, &reten_state,
                                  &stbuf);
@@ -352,7 +352,7 @@ gf_worm_state_transition(xlator_t *this, gf_boolean_t fop_with_fd,
             op_errno = 0;
             goto out;
         }
-    } else if (ret == -1 && (time(NULL) - start_time) < com_period) {
+    } else if (IS_ERROR(ret) && (time(NULL) - start_time) < com_period) {
         op_errno = 0;
         goto out;
     } else if (reten_state.retain && ((time(NULL) >= stbuf.ia_atime))) {

--- a/xlators/features/read-only/src/worm.c
+++ b/xlators/features/read-only/src/worm.c
@@ -55,7 +55,7 @@ worm_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     GF_ASSERT(priv);
     if (is_readonly_or_worm_enabled(frame, this))
         goto out;
-    if (!priv->worm_file || (frame->root->pid < 0)) {
+    if (!priv->worm_file || IS_ERROR(frame->root->pid)) {
         op_errno = 0;
         goto out;
     }
@@ -69,7 +69,7 @@ worm_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
 out:
     if (op_errno) {
-        if (op_errno < 0)
+        if (IS_ERROR(op_errno))
             op_errno = EROFS;
         STACK_UNWIND_STRICT(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
                             NULL);
@@ -91,7 +91,7 @@ worm_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     if (is_readonly_or_worm_enabled(frame, this)) {
         goto out;
     }
-    if (!priv->worm_file || (frame->root->pid < 0)) {
+    if (!priv->worm_file || IS_ERROR(frame->root->pid)) {
         op_errno = 0;
         goto out;
     }
@@ -104,7 +104,7 @@ worm_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     op_errno = gf_worm_state_transition(this, _gf_false, loc, GF_FOP_UNLINK);
 out:
     if (op_errno) {
-        if (op_errno < 0)
+        if (IS_ERROR(op_errno))
             op_errno = EROFS;
         STACK_UNWIND_STRICT(unlink, frame, -1, op_errno, NULL, NULL, NULL);
     } else
@@ -124,7 +124,7 @@ worm_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     GF_ASSERT(priv);
     if (is_readonly_or_worm_enabled(frame, this))
         goto out;
-    if (!priv->worm_file || (frame->root->pid < 0)) {
+    if (!priv->worm_file || IS_ERROR(frame->root->pid)) {
         op_errno = 0;
         goto out;
     }
@@ -151,7 +151,7 @@ worm_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
 out:
     if (op_errno) {
-        if (op_errno < 0)
+        if (IS_ERROR(op_errno))
             op_errno = EROFS;
         STACK_UNWIND_STRICT(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
                             NULL, NULL);
@@ -172,7 +172,7 @@ worm_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     GF_ASSERT(priv);
     if (is_readonly_or_worm_enabled(frame, this))
         goto out;
-    if (!priv->worm_file || (frame->root->pid < 0)) {
+    if (!priv->worm_file || IS_ERROR(frame->root->pid)) {
         op_errno = 0;
         goto out;
     }
@@ -185,7 +185,7 @@ worm_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
 
 out:
     if (op_errno) {
-        if (op_errno < 0)
+        if (IS_ERROR(op_errno))
             op_errno = EROFS;
         STACK_UNWIND_STRICT(truncate, frame, -1, op_errno, NULL, NULL, NULL);
     } else
@@ -205,7 +205,7 @@ worm_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     GF_ASSERT(priv);
     if (is_readonly_or_worm_enabled(frame, this))
         goto out;
-    if (!priv->worm_file || (frame->root->pid < 0)) {
+    if (!priv->worm_file || IS_ERROR(frame->root->pid)) {
         op_errno = 0;
         goto out;
     }
@@ -218,7 +218,7 @@ worm_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
 out:
     if (op_errno) {
-        if (op_errno < 0)
+        if (IS_ERROR(op_errno))
             op_errno = EROFS;
         STACK_UNWIND_STRICT(ftruncate, frame, -1, op_errno, NULL, NULL, NULL);
     } else
@@ -410,7 +410,7 @@ worm_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
 
     priv = this->private;
     GF_ASSERT(priv);
-    if (!priv->worm_file || (frame->root->pid < 0)) {
+    if (!priv->worm_file || IS_ERROR(frame->root->pid)) {
         op_errno = 0;
         goto out;
     }
@@ -422,7 +422,7 @@ worm_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
 
 out:
     if (op_errno) {
-        if (op_errno < 0)
+        if (IS_ERROR(op_errno))
             op_errno = EROFS;
         STACK_UNWIND_STRICT(writev, frame, -1, op_errno, NULL, NULL, NULL);
     } else
@@ -443,7 +443,7 @@ worm_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     // In case of an error exit because fd can be NULL and this would
     // cause an segfault when performing fsetxattr . We explicitly
     // unwind to avoid future problems
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 

--- a/xlators/features/sdfs/src/sdfs.c
+++ b/xlators/features/sdfs/src/sdfs.c
@@ -144,7 +144,7 @@ sdfs_get_new_frame_common(call_frame_t *frame, call_frame_t **new_frame)
 
     ret = 0;
 err:
-    if ((ret == -1) && (*new_frame)) {
+    if (IS_ERROR(ret) && (*new_frame)) {
         SDFS_STACK_DESTROY((*new_frame));
         *new_frame = NULL;
     }
@@ -159,7 +159,7 @@ sdfs_get_new_frame(call_frame_t *frame, loc_t *loc, call_frame_t **new_frame)
     sdfs_local_t *local = NULL;
 
     ret = sdfs_get_new_frame_common(frame, new_frame);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -171,7 +171,7 @@ sdfs_get_new_frame(call_frame_t *frame, loc_t *loc, call_frame_t **new_frame)
     }
 
     ret = loc_copy(&local->loc, loc);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -194,7 +194,7 @@ sdfs_get_new_frame_readdirp(call_frame_t *frame, fd_t *fd,
     sdfs_local_t *local = NULL;
 
     ret = sdfs_get_new_frame_common(frame, new_frame);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -224,7 +224,7 @@ sdfs_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->stub = NULL;
         call_resume(stub);
     } else {
-        if (op_ret < 0)
+        if (IS_ERROR(op_ret))
             gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                    "Unlocking entry lock failed for %s", local->loc.name);
 
@@ -266,7 +266,7 @@ sdfs_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -297,7 +297,7 @@ sdfs_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     call_stub_t *stub = NULL;
     int op_errno = 0;
 
-    if (-1 == sdfs_get_new_frame(frame, loc, &new_frame)) {
+    if (IS_ERROR(sdfs_get_new_frame(frame, loc, &new_frame))) {
         op_errno = ENOMEM;
         goto err;
     }
@@ -357,7 +357,7 @@ sdfs_rmdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -387,7 +387,7 @@ sdfs_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
     call_stub_t *stub = NULL;
     int op_errno = 0;
 
-    if (-1 == sdfs_get_new_frame(frame, loc, &new_frame)) {
+    if (IS_ERROR(sdfs_get_new_frame(frame, loc, &new_frame))) {
         op_errno = ENOMEM;
         goto err;
     }
@@ -447,7 +447,7 @@ sdfs_create_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -478,7 +478,7 @@ sdfs_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     call_stub_t *stub = NULL;
     int op_errno = 0;
 
-    if (-1 == sdfs_get_new_frame(frame, loc, &new_frame)) {
+    if (IS_ERROR(sdfs_get_new_frame(frame, loc, &new_frame))) {
         op_errno = ENOMEM;
         goto err;
     }
@@ -538,7 +538,7 @@ sdfs_unlink_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -568,7 +568,7 @@ sdfs_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
     call_stub_t *stub = NULL;
     int op_errno = 0;
 
-    if (-1 == sdfs_get_new_frame(frame, loc, &new_frame)) {
+    if (IS_ERROR(sdfs_get_new_frame(frame, loc, &new_frame))) {
         op_errno = ENOMEM;
         goto err;
     }
@@ -627,7 +627,7 @@ sdfs_symlink_helper(call_frame_t *frame, xlator_t *this, const char *linkname,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -657,7 +657,7 @@ sdfs_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
     call_stub_t *stub = NULL;
     int op_errno = 0;
 
-    if (-1 == sdfs_get_new_frame(frame, loc, &new_frame)) {
+    if (IS_ERROR(sdfs_get_new_frame(frame, loc, &new_frame))) {
         op_errno = ENOMEM;
         goto err;
     }
@@ -701,7 +701,7 @@ sdfs_common_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     locks = local->lock;
     lk_index = (long)cookie;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
     } else {
@@ -721,7 +721,7 @@ sdfs_common_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->stub = NULL;
         call_resume(stub);
     } else {
-        if (local->op_ret < 0)
+        if (IS_ERROR(local->op_ret))
             gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                    "unlocking entry lock failed ");
         SDFS_STACK_DESTROY(frame);
@@ -772,7 +772,7 @@ sdfs_link_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
     local = frame->local;
     locks = local->lock;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed");
         goto err;
@@ -900,7 +900,7 @@ sdfs_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     GF_ATOMIC_INIT(local->call_cnt, lock->lock_count);
 
     ret = loc_copy(&local->loc, newloc);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         op_errno = ENOMEM;
         goto err;
     }
@@ -961,7 +961,7 @@ sdfs_mknod_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -991,7 +991,7 @@ sdfs_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     call_stub_t *stub = NULL;
     int op_errno = 0;
 
-    if (-1 == sdfs_get_new_frame(frame, loc, &new_frame)) {
+    if (IS_ERROR(sdfs_get_new_frame(frame, loc, &new_frame))) {
         op_errno = ENOMEM;
         goto err;
     }
@@ -1068,7 +1068,7 @@ sdfs_rename_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
     local = frame->local;
     lock = local->lock;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed ");
         goto err;
@@ -1232,7 +1232,7 @@ sdfs_lookup_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -1273,7 +1273,7 @@ sdfs_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         return 0;
     }
 
-    if (-1 == sdfs_get_new_frame(frame, loc, &new_frame)) {
+    if (IS_ERROR(sdfs_get_new_frame(frame, loc, &new_frame))) {
         op_errno = ENOMEM;
         goto err;
     }
@@ -1331,7 +1331,7 @@ sdfs_readdirp_helper(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     gf_uuid_unparse(fd->inode->gfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -1362,7 +1362,7 @@ sdfs_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     call_stub_t *stub = NULL;
     int op_errno = 0;
 
-    if (-1 == sdfs_get_new_frame_readdirp(frame, fd, &new_frame)) {
+    if (IS_ERROR(sdfs_get_new_frame_readdirp(frame, fd, &new_frame))) {
         op_errno = ENOMEM;
         goto err;
     }

--- a/xlators/features/selinux/src/selinux.c
+++ b/xlators/features/selinux/src/selinux.c
@@ -25,7 +25,7 @@ selinux_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (op_errno == 0 && dict && name &&
         (!strcmp(name, SELINUX_GLUSTER_XATTR))) {
         ret = dict_rename_key(dict, SELINUX_GLUSTER_XATTR, SELINUX_XATTR);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg(this->name, GF_LOG_ERROR, op_errno,
                    SL_MSG_SELINUX_GLUSTER_XATTR_MISSING,
                    "getxattr failed for %s", SELINUX_XATTR);
@@ -76,7 +76,7 @@ selinux_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (op_errno == 0 && dict && name &&
         (!strcmp(name, SELINUX_GLUSTER_XATTR))) {
         ret = dict_rename_key(dict, SELINUX_GLUSTER_XATTR, SELINUX_XATTR);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg(this->name, GF_LOG_ERROR, op_errno,
                    SL_MSG_SELINUX_GLUSTER_XATTR_MISSING,
                    "getxattr failed for %s", SELINUX_XATTR);
@@ -142,7 +142,7 @@ selinux_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
         goto off;
 
     ret = dict_rename_key(dict, SELINUX_XATTR, SELINUX_GLUSTER_XATTR);
-    if (ret < 0 && ret != -ENODATA)
+    if (IS_ERROR(ret) && ret != -ENODATA)
         goto err;
 
 off:
@@ -180,7 +180,7 @@ selinux_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
         goto off;
 
     ret = dict_rename_key(dict, SELINUX_XATTR, SELINUX_GLUSTER_XATTR);
-    if (ret < 0 && ret != -ENODATA)
+    if (IS_ERROR(ret) && ret != -ENODATA)
         goto err;
 
 off:

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -82,7 +82,7 @@ __shard_inode_ctx_get(inode_t *inode, xlator_t *this, shard_inode_ctx_t **ctx)
 
     ctx_uint = (uint64_t)(uintptr_t)ctx_p;
     ret = __inode_ctx_set(inode, this, &ctx_uint);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         GF_FREE(ctx_p);
         return ret;
     }
@@ -364,7 +364,7 @@ __shard_inode_ctx_get_block_size(inode_t *inode, xlator_t *this,
     shard_inode_ctx_t *ctx = NULL;
 
     ret = __inode_ctx_get(inode, this, &ctx_uint);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return ret;
 
     ctx = (shard_inode_ctx_t *)(uintptr_t)ctx_uint;
@@ -398,7 +398,7 @@ __shard_inode_ctx_get_fsync_count(inode_t *inode, xlator_t *this,
     shard_inode_ctx_t *ctx = NULL;
 
     ret = __inode_ctx_get(inode, this, &ctx_uint);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return ret;
 
     ctx = (shard_inode_ctx_t *)(uintptr_t)ctx_uint;
@@ -431,7 +431,7 @@ __shard_inode_ctx_get_all(inode_t *inode, xlator_t *this,
     shard_inode_ctx_t *ctx = NULL;
 
     ret = __inode_ctx_get(inode, this, &ctx_uint);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return ret;
 
     ctx = (shard_inode_ctx_t *)(uintptr_t)ctx_uint;
@@ -465,7 +465,7 @@ __shard_inode_ctx_fill_iatt_from_cache(inode_t *inode, xlator_t *this,
     shard_inode_ctx_t *ctx = NULL;
 
     ret = __inode_ctx_get(inode, this, &ctx_uint);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return ret;
 
     ctx = (shard_inode_ctx_t *)(uintptr_t)ctx_uint;
@@ -637,7 +637,7 @@ shard_init_internal_dir_loc(xlator_t *this, shard_local_t *local,
     internal_dir_loc->parent = parent;
     ret = inode_path(internal_dir_loc->parent, bname,
                      (char **)&internal_dir_loc->path);
-    if (ret < 0 || !(internal_dir_loc->inode)) {
+    if (IS_ERROR(ret) || !(internal_dir_loc->inode)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SHARD_MSG_INODE_PATH_FAILED,
                "Inode path failed on %s", bname);
         goto out;
@@ -938,7 +938,7 @@ shard_evicted_inode_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     priv = this->private;
 
-    if (anon_fd == NULL || op_ret < 0) {
+    if (anon_fd == NULL || IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, SHARD_MSG_MEMALLOC_FAILED,
                "fsync failed on shard");
         goto out;
@@ -1028,7 +1028,7 @@ shard_common_resolve_shards(call_frame_t *frame, xlator_t *this,
     else
         gf_uuid_copy(gfid, local->base_gfid);
 
-    if ((local->op_ret < 0) || (local->resolve_not))
+    if (IS_ERROR(local->op_ret) || local->resolve_not)
         goto out;
 
     while (shard_idx_iter <= local->last_block) {
@@ -1089,7 +1089,7 @@ shard_update_file_size_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     else if (local->loc.inode)
         inode = local->loc.inode;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno,
                SHARD_MSG_UPDATE_FILE_SIZE_FAILED,
                "Update to file size"
@@ -1517,7 +1517,7 @@ shard_start_background_deletion(xlator_t *this)
 
     ret = synctask_new(this->ctx->env, shard_delete_shards,
                        shard_delete_shards_cbk, cleanup_frame, cleanup_frame);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, errno,
                SHARD_MSG_SHARDS_DELETION_FAILED,
                "failed to create task to do background "
@@ -1547,7 +1547,7 @@ shard_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     priv = this->private;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     if (IA_ISDIR(buf->ia_type))
@@ -1585,7 +1585,7 @@ shard_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto unwind;
 
     ret = shard_start_background_deletion(this);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         LOCK(&priv->lock);
         {
             priv->first_lookup_done = _gf_false;
@@ -1673,7 +1673,7 @@ shard_lookup_base_file_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno,
                SHARD_MSG_BASE_FILE_LOOKUP_FAILED,
                "Lookup on base file"
@@ -1800,7 +1800,7 @@ shard_common_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, SHARD_MSG_STAT_FAILED,
                "stat failed: %s",
                local->fd ? uuid_utoa(local->fd->inode->gfid)
@@ -1967,7 +1967,7 @@ shard_truncate_last_shard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     inode = (local->fop == GF_FOP_TRUNCATE) ? local->loc.inode
                                             : local->fd->inode;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno,
                SHARD_MSG_TRUNCATE_LAST_SHARD_FAILED,
                "truncate on last"
@@ -2054,7 +2054,7 @@ shard_truncate_htol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
         goto done;
@@ -2168,7 +2168,7 @@ shard_truncate_htol(call_frame_t *frame, xlator_t *this, inode_t *inode)
         bname = strrchr(path, '/') + 1;
         loc.parent = inode_ref(priv->dot_shard_inode);
         ret = inode_path(loc.parent, bname, (char **)&(loc.path));
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, SHARD_MSG_INODE_PATH_FAILED,
                    "Inode path failed"
                    " on %s. Base file gfid = %s",
@@ -2227,7 +2227,7 @@ shard_post_lookup_shards_truncate_handler(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(local->fop, frame, local->op_ret,
                                     local->op_errno);
         return 0;
@@ -2303,7 +2303,7 @@ shard_common_lookup_shards_cbk(call_frame_t *frame, void *cookie,
     else
         gf_uuid_copy(gfid, local->base_gfid);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         /* Ignore absence of shards in the backend in truncate fop. */
         switch (local->fop) {
             case GF_FOP_TRUNCATE:
@@ -2450,7 +2450,7 @@ shard_common_lookup_shards(call_frame_t *frame, xlator_t *this, inode_t *inode,
         loc.parent = inode_ref(priv->dot_shard_inode);
         gf_uuid_copy(loc.pargfid, priv->dot_shard_gfid);
         ret = inode_path(loc.parent, bname, (char **)&(loc.path));
-        if (ret < 0 || !(loc.inode)) {
+        if (IS_ERROR(ret) || !(loc.inode)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, SHARD_MSG_INODE_PATH_FAILED,
                    "Inode path failed"
                    " on %s, base file gfid = %s",
@@ -2507,7 +2507,7 @@ shard_post_resolve_truncate_handler(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         if (local->op_errno == ENOENT) {
             /* If lookup on /.shard fails with ENOENT, it means that
              * the file was 0-byte in size but truncated sometime in
@@ -2625,7 +2625,7 @@ shard_post_lookup_truncate_handler(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(local->fop, frame, local->op_ret,
                                     local->op_errno);
         return 0;
@@ -2798,7 +2798,7 @@ shard_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     ret = shard_inode_ctx_set(inode, this, buf, local->block_size,
@@ -2851,7 +2851,7 @@ shard_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     shard_local_t *local = NULL;
 
     local = frame->local;
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto err;
 
     shard_inode_ctx_set(inode, this, buf, 0,
@@ -2874,7 +2874,7 @@ shard_post_lookup_link_handler(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         SHARD_STACK_UNWIND(link, frame, local->op_ret, local->op_errno, NULL,
                            NULL, NULL, NULL, NULL);
         return 0;
@@ -2950,7 +2950,7 @@ shard_post_lookup_shards_unlink_handler(call_frame_t *frame, xlator_t *this)
     else
         gf_uuid_copy(gfid, local->base_gfid);
 
-    if ((local->op_ret < 0) && (local->op_errno != ENOENT)) {
+    if (IS_ERROR(local->op_ret) && (local->op_errno != ENOENT)) {
         gf_msg(this->name, GF_LOG_ERROR, local->op_errno, SHARD_MSG_FOP_FAILED,
                "failed to delete shards of %s", uuid_utoa(gfid));
         return 0;
@@ -3081,7 +3081,7 @@ shard_unlink_shards_do_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
         goto done;
@@ -3159,7 +3159,7 @@ shard_unlink_shards_do(call_frame_t *frame, xlator_t *this, inode_t *inode)
         bname = strrchr(path, '/') + 1;
         loc.parent = inode_ref(priv->dot_shard_inode);
         ret = inode_path(loc.parent, bname, (char **)&(loc.path));
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, SHARD_MSG_INODE_PATH_FAILED,
                    "Inode path failed"
                    " on %s, base file gfid = %s",
@@ -3294,7 +3294,7 @@ __shard_delete_shards_of_entry(call_frame_t *cleanup_frame, xlator_t *this,
     loc.inode = inode_ref(inode);
     loc.parent = inode_ref(priv->dot_shard_rm_inode);
     ret = inode_path(loc.parent, entry->d_name, (char **)&(loc.path));
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SHARD_MSG_INODE_PATH_FAILED,
                "Inode path  failed on %s", entry->d_name);
         ret = -ENOMEM;
@@ -3328,7 +3328,7 @@ __shard_delete_shards_of_entry(call_frame_t *cleanup_frame, xlator_t *this,
     size = ntoh64(size_array[0]);
 
     shard_count = (size / block_size) - 1;
-    if (shard_count < 0) {
+    if (IS_ERROR(shard_count)) {
         gf_msg_debug(this->name, 0,
                      "Size of %s hasn't grown beyond "
                      "its shard-block-size. Nothing to delete. "
@@ -3405,7 +3405,7 @@ delete_marker:
     loc.inode = inode_ref(inode);
     loc.parent = inode_ref(priv->dot_shard_rm_inode);
     ret = inode_path(loc.parent, entry->d_name, (char **)&(loc.path));
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SHARD_MSG_INODE_PATH_FAILED,
                "Inode path  failed on %s", entry->d_name);
         ret = -ENOMEM;
@@ -3442,7 +3442,7 @@ shard_delete_shards_of_entry(call_frame_t *cleanup_frame, xlator_t *this,
 
     ret = syncop_entrylk(FIRST_CHILD(this), this->name, &loc, entry->d_name,
                          ENTRYLK_LOCK_NB, ENTRYLK_WRLCK, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (ret == -EAGAIN) {
             ret = 0;
         }
@@ -3513,7 +3513,7 @@ shard_resolve_internal_dir(xlator_t *this, shard_local_t *local,
         ret = dict_set_gfuuid(local->xattr_req, "gfid-req", gfid, true);
         ret = syncop_lookup(FIRST_CHILD(this), loc, &stbuf, NULL,
                             local->xattr_req, NULL);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             if (ret != -ENOENT)
                 gf_msg(this->name, GF_LOG_ERROR, -ret,
                        SHARD_MSG_SHARDS_DELETION_FAILED,
@@ -3545,7 +3545,7 @@ shard_lookup_marker_entry(xlator_t *this, shard_local_t *local,
     loc.parent = inode_ref(local->fd->inode);
 
     ret = inode_path(loc.parent, entry->d_name, (char **)&(loc.path));
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SHARD_MSG_INODE_PATH_FAILED,
                "Inode path failed on %s", entry->d_name);
         ret = -ENOMEM;
@@ -3557,7 +3557,7 @@ shard_lookup_marker_entry(xlator_t *this, shard_local_t *local,
         loc.name++;
 
     ret = syncop_lookup(FIRST_CHILD(this), &loc, NULL, NULL, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
     entry->inode = inode_ref(loc.inode);
@@ -3615,7 +3615,7 @@ shard_delete_shards(void *opaque)
                      " delete. Exiting");
         ret = 0;
         goto err;
-    } else if (ret < 0) {
+    } else if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -3627,7 +3627,7 @@ shard_delete_shards(void *opaque)
                      "Nothing to delete. Exiting");
         ret = 0;
         goto err;
-    } else if (ret < 0) {
+    } else if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -3665,7 +3665,7 @@ shard_delete_shards(void *opaque)
 
                 if (!entry->inode) {
                     ret = shard_lookup_marker_entry(this, local, entry);
-                    if (ret < 0)
+                    if (IS_ERROR(ret))
                         continue;
                 }
                 link_inode = inode_link(entry->inode, local->fd->inode,
@@ -3767,7 +3767,7 @@ shard_rename_src_base_file(call_frame_t *frame, xlator_t *this)
         tmp_loc.parent = inode_ref(local->loc2.parent);
         ret = inode_path(tmp_loc.parent, local->loc2.name,
                          (char **)&tmp_loc.path);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, SHARD_MSG_INODE_PATH_FAILED,
                    "Inode path failed"
                    " on pargfid=%s bname=%s",
@@ -3812,7 +3812,7 @@ shard_set_size_attrs_on_marker_file_cbk(call_frame_t *frame, void *cookie,
 
     priv = this->private;
     local = frame->local;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, SHARD_MSG_FOP_FAILED,
                "Xattrop on marker file failed "
                "while performing %s; entry gfid=%s",
@@ -3877,7 +3877,7 @@ shard_lookup_marker_file_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     priv = this->private;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, SHARD_MSG_FOP_FAILED,
                "Lookup on marker file failed "
                "while performing %s; entry gfid=%s",
@@ -3932,7 +3932,7 @@ shard_create_marker_file_under_remove_me_cbk(
     priv = this->private;
 
     SHARD_UNSET_ROOT_FS_ID(frame, local);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno != EEXIST) && (op_errno != ENODATA)) {
             local->op_ret = op_ret;
             local->op_errno = op_errno;
@@ -3992,7 +3992,7 @@ shard_create_marker_file_under_remove_me(call_frame_t *frame, xlator_t *this,
     local->newloc.parent = inode_ref(priv->dot_shard_rm_inode);
     ret = inode_path(local->newloc.parent, uuid_utoa(loc->inode->gfid),
                      (char **)&local->newloc.path);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SHARD_MSG_INODE_PATH_FAILED,
                "Inode path failed on "
                "pargfid=%s bname=%s",
@@ -4040,7 +4040,7 @@ shard_unlink_base_file_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
     } else {
@@ -4055,14 +4055,14 @@ shard_unlink_base_file_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (local->entrylk_frame) {
         ret = shard_unlock_entrylk(frame, this);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             local->op_ret = -1;
             local->op_errno = -ret;
         }
     }
 
     ret = shard_unlock_inodelk(frame, this);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         local->op_ret = -1;
         local->op_errno = -ret;
     }
@@ -4153,7 +4153,7 @@ shard_acquire_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     main_frame = local->main_frame;
     main_local = main_frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(main_local->fop, main_frame, op_ret,
                                     op_errno);
         return 0;
@@ -4218,7 +4218,7 @@ shard_post_lookup_base_shard_rm_handler(call_frame_t *frame, xlator_t *this)
     priv = this->private;
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(local->fop, frame, -1, local->op_errno);
         return 0;
     }
@@ -4278,7 +4278,7 @@ shard_acquire_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     main_frame = local->main_frame;
     main_local = main_frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(main_local->fop, main_frame, op_ret,
                                     op_errno);
         return 0;
@@ -4339,7 +4339,7 @@ shard_post_mkdir_rm_handler(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(local->fop, frame, -1, local->op_errno);
         return 0;
     }
@@ -4362,7 +4362,7 @@ shard_pre_mkdir_rm_handler(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(local->fop, frame, -1, local->op_errno);
         return 0;
     }
@@ -4465,7 +4465,7 @@ shard_rename_src_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
         goto err;
@@ -4489,14 +4489,14 @@ shard_rename_src_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (local->dst_block_size) {
         if (local->entrylk_frame) {
             ret = shard_unlock_entrylk(frame, this);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 local->op_ret = -1;
                 local->op_errno = -ret;
             }
         }
 
         ret = shard_unlock_inodelk(frame, this);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             local->op_ret = -1;
             local->op_errno = -ret;
             goto err;
@@ -4529,7 +4529,7 @@ shard_post_lookup_dst_base_file_handler(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(local->fop, frame, local->op_ret,
                                     local->op_errno);
         return 0;
@@ -4634,7 +4634,7 @@ shard_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     ret = shard_inode_ctx_set(inode, this, stbuf, local->block_size,
@@ -4720,10 +4720,10 @@ shard_readv_do_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     /* If shard has already seen a failure here before, there is no point
      * in aggregating subsequent reads, so just go to out.
      */
-    if (local->op_ret < 0)
+    if (IS_ERROR(local->op_ret))
         goto out;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
         goto out;
@@ -4761,7 +4761,7 @@ out:
     call_count = shard_call_count_return(frame);
     if (call_count == 0) {
         SHARD_UNSET_ROOT_FS_ID(frame, local);
-        if (local->op_ret < 0) {
+        if (IS_ERROR(local->op_ret)) {
             shard_common_failure_unwind(GF_FOP_READ, frame, local->op_ret,
                                         local->op_errno);
         } else {
@@ -4865,7 +4865,7 @@ shard_common_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == EEXIST) {
             LOCK(&frame->lock);
             {
@@ -4974,7 +4974,7 @@ shard_common_resume_mknod(call_frame_t *frame, xlator_t *this,
         loc.inode = inode_new(this->itable);
         loc.parent = inode_ref(priv->dot_shard_inode);
         ret = inode_path(loc.parent, bname, (char **)&(loc.path));
-        if (ret < 0 || !(loc.inode)) {
+        if (IS_ERROR(ret) || !(loc.inode)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, SHARD_MSG_INODE_PATH_FAILED,
                    "Inode path failed"
                    "on %s, base file gfid = %s",
@@ -5028,7 +5028,7 @@ shard_post_lookup_shards_readv_handler(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(GF_FOP_READ, frame, local->op_ret,
                                     local->op_errno);
         return 0;
@@ -5050,7 +5050,7 @@ shard_post_mknod_readv_handler(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(GF_FOP_READ, frame, local->op_ret,
                                     local->op_errno);
         return 0;
@@ -5073,7 +5073,7 @@ shard_post_resolve_readv_handler(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         if (local->op_errno != ENOENT) {
             shard_common_failure_unwind(GF_FOP_READ, frame, local->op_ret,
                                         local->op_errno);
@@ -5113,7 +5113,7 @@ shard_post_lookup_readv_handler(call_frame_t *frame, xlator_t *this)
     priv = this->private;
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(GF_FOP_READ, frame, local->op_ret,
                                     local->op_errno);
         return 0;
@@ -5262,7 +5262,7 @@ shard_common_inode_write_post_update_size_handler(call_frame_t *frame,
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(local->fop, frame, local->op_ret,
                                     local->op_errno);
     } else {
@@ -5293,7 +5293,7 @@ __shard_get_delta_size_from_inode_ctx(shard_local_t *local, inode_t *inode,
     shard_inode_ctx_t *ctx = NULL;
 
     ret = __inode_ctx_get(inode, this, &ctx_uint);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return ret;
 
     ctx = (shard_inode_ctx_t *)(uintptr_t)ctx_uint;
@@ -5343,7 +5343,7 @@ shard_common_inode_write_do_cbk(call_frame_t *frame, void *cookie,
 
     LOCK(&frame->lock);
     {
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             local->op_ret = op_ret;
             local->op_errno = op_errno;
         } else {
@@ -5366,7 +5366,7 @@ shard_common_inode_write_do_cbk(call_frame_t *frame, void *cookie,
     call_count = shard_call_count_return(frame);
     if (call_count == 0) {
         SHARD_UNSET_ROOT_FS_ID(frame, local);
-        if (local->op_ret < 0) {
+        if (IS_ERROR(local->op_ret)) {
             shard_common_failure_unwind(fop, frame, local->op_ret,
                                         local->op_errno);
         } else {
@@ -5491,7 +5491,7 @@ shard_common_inode_write_do(call_frame_t *frame, xlator_t *this)
             vec = NULL;
             count = iov_subset(local->vector, local->count, vec_offset,
                                shard_write_size, &vec, 0);
-            if (count < 0) {
+            if (IS_ERROR(count)) {
                 local->op_ret = -1;
                 local->op_errno = ENOMEM;
                 wind_failed = _gf_true;
@@ -5551,7 +5551,7 @@ shard_common_inode_write_post_lookup_shards_handler(call_frame_t *frame,
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(local->fop, frame, local->op_ret,
                                     local->op_errno);
         return 0;
@@ -5574,7 +5574,7 @@ shard_common_inode_write_post_mknod_handler(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(local->fop, frame, local->op_ret,
                                     local->op_errno);
         return 0;
@@ -5600,7 +5600,7 @@ shard_common_inode_write_post_resolve_handler(call_frame_t *frame,
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(local->fop, frame, local->op_ret,
                                     local->op_errno);
         return 0;
@@ -5624,7 +5624,7 @@ shard_common_inode_write_post_lookup_handler(call_frame_t *frame,
     shard_local_t *local = frame->local;
     shard_priv_t *priv = this->private;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(local->fop, frame, local->op_ret,
                                     local->op_errno);
         return 0;
@@ -5686,7 +5686,7 @@ shard_mkdir_internal_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     SHARD_UNSET_ROOT_FS_ID(frame, local);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno != EEXIST) {
             local->op_ret = op_ret;
             local->op_errno = op_errno;
@@ -5813,7 +5813,7 @@ __shard_get_timestamps_from_inode_ctx(shard_local_t *local, inode_t *inode,
     shard_inode_ctx_t *ctx = NULL;
 
     ret = __inode_ctx_get(inode, this, &ctx_uint);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return ret;
 
     ctx = (shard_inode_ctx_t *)(uintptr_t)ctx_uint;
@@ -5860,12 +5860,12 @@ shard_fsync_shards_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     base_inode = local->fd->inode;
 
-    if (local->op_ret < 0)
+    if (IS_ERROR(local->op_ret))
         goto out;
 
     LOCK(&frame->lock);
     {
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             local->op_ret = op_ret;
             local->op_errno = op_errno;
             UNLOCK(&frame->lock);
@@ -5906,7 +5906,7 @@ out:
     if (call_count != 0)
         return 0;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(GF_FOP_FSYNC, frame, local->op_ret,
                                     local->op_errno);
     } else {
@@ -5938,7 +5938,7 @@ shard_post_lookup_fsync_handler(call_frame_t *frame, xlator_t *this)
     local->postbuf = local->prebuf;
     INIT_LIST_HEAD(&copy);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         shard_common_failure_unwind(GF_FOP_FSYNC, frame, local->op_ret,
                                     local->op_errno);
         return 0;
@@ -6065,7 +6065,7 @@ shard_readdir_past_dot_shard_cbk(call_frame_t *frame, void *cookie,
 
     local = frame->local;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     list_for_each_entry_safe(entry, tmp, (&orig_entries->list), list)
@@ -6112,7 +6112,7 @@ shard_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     fd = local->fd;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     list_for_each_entry_safe(entry, tmp, (&orig_entries->list), list)
@@ -6288,7 +6288,7 @@ shard_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                     int32_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata)
 {
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     if (dict && (frame->root->pid != GF_CLIENT_PID_GSYNCD)) {
@@ -6326,7 +6326,7 @@ shard_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                    int32_t op_ret, int32_t op_errno, dict_t *dict,
                    dict_t *xdata)
 {
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     if (dict && (frame->root->pid != GF_CLIENT_PID_GSYNCD)) {
@@ -6428,7 +6428,7 @@ shard_common_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
         goto unwind;

--- a/xlators/features/shard/src/shard.c
+++ b/xlators/features/shard/src/shard.c
@@ -1765,7 +1765,7 @@ shard_post_fstat_handler(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret >= 0)
+    if (IS_SUCCESS(local->op_ret))
         shard_inode_ctx_set(local->fd->inode, this, &local->prebuf, 0,
                             SHARD_LOOKUP_MASK);
 
@@ -1781,7 +1781,7 @@ shard_post_stat_handler(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret >= 0)
+    if (IS_SUCCESS(local->op_ret))
         shard_inode_ctx_set(local->loc.inode, this, &local->prebuf, 0,
                             SHARD_LOOKUP_MASK);
 
@@ -3020,7 +3020,7 @@ shard_unlink_block_inode(shard_local_t *local, int shard_block_num)
             priv->inode_count--;
             unref_base_inode++;
             unref_shard_inode++;
-            GF_ASSERT(priv->inode_count >= 0);
+            GF_ASSERT(IS_SUCCESS(priv->inode_count));
         }
         if (ctx->fsync_needed) {
             unref_base_inode++;
@@ -4729,7 +4729,7 @@ shard_readv_do_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if (local->op_ret >= 0)
+    if (IS_SUCCESS(local->op_ret))
         local->op_ret += op_ret;
 
     shard_inode_ctx_get(anon_fd->inode, this, &ctx);
@@ -5885,7 +5885,7 @@ out:
             __shard_inode_ctx_get(base_inode, this, &base_ictx);
             if (op_ret == 0)
                 ctx->fsync_needed -= fsync_count;
-            GF_ASSERT(ctx->fsync_needed >= 0);
+            GF_ASSERT(IS_SUCCESS(ctx->fsync_needed));
             if (ctx->fsync_needed != 0) {
                 list_add_tail(&ctx->to_fsync_list, &base_ictx->to_fsync_list);
                 base_ictx->fsync_count++;
@@ -6403,13 +6403,13 @@ shard_post_setattr_handler(call_frame_t *frame, xlator_t *this)
     local = frame->local;
 
     if (local->fop == GF_FOP_SETATTR) {
-        if (local->op_ret >= 0)
+        if (IS_SUCCESS(local->op_ret))
             shard_inode_ctx_set(local->loc.inode, this, &local->postbuf, 0,
                                 SHARD_LOOKUP_MASK);
         SHARD_STACK_UNWIND(setattr, frame, local->op_ret, local->op_errno,
                            &local->prebuf, &local->postbuf, local->xattr_rsp);
     } else if (local->fop == GF_FOP_FSETATTR) {
-        if (local->op_ret >= 0)
+        if (IS_SUCCESS(local->op_ret))
             shard_inode_ctx_set(local->fd->inode, this, &local->postbuf, 0,
                                 SHARD_LOOKUP_MASK);
         SHARD_STACK_UNWIND(fsetattr, frame, local->op_ret, local->op_errno,

--- a/xlators/features/snapview-client/src/snapview-client.c
+++ b/xlators/features/snapview-client/src/snapview-client.c
@@ -438,7 +438,7 @@ gf_svc_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
             wind = _gf_true;
             goto out;
         } else {
-            if (inode_type >= 0)
+            if (IS_SUCCESS(inode_type))
                 subvolume = svc_get_subvolume(this, inode_type);
             else
                 subvolume = FIRST_CHILD(this);

--- a/xlators/features/snapview-client/src/snapview-client.c
+++ b/xlators/features/snapview-client/src/snapview-client.c
@@ -68,7 +68,7 @@ __svc_inode_ctx_get(xlator_t *this, inode_t *inode, int *inode_type)
     GF_VALIDATE_OR_GOTO(this->name, inode, out);
 
     ret = __inode_ctx_get(inode, this, &value);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     *inode_type = (int)(value);
@@ -337,7 +337,7 @@ gf_svc_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             if (inode != NULL)
                 ret = svc_inode_ctx_get(this, inode, &inode_type);
 
-            if (ret < 0 || inode == NULL) {
+            if (IS_ERROR(ret) || inode == NULL) {
                 gf_msg_debug(this->name, 0,
                              "Lookup on normal graph failed. "
                              " Sending lookup to snapview-server");
@@ -779,7 +779,7 @@ gf_svc_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     GF_VALIDATE_OR_GOTO(this->name, loc->inode, out);
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
@@ -824,7 +824,7 @@ gf_svc_fsetattr (call_frame_t *frame, xlator_t *this, fd_t *fd,
         GF_VALIDATE_OR_GOTO (this->name, fd->inode, out);
 
         ret = svc_inode_ctx_get (this, fd->inode, &inode_type);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
                 op_ret = -1;
                 op_errno = EINVAL;
                 gf_msg (this->name, GF_LOG_ERROR, op_errno,
@@ -989,7 +989,7 @@ gf_svc_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
     GF_VALIDATE_OR_GOTO(this->name, loc->inode, out);
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
@@ -1033,7 +1033,7 @@ gf_svc_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
     GF_VALIDATE_OR_GOTO(this->name, fd->inode, out);
 
     ret = svc_inode_ctx_get(this, fd->inode, &inode_type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
@@ -1077,7 +1077,7 @@ gf_svc_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
     GF_VALIDATE_OR_GOTO(this->name, loc->inode, out);
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
@@ -1112,7 +1112,7 @@ gf_svc_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int inode_type = -1;
     int ret = -1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     inode_type = NORMAL_INODE;
@@ -1146,7 +1146,7 @@ gf_svc_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     GF_VALIDATE_OR_GOTO(this->name, loc->inode, out);
 
     ret = svc_inode_ctx_get(this, loc->parent, &parent_type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
@@ -1188,7 +1188,7 @@ gf_svc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int inode_type = -1;
     int ret = -1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     inode_type = NORMAL_INODE;
@@ -1222,7 +1222,7 @@ gf_svc_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     GF_VALIDATE_OR_GOTO(this->name, loc->inode, out);
 
     ret = svc_inode_ctx_get(this, loc->parent, &parent_type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
@@ -1312,7 +1312,7 @@ gf_svc_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int inode_type = -1;
     int ret = -1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     inode_type = NORMAL_INODE;
@@ -1348,7 +1348,7 @@ gf_svc_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
     ret = svc_inode_ctx_get(this, loc->parent, &parent_type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
@@ -1391,7 +1391,7 @@ gf_svc_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int inode_type = -1;
     int ret = -1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     inode_type = NORMAL_INODE;
@@ -1426,7 +1426,7 @@ gf_svc_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
     GF_VALIDATE_OR_GOTO(this->name, loc->inode, out);
 
     ret = svc_inode_ctx_get(this, loc->parent, &parent_type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
@@ -1476,7 +1476,7 @@ gf_svc_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
     GF_VALIDATE_OR_GOTO(this->name, loc->inode, out);
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
@@ -1607,7 +1607,7 @@ gf_svc_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     local = frame->local;
@@ -1856,7 +1856,7 @@ gf_svc_special_dir_revalidate_lookup(call_frame_t *frame, xlator_t *this,
 
     gf_uuid_copy(local->loc.gfid, loc->inode->gfid);
     ret = inode_path(loc->parent, entry_point, &path);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (loc->path)
@@ -1964,7 +1964,7 @@ gf_svc_readdir_on_special_dir(call_frame_t *frame, void *cookie, xlator_t *this,
         else
             ret = inode_path(inode, NULL, &path);
 
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
         loc->path = gf_strdup(path);
         if (loc->path) {
@@ -2023,7 +2023,7 @@ gf_svc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     GF_VALIDATE_OR_GOTO("snapview-client", this, out);
@@ -2179,7 +2179,7 @@ gf_svc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     GF_VALIDATE_OR_GOTO(this->name, newloc, out);
 
     ret = svc_inode_ctx_get(this, oldloc->inode, &src_inode_type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
@@ -2208,7 +2208,7 @@ gf_svc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
         }
     }
 
-    if (dst_inode_type < 0) {
+    if (IS_ERROR(dst_inode_type)) {
         ret = svc_inode_ctx_get(this, newloc->parent, &dst_parent_type);
         if (!ret && dst_parent_type == VIRTUAL_INODE) {
             op_ret = -1;
@@ -2300,7 +2300,7 @@ gf_svc_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     GF_VALIDATE_OR_GOTO(this->name, loc->inode, out);
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
@@ -2343,7 +2343,7 @@ gf_svc_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
     GF_VALIDATE_OR_GOTO(this->name, fd->inode, out);
 
     ret = svc_inode_ctx_get(this, fd->inode, &inode_type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
@@ -2410,7 +2410,7 @@ gf_svc_releasedir(xlator_t *this, fd_t *fd)
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
     ret = fd_ctx_del(fd, this, &tmp_pfd);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, 0, "pfd from fd=%p is NULL", fd);
         goto out;
     }

--- a/xlators/features/snapview-client/src/snapview-client.h
+++ b/xlators/features/snapview-client/src/snapview-client.h
@@ -65,7 +65,7 @@ typedef struct __svc_local svc_local_t;
                                 inode, subvolume, label)                       \
     do {                                                                       \
         ret = svc_inode_ctx_get(this, inode, &inode_type);                     \
-        if (ret < 0) {                                                         \
+        if (IS_ERROR(ret)) {                                                   \
             gf_log(this->name, GF_LOG_ERROR,                                   \
                    "inode context not found for gfid %s",                      \
                    uuid_utoa(inode->gfid));                                    \

--- a/xlators/features/snapview-server/src/snapview-server-mgmt.c
+++ b/xlators/features/snapview-server/src/snapview-server-mgmt.c
@@ -205,7 +205,7 @@ svs_mgmt_submit_request(void *req, call_frame_t *frame, glusterfs_ctx_t *ctx,
 
         /* Create the xdr payload */
         ret = xdr_serialize_generic(iov, req, xdrproc);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(frame->this->name, GF_LOG_WARNING, 0,
                    SVS_MSG_XDR_PAYLOAD_FAILED, "Failed to create XDR payload");
             goto out;
@@ -265,7 +265,7 @@ mgmt_get_snapinfo_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         errno = EINVAL;
         gf_msg(frame->this->name, GF_LOG_ERROR, errno, SVS_MSG_RPC_CALL_FAILED,
                "RPC call is not successful");
@@ -273,13 +273,13 @@ mgmt_get_snapinfo_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_getsnap_name_uuid_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(frame->this->name, GF_LOG_ERROR, 0, SVS_MSG_XDR_DECODE_FAILED,
                "Failed to decode xdr response, rsp.op_ret = %d", rsp.op_ret);
         goto out;
     }
 
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         errno = rsp.op_errno;
         ret = -1;
         goto out;

--- a/xlators/features/snapview-server/src/snapview-server.c
+++ b/xlators/features/snapview-server/src/snapview-server.c
@@ -632,7 +632,7 @@ svs_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
     if (xdata && !inode_ctx) {
         ret = dict_get_str_boolean(xdata, "entry-point", _gf_false);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg_debug(this->name, 0,
                          "failed to get the "
                          "entry point info");
@@ -860,7 +860,7 @@ svs_add_xattrs_to_dict(xlator_t *this, dict_t *dict, char *list, ssize_t size)
         GF_FREE(newkey);
 #endif
         ret = dict_set_str(dict, keybuffer, "");
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, SVS_MSG_DICT_SET_FAILED,
                    "dict set operation "
                    "for the key %s failed.",
@@ -875,7 +875,7 @@ svs_add_xattrs_to_dict(xlator_t *this, dict_t *dict, char *list, ssize_t size)
     /* Add an additional key to indicate that we don't need to cache these
      * xattrs(with value "") */
     ret = dict_set_str(dict, "glusterfs.skip-cache", "");
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SVS_MSG_DICT_SET_FAILED,
                "dict set operation for the key glusterfs.skip-cache failed.");
         goto out;
@@ -949,7 +949,7 @@ svs_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
         }
 
         size = glfs_h_getxattrs(fs, object, name, NULL, 0);
-        if (size == -1) {
+        if (IS_ERROR(size)) {
             op_ret = -1;
             op_errno = errno;
             if (errno == ENODATA) {
@@ -977,7 +977,7 @@ svs_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
         }
 
         size = glfs_h_getxattrs(fs, object, name, value, size);
-        if (size == -1) {
+        if (IS_ERROR(size)) {
             op_ret = -1;
             op_errno = errno;
             gf_msg(this->name, GF_LOG_ERROR, op_errno, SVS_MSG_GETXATTR_FAILED,
@@ -990,7 +990,7 @@ svs_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
 
         if (name) {
             op_ret = dict_set_dynptr(dict, (char *)name, value, size);
-            if (op_ret < 0) {
+            if (IS_ERROR(op_ret)) {
                 op_errno = -op_ret;
                 gf_msg(this->name, GF_LOG_ERROR, op_errno,
                        SVS_MSG_DICT_SET_FAILED,
@@ -1003,7 +1003,7 @@ svs_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
             }
         } else {
             op_ret = svs_add_xattrs_to_dict(this, dict, value, size);
-            if (op_ret == -1) {
+            if (IS_ERROR(op_ret)) {
                 op_errno = ENOMEM;
                 gf_msg(this->name, GF_LOG_ERROR, op_errno, SVS_MSG_NO_MEMORY,
                        "failed to add xattrs from the list to "
@@ -1107,7 +1107,7 @@ svs_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
 
         if (name) {
             size = glfs_fgetxattr(glfd, name, NULL, 0);
-            if (size == -1) {
+            if (IS_ERROR(size)) {
                 op_ret = -1;
                 op_errno = errno;
                 gf_msg(this->name, GF_LOG_ERROR, op_errno,
@@ -1130,7 +1130,7 @@ svs_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
             }
 
             size = glfs_fgetxattr(glfd, name, value, size);
-            if (size == -1) {
+            if (IS_ERROR(size)) {
                 op_ret = -1;
                 op_errno = errno;
                 gf_msg(this->name, GF_LOG_ERROR, op_errno,
@@ -1143,7 +1143,7 @@ svs_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
             value[size] = '\0';
 
             op_ret = dict_set_dynptr(dict, (char *)name, value, size);
-            if (op_ret < 0) {
+            if (IS_ERROR(op_ret)) {
                 op_errno = -op_ret;
                 gf_msg(this->name, GF_LOG_ERROR, op_errno,
                        SVS_MSG_DICT_SET_FAILED,
@@ -1154,7 +1154,7 @@ svs_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
             }
         } else {
             size = glfs_flistxattr(glfd, NULL, 0);
-            if (size == -1) {
+            if (IS_ERROR(size)) {
                 op_errno = errno;
                 gf_msg(this->name, GF_LOG_ERROR, op_errno,
                        SVS_MSG_LISTXATTR_FAILED, "listxattr on %s failed",
@@ -1175,7 +1175,7 @@ svs_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
             }
 
             size = glfs_flistxattr(glfd, value, size);
-            if (size == -1) {
+            if (IS_ERROR(size)) {
                 op_ret = -1;
                 op_errno = errno;
                 gf_msg(this->name, GF_LOG_ERROR, op_errno,
@@ -1185,7 +1185,7 @@ svs_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
             }
 
             op_ret = svs_add_xattrs_to_dict(this, dict, value, size);
-            if (op_ret == -1) {
+            if (IS_ERROR(op_ret)) {
                 op_errno = ENOMEM;
                 gf_msg(this->name, GF_LOG_ERROR, op_errno, SVS_MSG_NO_MEMORY,
                        "failed to add xattrs from the list "
@@ -1226,7 +1226,7 @@ svs_releasedir(xlator_t *this, fd_t *fd)
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
     ret = fd_ctx_del(fd, this, &tmp_pfd);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, 0, "pfd from fd=%p is NULL", fd);
         goto out;
     }
@@ -1291,7 +1291,7 @@ svs_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     }
 
     ret = fd_ctx_get(fd, this, &value);
-    if (ret < 0 && inode_ctx->type != SNAP_VIEW_ENTRY_POINT_INODE) {
+    if (IS_ERROR(ret) && inode_ctx->type != SNAP_VIEW_ENTRY_POINT_INODE) {
         op_errno = EINVAL;
         gf_msg(this->name, GF_LOG_WARNING, op_errno,
                SVS_MSG_GET_FD_CONTEXT_FAILED, "pfd is NULL on fd=%p", fd);
@@ -1320,7 +1320,7 @@ svs_release(xlator_t *this, fd_t *fd)
     GF_VALIDATE_OR_GOTO(this->name, fd, out);
 
     ret = fd_ctx_del(fd, this, &tmp_pfd);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, 0, "pfd from fd=%p is NULL", fd);
         goto out;
     }
@@ -1487,7 +1487,7 @@ svs_glfs_readdir(xlator_t *this, glfs_fd_t *glfd, gf_dirent_t *entries,
 
     while (filled_size < size) {
         in_case = glfs_telldir(glfd);
-        if (in_case == -1) {
+        if (IS_ERROR(in_case)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, SVS_MSG_TELLDIR_FAILED,
                    "telldir failed");
             break;
@@ -2332,7 +2332,7 @@ svs_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     }
 
     ret = glfs_pread(glfd, iobuf->ptr, size, offset, 0, &fstatbuf);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, SVS_MSG_READ_FAILED,
@@ -2433,7 +2433,7 @@ svs_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
 
     buf = alloca(size + 1);
     op_ret = glfs_h_readlink(fs, object, buf, size);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, SVS_MSG_READLINK_FAILED,
                "readlink on %s failed (gfid: %s)", loc->name,
@@ -2520,7 +2520,7 @@ svs_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int mask,
     }
 
     ret = glfs_h_access(fs, object, mask);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = -1;
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, SVS_MSG_ACCESS_FAILED,

--- a/xlators/features/thin-arbiter/src/thin-arbiter.c
+++ b/xlators/features/thin-arbiter/src/thin-arbiter.c
@@ -119,7 +119,7 @@ ta_verify_on_disk_source(ta_fop_t *fop, dict_t *dict)
     }
 
     ret = dict_foreach(dict, ta_get_incoming_and_brick_values, (void *)fop);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         return ret;
     }
     if (fop->on_disk[0] && fop->on_disk[1]) {
@@ -142,7 +142,7 @@ ta_get_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     ret = ta_verify_on_disk_source(fop, dict);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto unwind;
     }
@@ -195,7 +195,7 @@ ta_prepare_fop(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
         goto out;
     }
     ret = dict_foreach(dict, ta_set_incoming_values, (void *)fop);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
     frame->local = fop;

--- a/xlators/features/trash/src/trash.c
+++ b/xlators/features/trash/src/trash.c
@@ -308,7 +308,7 @@ trash_dir_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_ERROR,
                "rename trash directory "
                "failed: %s",
@@ -892,7 +892,7 @@ trash_unlink_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     loop_count = local->loop_count;
 
     /* The directory is not present , need to create it */
-    if ((op_ret == -1) && (op_errno == ENOENT)) {
+    if (IS_ERROR(op_ret) && (op_errno == ENOENT)) {
         tmp_dirname = strchr(tmp_str, '/');
         while (tmp_dirname) {
             count = tmp_dirname - tmp_str;
@@ -929,7 +929,7 @@ trash_unlink_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         strncpy(real_path, priv->brick_path, sizeof(real_path));
         real_path[sizeof(real_path) - 1] = 0;
 
-        remove_trash_path(tmp_path, (frame->root->pid < 0), &tmp_stat);
+        remove_trash_path(tmp_path, IS_ERROR(frame->root->pid), &tmp_stat);
         if (tmp_stat)
             strncat(real_path, tmp_stat,
                     sizeof(real_path) - strlen(real_path) - 1);
@@ -957,7 +957,7 @@ trash_unlink_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    if ((op_ret == -1) && (op_errno != EEXIST)) {
+    if (IS_ERROR(op_ret) && (op_errno != EEXIST)) {
         gf_log(this->name, GF_LOG_ERROR,
                "Directory creation failed [%s]. "
                "Therefore unlinking %s without moving to trash "
@@ -1013,7 +1013,7 @@ trash_unlink_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     strncpy(real_path, priv->brick_path, sizeof(real_path));
     real_path[sizeof(real_path) - 1] = 0;
 
-    remove_trash_path(tmp_path, (frame->root->pid < 0), &tmp_stat);
+    remove_trash_path(tmp_path, IS_ERROR(frame->root->pid), &tmp_stat);
     if (tmp_stat)
         strncat(real_path, tmp_stat, sizeof(real_path) - strlen(real_path) - 1);
 
@@ -1063,7 +1063,7 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if ((op_ret == -1) && (op_errno == ENOENT)) {
+    if (IS_ERROR(op_ret) && (op_errno == ENOENT)) {
         /* the file path does not exist we want to create path
          * for the file
          */
@@ -1091,7 +1091,7 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
         strncpy(real_path, priv->brick_path, sizeof(real_path));
         real_path[sizeof(real_path) - 1] = 0;
-        remove_trash_path(tmp_str, (frame->root->pid < 0), &tmp_stat);
+        remove_trash_path(tmp_str, IS_ERROR(frame->root->pid), &tmp_stat);
         if (tmp_stat)
             strncat(real_path, tmp_stat,
                     sizeof(real_path) - strlen(real_path) - 1);
@@ -1106,7 +1106,7 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if ((op_ret == -1) && (op_errno == ENOTDIR)) {
+    if (IS_ERROR(op_ret) && (op_errno == ENOTDIR)) {
         /* if entry is already present in trash directory,
          * new one is not copied*/
         gf_log(this->name, GF_LOG_DEBUG,
@@ -1119,7 +1119,7 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if ((op_ret == -1) && (op_errno == EISDIR)) {
+    if (IS_ERROR(op_ret) && (op_errno == EISDIR)) {
         /* if entry is directory,we remove directly */
         gf_log(this->name, GF_LOG_DEBUG,
                "target(%s) exists as directory, cannot keep copy, "
@@ -1152,7 +1152,7 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
          * */
         if (xdata) {
             ret = dict_set_uint32(xdata, GF_RESPONSE_LINK_COUNT_XDATA, 1);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 gf_log(this->name, GF_LOG_WARNING,
                        "Failed to set"
                        " GF_RESPONSE_LINK_COUNT_XDATA");
@@ -1166,7 +1166,7 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 goto ctr_out;
             }
             ret = dict_set_uint32(new_xdata, GF_RESPONSE_LINK_COUNT_XDATA, 1);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 gf_log(this->name, GF_LOG_WARNING,
                        "Failed to set"
                        " GF_RESPONSE_LINK_COUNT_XDATA");
@@ -1224,7 +1224,7 @@ trash_unlink_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG, "%s: %s", local->loc.path,
                strerror(op_errno));
         TRASH_STACK_UNWIND(unlink, frame, op_ret, op_errno, buf, NULL, xdata);
@@ -1301,7 +1301,7 @@ trash_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflags,
      * should moved to trash directory , but files by client should not
      * moved
      */
-    if ((frame->root->pid < 0) && !priv->internal) {
+    if (IS_ERROR(frame->root->pid) && !priv->internal) {
         STACK_WIND(frame, trash_common_unwind_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->unlink, loc, 0, xdata);
         goto out;
@@ -1354,8 +1354,8 @@ trash_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflags,
     loc_copy(&local->loc, loc);
 
     /* rename new location of file as starting from trash directory */
-    copy_trash_path(priv->newtrash_dir, (frame->root->pid < 0), local->newpath,
-                    sizeof(local->newpath));
+    copy_trash_path(priv->newtrash_dir, IS_ERROR(frame->root->pid),
+                    local->newpath, sizeof(local->newpath));
     strncat(local->newpath, pathbuf,
             sizeof(local->newpath) - strlen(local->newpath) - 1);
 
@@ -1399,7 +1399,7 @@ trash_truncate_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG, "deleting the newly created file: %s",
                strerror(op_errno));
     }
@@ -1425,7 +1425,7 @@ trash_truncate_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG,
                "readv on the existing file failed: %s", strerror(op_errno));
 
@@ -1456,7 +1456,7 @@ trash_truncate_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Let truncate work, but previous copy is not preserved. */
         gf_log(this->name, GF_LOG_DEBUG,
                "writev on the existing file failed: %s", strerror(op_errno));
@@ -1497,7 +1497,7 @@ trash_truncate_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Let truncate work, but previous copy is not preserved. */
         gf_log(this->name, GF_LOG_DEBUG, "open on the existing file failed: %s",
                strerror(op_errno));
@@ -1554,7 +1554,7 @@ trash_truncate_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     /* Checks whether path is present in trash directory or not */
 
-    if ((op_ret == -1) && (op_errno == ENOENT)) {
+    if (IS_ERROR(op_ret) && (op_errno == ENOENT)) {
         /* Creating the directory structure here. */
         tmp_str = gf_strdup(local->newpath);
         if (!tmp_str) {
@@ -1576,7 +1576,7 @@ trash_truncate_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
         strncpy(real_path, priv->brick_path, sizeof(real_path));
         real_path[sizeof(real_path) - 1] = 0;
-        remove_trash_path(tmp_path, (frame->root->pid < 0), &tmp_stat);
+        remove_trash_path(tmp_path, IS_ERROR(frame->root->pid), &tmp_stat);
         if (tmp_stat)
             strncat(real_path, tmp_stat,
                     sizeof(real_path) - strlen(real_path) - 1);
@@ -1591,7 +1591,7 @@ trash_truncate_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Let truncate work, but previous copy is not preserved.
          * Deleting the newly created copy.
          */
@@ -1671,7 +1671,7 @@ trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if ((op_ret == -1) && (op_errno == ENOENT)) {
+    if (IS_ERROR(op_ret) && (op_errno == ENOENT)) {
         tmp_dirname = strchr(tmp_str, '/');
         while (tmp_dirname) {
             count = tmp_dirname - tmp_str;
@@ -1707,7 +1707,7 @@ trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
         strncpy(real_path, priv->brick_path, sizeof(real_path));
         real_path[sizeof(real_path) - 1] = 0;
-        remove_trash_path(tmp_path, (frame->root->pid < 0), &tmp_stat);
+        remove_trash_path(tmp_path, IS_ERROR(frame->root->pid), &tmp_stat);
         if (tmp_stat)
             strncat(real_path, tmp_stat,
                     sizeof(real_path) - strlen(real_path) - 1);
@@ -1741,7 +1741,7 @@ trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    if ((op_ret == -1) && (op_errno != EEXIST)) {
+    if (IS_ERROR(op_ret) && (op_errno != EEXIST)) {
         gf_log(this->name, GF_LOG_ERROR,
                "Directory creation failed [%s]. "
                "Therefore truncating %s without moving the "
@@ -1794,7 +1794,7 @@ trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     strncpy(real_path, priv->brick_path, sizeof(real_path));
     real_path[sizeof(real_path) - 1] = 0;
-    remove_trash_path(tmp_path, (frame->root->pid < 0), &tmp_stat);
+    remove_trash_path(tmp_path, IS_ERROR(frame->root->pid), &tmp_stat);
     if (tmp_stat)
         strncat(real_path, tmp_stat, sizeof(real_path) - strlen(real_path) - 1);
 
@@ -1842,7 +1842,7 @@ trash_truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
     pthread_mutex_unlock(&table->lock);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG, "fstat on the file failed: %s",
                strerror(op_errno));
 
@@ -1881,8 +1881,8 @@ trash_truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* Stores new path for source file */
-    copy_trash_path(priv->newtrash_dir, (frame->root->pid < 0), local->newpath,
-                    sizeof(local->newpath));
+    copy_trash_path(priv->newtrash_dir, IS_ERROR(frame->root->pid),
+                    local->newpath, sizeof(local->newpath));
     strncat(local->newpath, local->loc.path,
             sizeof(local->newpath) - strlen(local->newpath) - 1);
 
@@ -1970,7 +1970,7 @@ trash_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     /* The files removed by gluster operations such as self-heal,
        should moved to trash directory, but files by client should
        not moved */
-    if ((frame->root->pid < 0) && !priv->internal) {
+    if (IS_ERROR(frame->root->pid) && !priv->internal) {
         STACK_WIND(frame, trash_common_unwind_buf_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->truncate, loc, offset, xdata);
         goto out;
@@ -2059,7 +2059,7 @@ trash_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
      * should moved to trash directory, but files by client
      * should not moved
      */
-    if ((frame->root->pid < 0) && !priv->internal) {
+    if (IS_ERROR(frame->root->pid) && !priv->internal) {
         STACK_WIND(frame, trash_common_unwind_buf_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->ftruncate, fd, offset, xdata);
         goto out;

--- a/xlators/features/upcall/src/upcall-internal.c
+++ b/xlators/features/upcall/src/upcall-internal.c
@@ -142,13 +142,13 @@ __upcall_inode_ctx_get(inode_t *inode, xlator_t *this)
 
     ret = __inode_ctx_get(inode, this, &ctx);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = __upcall_inode_ctx_set(inode, this);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = __inode_ctx_get(inode, this, &ctx);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 
@@ -262,7 +262,7 @@ upcall_cleanup_inode_ctx(xlator_t *this, inode_t *inode)
 
     ret = inode_ctx_del(inode, this, &ctx);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("upcall", GF_LOG_WARNING, 0, UPCALL_MSG_INTERNAL_ERROR,
                "Failed to del upcall_inode_ctx (%p)", inode);
         goto out;
@@ -635,7 +635,7 @@ upcall_client_cache_invalidate(xlator_t *this, uuid_t gfid,
          * notify may fail as the client could have been
          * dis(re)connected. Cleanup the client entry.
          */
-        if (ret < 0)
+        if (IS_ERROR(ret))
             __upcall_cleanup_client_entry(up_client_entry);
 
     } else {

--- a/xlators/features/upcall/src/upcall.c
+++ b/xlators/features/upcall/src/upcall.c
@@ -40,7 +40,7 @@ up_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -91,7 +91,7 @@ up_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -147,7 +147,7 @@ up_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -200,7 +200,7 @@ up_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -252,7 +252,7 @@ up_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -306,7 +306,7 @@ up_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     /* XXX: setattr -> UP_SIZE or UP_OWN or UP_MODE or UP_TIMES
@@ -375,7 +375,7 @@ up_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = (UP_RENAME_FLAGS | UP_PARENT_DENTRY_FLAGS);
@@ -443,7 +443,7 @@ up_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = (UP_NLINK_FLAGS | UP_PARENT_DENTRY_FLAGS);
@@ -501,7 +501,7 @@ up_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = (UP_NLINK_FLAGS | UP_PARENT_DENTRY_FLAGS);
@@ -560,7 +560,7 @@ up_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -619,7 +619,7 @@ up_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -680,7 +680,7 @@ up_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -744,7 +744,7 @@ up_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -796,7 +796,7 @@ up_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -898,7 +898,7 @@ up_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -951,7 +951,7 @@ up_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1004,7 +1004,7 @@ up_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1066,7 +1066,7 @@ up_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1126,7 +1126,7 @@ up_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1178,7 +1178,7 @@ up_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1230,7 +1230,7 @@ up_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1284,7 +1284,7 @@ up_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1372,7 +1372,7 @@ up_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -1426,7 +1426,7 @@ up_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -1479,7 +1479,7 @@ up_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -1531,7 +1531,7 @@ up_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1591,14 +1591,14 @@ up_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
     flags = UP_XATTR;
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = ret;
         goto out;
     }
@@ -1665,14 +1665,14 @@ up_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
     flags = UP_XATTR;
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = ret;
         goto out;
     }
@@ -1739,13 +1739,13 @@ up_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_XATTR_RM;
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = ret;
         goto out;
     }
@@ -1822,13 +1822,13 @@ up_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_XATTR_RM;
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_ret = ret;
         goto out;
     }
@@ -1897,7 +1897,7 @@ up_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1946,7 +1946,7 @@ up_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -2021,12 +2021,12 @@ up_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
     if (up_invalidate_needed(local->xattr)) {
-        if (dict_foreach(local->xattr, up_compare_afr_xattr, dict) < 0)
+        if (IS_ERROR(dict_foreach(local->xattr, up_compare_afr_xattr, dict)))
             goto out;
 
         upcall_cache_invalidate(frame, this, client, local->inode, UP_XATTR,
@@ -2062,7 +2062,7 @@ up_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 
@@ -2096,7 +2096,7 @@ up_fxattrop(call_frame_t *frame, xlator_t *this, fd_t *fd,
     }
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto err;
     }
 

--- a/xlators/features/utime/src/utime.c
+++ b/xlators/features/utime/src/utime.c
@@ -178,7 +178,7 @@ gf_utime_set_mdata_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
         iatt_to_mdata(mdata, stbuf);
         ret = dict_set_mdata(dict, CTIME_MDATA_XDATA_KEY, mdata, _gf_false);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, ENOMEM, UTIME_MSG_NO_MEMORY,
                    "dict set of key for set-ctime-mdata failed");
             goto err;
@@ -249,7 +249,7 @@ gf_utime_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     }
 
     ret = dict_set_int8(xdata, GF_XATTR_MDATA_KEY, 1);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, -ret, UTIME_MSG_DICT_SET_FAILED,
                "%s: Unable to set dict value for %s", loc->path,
                GF_XATTR_MDATA_KEY);

--- a/xlators/lib/src/libxlator.c
+++ b/xlators/lib/src/libxlator.c
@@ -102,7 +102,7 @@ evaluate_marker_results(int *gauge, int *count)
     for (i = 0; i < MCNT_MAX; i++) {
         if (sane) {
             if ((gauge[i] > 0 && count[i] < gauge[i]) ||
-                (gauge[i] < 0 && count[i] >= -gauge[i])) {
+                (IS_ERROR(gauge[i]) && count[i] >= -gauge[i])) {
                 sane = _gf_false;
                 /* generic action: adopt corresponding errno */
                 op_errno = marker_idx_errno_map[i];
@@ -310,13 +310,13 @@ gf_get_min_stime(xlator_t *this, dict_t *dst, char *key, data_t *value)
 
     /* stime should be minimum of all the other nodes */
     ret = dict_get_bin(dst, key, (void **)&net_timebuf);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         net_timebuf = GF_CALLOC(1, sizeof(int64_t), gf_common_mt_char);
         if (!net_timebuf)
             goto out;
 
         ret = dict_set_bin(dst, key, net_timebuf, sizeof(int64_t));
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(this->name, GF_LOG_WARNING, "key=%s: dict set failed", key);
             goto error;
         }
@@ -367,13 +367,13 @@ gf_get_max_stime(xlator_t *this, dict_t *dst, char *key, data_t *value)
 
     /* stime should be maximum of all the other nodes */
     ret = dict_get_bin(dst, key, (void **)&net_timebuf);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         net_timebuf = GF_CALLOC(1, sizeof(int64_t), gf_common_mt_char);
         if (!net_timebuf)
             goto out;
 
         ret = dict_set_bin(dst, key, net_timebuf, sizeof(int64_t));
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(this->name, GF_LOG_WARNING, "key=%s: dict set failed", key);
             goto error;
         }

--- a/xlators/meta/src/meta-defaults.c
+++ b/xlators/meta/src/meta-defaults.c
@@ -103,7 +103,7 @@ meta_default_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     ret = ops->file_write(this, fd, vector, count);
 
-    META_STACK_UNWIND(IS_SUCCESS(writev, frame, (ret) ? ret : -1),
+    META_STACK_UNWIND(writev, frame, (IS_SUCCESS(ret) ? ret : -1),
                       (IS_ERROR(ret) ? -ret : 0), &dummy, &dummy, xdata);
     return 0;
 err:

--- a/xlators/meta/src/meta-defaults.c
+++ b/xlators/meta/src/meta-defaults.c
@@ -104,7 +104,7 @@ meta_default_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
     ret = ops->file_write(this, fd, vector, count);
 
     META_STACK_UNWIND(writev, frame, (ret >= 0 ? ret : -1),
-                      (ret < 0 ? -ret : 0), &dummy, &dummy, xdata);
+                      (IS_ERROR(ret) ? -ret : 0), &dummy, &dummy, xdata);
     return 0;
 err:
     return default_writev_failure_cbk(frame, EPERM);

--- a/xlators/meta/src/meta-defaults.c
+++ b/xlators/meta/src/meta-defaults.c
@@ -103,7 +103,7 @@ meta_default_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     ret = ops->file_write(this, fd, vector, count);
 
-    META_STACK_UNWIND(writev, frame, (ret >= 0 ? ret : -1),
+    META_STACK_UNWIND(IS_SUCCESS(writev, frame, (ret) ? ret : -1),
                       (IS_ERROR(ret) ? -ret : 0), &dummy, &dummy, xdata);
     return 0;
 err:

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -273,7 +273,7 @@ meta_file_fill(xlator_t *this, fd_t *fd)
     if (ops->file_fill)
         ret = ops->file_fill(this, fd->inode, strfd);
 
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         meta_fd->data = strfd->data;
         meta_fd->size = strfd->size;
 

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -22,7 +22,7 @@ meta_fd_get(fd_t *fd, xlator_t *this)
 
     LOCK(&fd->lock);
     {
-        if (__fd_ctx_get(fd, this, &value) < 0) {
+        if (IS_ERROR(__fd_ctx_get(fd, this, &value))) {
             if (!value) {
                 meta_fd = GF_CALLOC(1, sizeof(*meta_fd), gf_meta_mt_fd_t);
                 if (!meta_fd)

--- a/xlators/mgmt/glusterd/src/glusterd-bitrot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-bitrot.c
@@ -64,7 +64,7 @@ __glusterd_handle_bitrot(rpcsvc_request_t *req)
     GF_ASSERT(conf);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto out;
     }
@@ -75,7 +75,7 @@ __glusterd_handle_bitrot(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -633,13 +633,13 @@ glusterd_op_bitrot(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     switch (type) {
         case GF_BITROT_OPTION_TYPE_ENABLE:
             ret = glusterd_bitrot_enable(volinfo, op_errstr);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
             break;
 
         case GF_BITROT_OPTION_TYPE_DISABLE:
             ret = glusterd_bitrot_disable(volinfo, op_errstr);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
 
             break;

--- a/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-brick-ops.c
@@ -279,7 +279,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
     GF_ASSERT(conf);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         snprintf(err_str, sizeof(err_str), "Garbage args received");
@@ -295,7 +295,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, errno,
                    GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
@@ -394,7 +394,7 @@ __glusterd_handle_add_brick(rpcsvc_request_t *req)
     ret = gd_addbr_validate_replica_count(volinfo, replica_count, arbiter_count,
                                           total_bricks, &type, err_str,
                                           sizeof(err_str));
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_COUNT_VALIDATE_FAILED, "%s",
                err_str);
         goto out;
@@ -641,7 +641,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
     GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         snprintf(err_str, sizeof(err_str), "Received garbage args");
@@ -657,7 +657,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, errno,
                    GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
@@ -714,7 +714,7 @@ __glusterd_handle_remove_brick(rpcsvc_request_t *req)
                "request to change replica-count to %d", replica_count);
         ret = gd_rmbr_validate_replica_count(volinfo, replica_count, count,
                                              err_str, sizeof(err_str));
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             /* logging and error msg are done in above function
                itself */
             goto out;
@@ -1034,7 +1034,7 @@ glusterd_op_perform_add_bricks(glusterd_volinfo_t *volinfo, int32_t count,
     }
 
     brickid = glusterd_get_next_available_brickid(volinfo);
-    if (brickid < 0)
+    if (IS_ERROR(brickid))
         goto out;
     while (i <= count) {
         ret = glusterd_brickinfo_new_from_brick(brick, &brickinfo, _gf_true,
@@ -1177,7 +1177,7 @@ glusterd_op_perform_add_bricks(glusterd_volinfo_t *volinfo, int32_t count,
             if (!gf_uuid_compare(brickinfo->uuid, MY_UUID)) {
                 ret = glusterd_handle_replicate_brick_ops(volinfo, brickinfo,
                                                           GD_OP_ADD_BRICK);
-                if (ret < 0)
+                if (IS_ERROR(ret))
                     goto out;
             }
         }
@@ -1407,7 +1407,7 @@ glusterd_op_stage_add_brick(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                                "count needs all the bricks "
                                "to be up to avoid data loss",
                                brickinfo->path);
-                if (len < 0) {
+                if (IS_ERROR(len)) {
                     strcpy(msg, "<error>");
                 }
                 gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_BRICK_ADD_FAIL, "%s",
@@ -2464,7 +2464,7 @@ glusterd_op_stage_barrier(dict_t *dict, char **op_errstr)
     }
 
     ret = dict_get_strn(dict, "barrier", SLEN("barrier"), &barrier_op);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_asprintf(op_errstr,
                     "Barrier op for volume %s not present "
                     "in dict",

--- a/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-conn-mgmt.c
@@ -61,7 +61,7 @@ glusterd_conn_init(glusterd_conn_t *conn, char *sockpath, int frame_timeout,
         goto out;
 
     ret = snprintf(conn->sockpath, sizeof(conn->sockpath), "%s", sockpath);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
     else
         ret = 0;

--- a/xlators/mgmt/glusterd/src/glusterd-ganesha.c
+++ b/xlators/mgmt/glusterd/src/glusterd-ganesha.c
@@ -474,7 +474,7 @@ ganesha_manage_export(dict_t *dict, char *value,
         goto out;
     }
     ret = gf_string2boolean(value, &option);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, EINVAL, GD_MSG_INVALID_ENTRY,
                "invalid value.");
         goto out;
@@ -506,7 +506,7 @@ ganesha_manage_export(dict_t *dict, char *value,
     /* Check if global option is enabled, proceed only then */
     ret = dict_get_str_boolean(priv->opts, GLUSTERD_STORE_KEY_GANESHA_GLOBAL,
                                _gf_false);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, 0,
                      "Failed to get "
                      "global option dict.");
@@ -621,7 +621,7 @@ tear_down_cluster(gf_boolean_t run_teardown)
         while (entry) {
             snprintf(path, PATH_MAX, "%s/%s", CONFDIR, entry->d_name);
             ret = sys_lstat(path, &st);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 gf_msg_debug(THIS->name, 0,
                              "Failed to stat entry %s :"
                              " %s",
@@ -704,7 +704,7 @@ teardown(gf_boolean_t run_teardown, char **op_errstr)
     priv = THIS->private;
 
     ret = tear_down_cluster(run_teardown);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_asprintf(op_errstr,
                     "Cleanup of NFS-Ganesha"
                     " HA config failed.");
@@ -859,7 +859,7 @@ pre_setup(gf_boolean_t run_setup, char **op_errstr)
         }
     }
     ret = setup_cluster(run_setup);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         gf_asprintf(op_errstr,
                     "Failed to set up HA "
                     "config for NFS-Ganesha. "
@@ -881,13 +881,13 @@ glusterd_handle_ganesha_op(dict_t *dict, char **op_errstr, char *key,
 
     if (strcmp(key, "ganesha.enable") == 0) {
         ret = ganesha_manage_export(dict, value, _gf_true, op_errstr);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 
     /* It is possible that the key might not be set */
     ret = gf_string2boolean(value, &option);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_asprintf(op_errstr, "Invalid value in key-value pair.");
         goto out;
     }
@@ -901,11 +901,11 @@ glusterd_handle_ganesha_op(dict_t *dict, char **op_errstr, char *key,
          */
         if (option) {
             ret = pre_setup(is_origin_glusterd(dict), op_errstr);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
         } else {
             ret = teardown(is_origin_glusterd(dict), op_errstr);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
         }
     }

--- a/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
+++ b/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
@@ -1477,7 +1477,7 @@ glusterd_remove_slave_in_info(glusterd_volinfo_t *volinfo, char *slave,
         }
         zero_slave_entries = _gf_false;
         dict_del(volinfo->gsync_slaves, slavekey);
-    } while (ret >= 0);
+    } while (IS_SUCCESS(ret));
 
     ret = glusterd_store_volinfo(volinfo, GLUSTERD_VOLINFO_VER_AC_INCREMENT);
     if (ret) {

--- a/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
+++ b/xlators/mgmt/glusterd/src/glusterd-geo-rep.c
@@ -113,7 +113,7 @@ __glusterd_handle_sys_exec(rpcsvc_request_t *req)
     GF_ASSERT(priv);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto out;
     }
@@ -125,7 +125,7 @@ __glusterd_handle_sys_exec(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -186,7 +186,7 @@ __glusterd_handle_copy_file(rpcsvc_request_t *req)
     GF_ASSERT(priv);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto out;
     }
@@ -198,7 +198,7 @@ __glusterd_handle_copy_file(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to"
                    "unserialize req-buffer to dictionary");
@@ -265,7 +265,7 @@ __glusterd_handle_gsync_set(rpcsvc_request_t *req)
     GF_ASSERT(priv);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto out;
     }
@@ -277,7 +277,7 @@ __glusterd_handle_gsync_set(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -303,21 +303,21 @@ __glusterd_handle_gsync_set(rpcsvc_request_t *req)
     }
 
     ret = dict_get_str(dict, "master", &master);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
                "master not found, while handling " GEOREP " options");
         master = "(No Master)";
     }
 
     ret = dict_get_str(dict, "slave", &slave);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_DICT_GET_FAILED,
                "slave not found, while handling " GEOREP " options");
         slave = "(No Slave)";
     }
 
     ret = dict_get_int32(dict, "type", &type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(err_str, sizeof(err_str),
                  "Command type not found "
                  "while handling " GEOREP " options");
@@ -466,7 +466,7 @@ _glusterd_urltransform_add_iter(dict_t *dict, char *key, data_t *value,
     }
 
     ret = parse_slave_url(slv_url, &slave);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SLAVE_VOL_PARSE_FAIL,
                "Error in parsing slave: %s!", value->data);
         goto out;
@@ -645,13 +645,13 @@ glusterd_get_slave(glusterd_volinfo_t *vol, const char *slaveurl,
     glusterd_urltransform_init(&runner, "canonicalize");
     ret = dict_foreach(vol->gsync_slaves, _glusterd_urltransform_add_iter,
                        &runner);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return -2;
 
     glusterd_urltransform_add(&runner, slaveurl);
 
     n = glusterd_urltransform(&runner, &linearr);
-    if (n == -1)
+    if (IS_ERROR(n))
         return -2;
 
     for (i = 0; i < n - 1; i++) {
@@ -990,7 +990,7 @@ gsyncd_getpidfile(char *master, char *slave, char *pidfile, char *conf_path,
 
     len = snprintf(temp_conf_path, sizeof(temp_conf_path),
                    "%s/" GSYNC_CONF_TEMPLATE, priv->workdir);
-    if ((len < 0) || (len >= sizeof(temp_conf_path))) {
+    if (IS_ERROR(len) || (len >= sizeof(temp_conf_path))) {
         goto out;
     }
 
@@ -1020,7 +1020,7 @@ fetch_data:
 
     ret = glusterd_gsync_get_param_file(pidfile, "pid", master, slave,
                                         working_conf_path);
-    if ((ret == -1) || strlen(pidfile) == 0) {
+    if (IS_ERROR(ret) || strlen(pidfile) == 0) {
         if (*is_template_in_use == _gf_false) {
             gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_PIDFILE_CREATE_FAILED,
                    "failed to create the pidfile string. "
@@ -1334,7 +1334,7 @@ _get_status_mst_slv(dict_t *dict, char *key, data_t *value, void *data)
     }
 
     ret = parse_slave_url(slv_url, &slave);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SLAVE_VOL_PARSE_FAIL,
                "Error in parsing slave: %s!", value->data);
         goto out;
@@ -1471,7 +1471,7 @@ glusterd_remove_slave_in_info(glusterd_volinfo_t *volinfo, char *slave,
 
     do {
         ret = glusterd_get_slave(volinfo, slave, &slavekey);
-        if (ret < 0 && zero_slave_entries) {
+        if (IS_ERROR(ret) && zero_slave_entries) {
             ret++;
             goto out;
         }
@@ -1507,7 +1507,7 @@ glusterd_gsync_get_uuid(char *slave, glusterd_volinfo_t *vol, uuid_t uuid)
     GF_ASSERT(slave);
 
     ret = glusterd_get_slave(vol, slave, &slavekey);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /* XXX colliding cases of failure and non-extant
          * slave... now just doing this as callers of this
          * function can make sense only of -1 and 0 as retvals;
@@ -1583,7 +1583,7 @@ update_slave_voluuid(dict_t *dict, char *key, data_t *value, void *data)
         }
 
         ret = parse_slave_url(slv_url, &slave);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SLAVE_VOL_PARSE_FAIL,
                    "Error in parsing slave: %s!", value->data);
             goto out;
@@ -1708,7 +1708,7 @@ glusterd_check_gsync_running_local(char *master, char *slave, char *conf_path,
                        &is_template_in_use);
     if (ret == 0 && ret_status == 0)
         *is_run = _gf_true;
-    else if (ret == -1) {
+    else if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_VALIDATE_FAILED,
                GEOREP " validation failed");
         goto out;
@@ -1795,13 +1795,13 @@ glusterd_store_slave_in_info(glusterd_volinfo_t *volinfo, char *slave,
     }
 
     ret = glusterd_urltransform_single(slave, "normalize", &linearr);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = gf_asprintf(&value, "%s:%s:%s", host_uuid, linearr[0], slave_voluuid);
 
     glusterd_urltransform_free(linearr, 1);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     /* Given the slave volume uuid, check and get any existing slave */
@@ -1818,7 +1818,7 @@ glusterd_store_slave_in_info(glusterd_volinfo_t *volinfo, char *slave,
             GF_FREE(value);
             goto out;
         }
-    } else if (ret == -1) { /* Existing slave */
+    } else if (IS_ERROR(ret)) { /* Existing slave */
         keylen = snprintf(key, sizeof(key), "slave%d", slave1.old_slvidx);
 
         gf_msg_debug(this->name, 0,
@@ -1939,7 +1939,7 @@ glusterd_op_verify_gsync_start_options(glusterd_volinfo_t *volinfo, char *slave,
             ret = -1;
             goto out;
         }
-    } else if (ret == -1) {
+    } else if (IS_ERROR(ret)) {
         snprintf(msg, sizeof(msg),
                  GEOREP
                  " start option "
@@ -2133,7 +2133,7 @@ _get_slave_status(dict_t *dict, char *key, data_t *value, void *data)
     ret = snprintf(conf_path, sizeof(conf_path) - 1,
                    "%s/" GEOREP "/%s_%s_%s/gsyncd.conf", priv->workdir,
                    param->volinfo->volname, slave_host, slave_vol);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_CONF_PATH_ASSIGN_FAILED,
                "Unable to assign conf_path.");
         ret = -1;
@@ -2264,7 +2264,7 @@ glusterd_op_verify_gsync_running(glusterd_volinfo_t *volinfo, char *slave,
         ret = -1;
         goto out;
     }
-    if (gsync_status_byfd(pfd) == -1) {
+    if (IS_ERROR(gsync_status_byfd(pfd))) {
         snprintf(msg, sizeof(msg),
                  GEOREP
                  " session b/w %s & %s is "
@@ -2287,7 +2287,7 @@ glusterd_op_verify_gsync_running(glusterd_volinfo_t *volinfo, char *slave,
         goto out;
     }
 
-    if (pfd < 0)
+    if (IS_ERROR(pfd))
         goto out;
 
     ret = 0;
@@ -2329,7 +2329,7 @@ glusterd_verify_gsync_status_opts(dict_t *dict, char **op_errstr)
     }
 
     ret = dict_get_str(dict, "master", &volname);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = 0;
         goto out;
     }
@@ -2347,7 +2347,7 @@ glusterd_verify_gsync_status_opts(dict_t *dict, char **op_errstr)
     }
 
     ret = dict_get_str(dict, "slave", &slave);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = 0;
         goto out;
     }
@@ -2381,7 +2381,7 @@ glusterd_op_gsync_args_get(dict_t *dict, char **op_errstr, char **master,
 
     if (master) {
         ret = dict_get_str(dict, "master", master);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_DICT_GET_FAILED,
                    "master not found");
             *op_errstr = gf_strdup("master not found");
@@ -2391,7 +2391,7 @@ glusterd_op_gsync_args_get(dict_t *dict, char **op_errstr, char **master,
 
     if (slave) {
         ret = dict_get_str(dict, "slave", slave);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_DICT_GET_FAILED,
                    "slave not found");
             *op_errstr = gf_strdup("slave not found");
@@ -2401,7 +2401,7 @@ glusterd_op_gsync_args_get(dict_t *dict, char **op_errstr, char **master,
 
     if (host_uuid) {
         ret = dict_get_str(dict, "host-uuid", host_uuid);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_DICT_GET_FAILED,
                    "host_uuid not found");
             *op_errstr = gf_strdup("host_uuid not found");
@@ -2537,7 +2537,7 @@ glusterd_op_stage_copy_file(dict_t *dict, char **op_errstr)
     }
 
     ret = dict_get_str(dict, "host-uuid", &host_uuid);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch host-uuid from dict.");
         goto out;
@@ -2546,7 +2546,7 @@ glusterd_op_stage_copy_file(dict_t *dict, char **op_errstr)
     uuid_utoa_r(MY_UUID, uuid_str);
     if (!strcmp(uuid_str, host_uuid)) {
         ret = dict_get_str(dict, "source", &filename);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                    "Unable to fetch filename from dict.");
             *op_errstr = gf_strdup("command unsuccessful");
@@ -2554,7 +2554,7 @@ glusterd_op_stage_copy_file(dict_t *dict, char **op_errstr)
         }
         len = snprintf(abs_filename, sizeof(abs_filename), "%s/%s",
                        priv->workdir, filename);
-        if ((len < 0) || (len >= sizeof(abs_filename))) {
+        if (IS_ERROR(len) || (len >= sizeof(abs_filename))) {
             ret = -1;
             goto out;
         }
@@ -2564,7 +2564,7 @@ glusterd_op_stage_copy_file(dict_t *dict, char **op_errstr)
                            "Failed to "
                            "get realpath of %s: %s",
                            priv->workdir, strerror(errno));
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(errmsg, "<error>");
             }
             *op_errstr = gf_strdup(errmsg);
@@ -2585,7 +2585,7 @@ glusterd_op_stage_copy_file(dict_t *dict, char **op_errstr)
         /* Add Trailing slash to workdir, without slash strncmp
            will succeed for /var/lib/glusterd_bad */
         len = snprintf(workdir, sizeof(workdir), "%s/", realpath_workdir);
-        if ((len < 0) || (len >= sizeof(workdir))) {
+        if (IS_ERROR(len) || (len >= sizeof(workdir))) {
             ret = -1;
             goto out;
         }
@@ -2596,7 +2596,7 @@ glusterd_op_stage_copy_file(dict_t *dict, char **op_errstr)
                            "Source file"
                            " is outside of %s directory",
                            priv->workdir);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(errmsg, "<error>");
             }
             *op_errstr = gf_strdup(errmsg);
@@ -2610,7 +2610,7 @@ glusterd_op_stage_copy_file(dict_t *dict, char **op_errstr)
                            "Source file"
                            " does not exist in %s",
                            priv->workdir);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(errmsg, "<error>");
             }
             *op_errstr = gf_strdup(errmsg);
@@ -2674,7 +2674,7 @@ glusterd_get_statefile_name(glusterd_volinfo_t *volinfo, char *slave,
 
     len = snprintf(temp_conf_path, sizeof(temp_conf_path),
                    "%s/" GSYNC_CONF_TEMPLATE, priv->workdir);
-    if ((len < 0) || (len >= sizeof(temp_conf_path))) {
+    if (IS_ERROR(len) || (len >= sizeof(temp_conf_path))) {
         goto out;
     }
 
@@ -3243,7 +3243,7 @@ glusterd_op_stage_gsync_create(dict_t *dict, char **op_errstr)
         }
 
         ret = dict_get_int32(dict, "ssh_port", &ssh_port);
-        if (ret < 0 && ret != -ENOENT) {
+        if (IS_ERROR(ret) && ret != -ENOENT) {
             snprintf(errmsg, sizeof(errmsg),
                      "Fetching ssh_port failed while "
                      "handling " GEOREP " options");
@@ -3285,14 +3285,14 @@ glusterd_op_stage_gsync_create(dict_t *dict, char **op_errstr)
         if (!ret && is_pem_push) {
             ret = snprintf(common_pem_file, sizeof(common_pem_file),
                            "%s" GLUSTERD_COMMON_PEM_PUB_FILE, conf->workdir);
-            if ((ret < 0) || (ret >= sizeof(common_pem_file))) {
+            if (IS_ERROR(ret) || (ret >= sizeof(common_pem_file))) {
                 ret = -1;
                 goto out;
             }
 
             ret = snprintf(hook_script, sizeof(hook_script),
                            "%s" GLUSTERD_CREATE_HOOK_SCRIPT, conf->workdir);
-            if ((ret < 0) || (ret >= sizeof(hook_script))) {
+            if (IS_ERROR(ret) || (ret >= sizeof(hook_script))) {
                 ret = -1;
                 goto out;
             }
@@ -3306,7 +3306,7 @@ glusterd_op_stage_gsync_create(dict_t *dict, char **op_errstr)
                                " \"gluster system:: execute"
                                " gsec_create\"",
                                common_pem_file);
-                if (len < 0) {
+                if (IS_ERROR(len)) {
                     strcpy(errmsg, "<error>");
                 }
                 gf_msg(this->name, GF_LOG_ERROR, ENOENT, GD_MSG_FILE_OP_FAILED,
@@ -3324,7 +3324,7 @@ glusterd_op_stage_gsync_create(dict_t *dict, char **op_errstr)
                                "present. Please install the "
                                "hook-script and retry",
                                hook_script);
-                if (len < 0) {
+                if (IS_ERROR(len)) {
                     strcpy(errmsg, "<error>");
                 }
                 gf_msg(this->name, GF_LOG_ERROR, ENOENT, GD_MSG_FILE_OP_FAILED,
@@ -3342,7 +3342,7 @@ glusterd_op_stage_gsync_create(dict_t *dict, char **op_errstr)
                                " run \"gluster system:: "
                                "execute gsec_create\"",
                                common_pem_file);
-                if (len < 0) {
+                if (IS_ERROR(len)) {
                     strcpy(errmsg, "<error>");
                 }
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REG_FILE_MISSING,
@@ -3420,7 +3420,7 @@ glusterd_op_stage_gsync_create(dict_t *dict, char **op_errstr)
     /* Check whether session is already created using slave volume uuid */
     ret = glusterd_get_slavehost_from_voluuid(volinfo, slave_host, slave_vol,
                                               &slave1);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         if (!is_force) {
             snprintf(errmsg, sizeof(errmsg),
                      "Session between %s"
@@ -3467,7 +3467,7 @@ glusterd_op_stage_gsync_create(dict_t *dict, char **op_errstr)
             len = snprintf(old_confpath, sizeof(old_confpath),
                            "%s/" GEOREP "/%s_%s_%s/gsyncd.conf", conf->workdir,
                            volinfo->volname, slave1.old_slvhost, slave_vol);
-            if ((len < 0) || (len >= sizeof(old_confpath))) {
+            if (IS_ERROR(len) || (len >= sizeof(old_confpath))) {
                 ret = -1;
                 goto out;
             }
@@ -3475,7 +3475,7 @@ glusterd_op_stage_gsync_create(dict_t *dict, char **op_errstr)
             /* construct old slave url with (old) slave host */
             len = snprintf(old_slave_url, sizeof(old_slave_url), "%s::%s",
                            slave1.old_slvhost, slave_vol);
-            if ((len < 0) || (len >= sizeof(old_slave_url))) {
+            if (IS_ERROR(len) || (len >= sizeof(old_slave_url))) {
                 ret = -1;
                 goto out;
             }
@@ -3637,7 +3637,7 @@ glusterd_op_stage_gsync_set(dict_t *dict, char **op_errstr)
     GF_ASSERT(conf);
 
     ret = dict_get_int32(dict, "type", &type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_DICT_GET_FAILED,
                "command type not found");
         *op_errstr = gf_strdup("command unsuccessful");
@@ -3815,7 +3815,7 @@ glusterd_op_stage_gsync_set(dict_t *dict, char **op_errstr)
                                                        conf_path, op_errstr);
                 if (ret) {
                     ret = glusterd_get_local_brickpaths(volinfo, &path_list);
-                    if (!path_list && ret == -1)
+                    if (!path_list && IS_ERROR(ret))
                         goto out;
                 }
 
@@ -3848,7 +3848,7 @@ glusterd_op_stage_gsync_set(dict_t *dict, char **op_errstr)
                                                    op_errstr);
             if (ret) {
                 ret = glusterd_get_local_brickpaths(volinfo, &path_list);
-                if (!path_list && ret == -1)
+                if (!path_list && IS_ERROR(ret))
                     goto out;
             }
 
@@ -3869,7 +3869,7 @@ glusterd_op_stage_gsync_set(dict_t *dict, char **op_errstr)
                                                  statefile, op_errstr);
                 if (ret) {
                     ret = glusterd_get_local_brickpaths(volinfo, &path_list);
-                    if (!path_list && ret == -1)
+                    if (!path_list && IS_ERROR(ret))
                         goto out;
                 }
             }
@@ -3990,14 +3990,14 @@ gd_pause_or_resume_gsync(dict_t *dict, char *master, char *slave,
         goto out;
     }
 
-    if (gsync_status_byfd(pfd) == -1) {
+    if (IS_ERROR(gsync_status_byfd(pfd))) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_GSYNCD_ERROR,
                "gsyncd b/w %s & %s is not running", master, slave);
         /* monitor gsyncd already dead */
         goto out;
     }
 
-    if (pfd < 0)
+    if (IS_ERROR(pfd))
         goto out;
 
     /* Prepare to update status file*/
@@ -4149,7 +4149,7 @@ stop_gsync(char *master, char *slave, char **msg, char *conf_path,
         goto out;
     }
 
-    if (pfd < 0)
+    if (IS_ERROR(pfd))
         goto out;
 
     ret = sys_read(pfd, buf, sizeof(buf) - 1);
@@ -4163,7 +4163,7 @@ stop_gsync(char *master, char *slave, char **msg, char *conf_path,
             goto out;
         }
         for (i = 0; i < 20; i++) {
-            if (gsync_status_byfd(pfd) == -1) {
+            if (IS_ERROR(gsync_status_byfd(pfd))) {
                 /* monitor gsyncd is dead but worker may
                  * still be alive, give some more time
                  * before SIGKILL (hack)
@@ -4363,7 +4363,7 @@ glusterd_gsync_configure(glusterd_volinfo_t *volinfo, char *slave,
     if (strcmp(op_name, "checkpoint") != 0 && strtail(subop, "set")) {
         ret = glusterd_gsync_op_already_set(master, slave, conf_path, op_name,
                                             op_value);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, 0, GD_MSG_GSYNCD_OP_SET_FAILED,
                    "glusterd_gsync_op_already_set failed.");
             gf_asprintf(op_errstr,
@@ -4465,7 +4465,7 @@ glusterd_gsync_read_frm_status(char *path, char *buf, size_t blen)
     GF_ASSERT(path);
     GF_ASSERT(buf);
     status_fd = open(path, O_RDONLY);
-    if (status_fd == -1) {
+    if (IS_ERROR(status_fd)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_FILE_OP_FAILED,
                "Unable to read gsyncd status file %s", path);
         return -1;
@@ -4640,7 +4640,7 @@ glusterd_read_status_file(glusterd_volinfo_t *volinfo, char *slave,
 
     len = snprintf(temp_conf_path, sizeof(temp_conf_path),
                    "%s/" GSYNC_CONF_TEMPLATE, priv->workdir);
-    if ((len < 0) || (len >= sizeof(temp_conf_path))) {
+    if (IS_ERROR(len) || (len >= sizeof(temp_conf_path))) {
         return -1;
     }
 
@@ -4721,7 +4721,7 @@ fetch_data:
 
         /* Slave Key */
         ret = glusterd_get_slave(volinfo, slave, &slavekey);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             GF_FREE(sts_val);
             goto out;
         }
@@ -4804,7 +4804,7 @@ fetch_data:
         }
 
         ret = dict_get_str(volinfo->gsync_slaves, slavekey, &slaveentry);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             GF_FREE(sts_val);
             goto out;
         }
@@ -4953,7 +4953,7 @@ glusterd_set_gsync_knob(glusterd_volinfo_t *volinfo, char *key, int *vc)
     GF_ASSERT(this->private);
 
     conf_enabled = glusterd_volinfo_get_boolean(volinfo, key);
-    if (conf_enabled == -1) {
+    if (IS_ERROR(conf_enabled)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_GET_KEY_FAILED,
                "failed to get key %s from volinfo", key);
         goto out;
@@ -5132,7 +5132,7 @@ glusterd_get_gsync_status(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     }
 
     ret = dict_get_str(dict, "master", &volname);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = glusterd_get_gsync_status_all(rsp_dict, my_hostname);
         goto out;
     }
@@ -5150,7 +5150,7 @@ glusterd_get_gsync_status(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     }
 
     ret = dict_get_str(dict, "slave", &slave);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = glusterd_get_gsync_status_mst(volinfo, rsp_dict, my_hostname);
         goto out;
     }
@@ -5354,7 +5354,7 @@ glusterd_op_sys_exec(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     runner_redir(&runner, STDOUT_FILENO, RUN_PIPE);
     synclock_unlock(&priv->big_lock);
     ret = runner_start(&runner);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         snprintf(errmsg, sizeof(errmsg),
                  "Unable to "
                  "execute command. Error : %s",
@@ -5459,11 +5459,11 @@ glusterd_op_copy_file(dict_t *dict, char **op_errstr)
     }
 
     ret = dict_get_str(dict, "host-uuid", &host_uuid);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_get_str(dict, "source", &filename);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Unable to fetch filename from dict.");
         *op_errstr = gf_strdup("command unsuccessful");
@@ -5471,7 +5471,7 @@ glusterd_op_copy_file(dict_t *dict, char **op_errstr)
     }
     len = snprintf(abs_filename, sizeof(abs_filename), "%s/%s", priv->workdir,
                    filename);
-    if ((len < 0) || (len >= sizeof(abs_filename))) {
+    if (IS_ERROR(len) || (len >= sizeof(abs_filename))) {
         ret = -1;
         goto out;
     }
@@ -5484,7 +5484,7 @@ glusterd_op_copy_file(dict_t *dict, char **op_errstr)
                            "Source file "
                            "does not exist in %s",
                            priv->workdir);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(errmsg, "<error>");
             }
             *op_errstr = gf_strdup(errmsg);
@@ -5504,10 +5504,10 @@ glusterd_op_copy_file(dict_t *dict, char **op_errstr)
         }
 
         fd = open(abs_filename, O_RDONLY);
-        if (fd < 0) {
+        if (IS_ERROR(fd)) {
             len = snprintf(errmsg, sizeof(errmsg), "Unable to open %s",
                            abs_filename);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(errmsg, "<error>");
             }
             *op_errstr = gf_strdup(errmsg);
@@ -5529,7 +5529,7 @@ glusterd_op_copy_file(dict_t *dict, char **op_errstr)
         if (bytes_read != stbuf.st_size) {
             len = snprintf(errmsg, sizeof(errmsg),
                            "Unable to read all the data from %s", abs_filename);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(errmsg, "<error>");
             }
             *op_errstr = gf_strdup(errmsg);
@@ -5608,10 +5608,10 @@ glusterd_op_copy_file(dict_t *dict, char **op_errstr)
         }
 
         fd = open(abs_filename, O_WRONLY | O_TRUNC | O_CREAT, 0600);
-        if (fd < 0) {
+        if (IS_ERROR(fd)) {
             len = snprintf(errmsg, sizeof(errmsg), "Unable to open %s",
                            abs_filename);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(errmsg, "<error>");
             }
             *op_errstr = gf_strdup(errmsg);
@@ -5626,7 +5626,7 @@ glusterd_op_copy_file(dict_t *dict, char **op_errstr)
         if (bytes_writen != contents_size) {
             len = snprintf(errmsg, sizeof(errmsg), "Failed to write to %s",
                            abs_filename);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(errmsg, "<error>");
             }
             *op_errstr = gf_strdup(errmsg);
@@ -5681,11 +5681,11 @@ glusterd_op_gsync_set(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     GF_ASSERT(rsp_dict);
 
     ret = dict_get_int32(dict, "type", &type);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_get_str(dict, "host-uuid", &host_uuid);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (type == GF_GSYNC_OPTION_TYPE_STATUS) {
@@ -5694,7 +5694,7 @@ glusterd_op_gsync_set(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     }
 
     ret = dict_get_str(dict, "slave", &slave);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     key = slave;
@@ -5738,7 +5738,7 @@ glusterd_op_gsync_set(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         }
 
         ret = glusterd_get_local_brickpaths(volinfo, &path_list);
-        if (!path_list && ret == -1)
+        if (!path_list && IS_ERROR(ret))
             goto out;
     }
 
@@ -5975,7 +5975,7 @@ glusterd_get_slave_info(char *slave, char **slave_url, char **hostname,
     GF_ASSERT(this);
 
     ret = glusterd_urltransform_single(slave, "normalize", &linearr);
-    if ((ret == -1) || (linearr[0] == NULL)) {
+    if (IS_ERROR(ret) || (linearr[0] == NULL)) {
         ret = snprintf(errmsg, sizeof(errmsg) - 1, "Invalid Url: %s", slave);
         errmsg[ret] = '\0';
         *op_errstr = gf_strdup(errmsg);
@@ -6068,7 +6068,7 @@ glusterd_check_gsync_present(int *valid_state)
     runner_add_args(&runner, GSYNCD_PREFIX "/gsyncd", "--version", NULL);
     runner_redir(&runner, STDOUT_FILENO, RUN_PIPE);
     ret = runner_start(&runner);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         if (errno == ENOENT) {
             gf_msg("glusterd", GF_LOG_INFO, ENOENT, GD_MSG_MODULE_NOT_INSTALLED,
                    GEOREP
@@ -6114,7 +6114,7 @@ create_conf_file(glusterd_conf_t *conf, char *conf_path)
 #define RUN_GSYNCD_CMD                                                         \
     do {                                                                       \
         ret = runner_run_reuse(&runner);                                       \
-        if (ret == -1) {                                                       \
+        if (IS_ERROR(ret)) {                                                   \
             runner_log(&runner, "glusterd", GF_LOG_ERROR, "command failed");   \
             runner_end(&runner);                                               \
             goto out;                                                          \
@@ -6133,7 +6133,7 @@ create_conf_file(glusterd_conf_t *conf, char *conf_path)
 
     valid_state = -1;
     ret = glusterd_check_gsync_present(&valid_state);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         ret = valid_state;
         goto out;
     }
@@ -6381,7 +6381,7 @@ glusterd_create_essential_dir_files(glusterd_volinfo_t *volinfo, dict_t *dict,
 
     ret = snprintf(buf, sizeof(buf), "%s/" GEOREP "/%s_%s_%s", conf->workdir,
                    volinfo->volname, slave_host, slave_vol);
-    if ((ret < 0) || (ret >= sizeof(buf))) {
+    if (IS_ERROR(ret) || (ret >= sizeof(buf))) {
         ret = -1;
         goto out;
     }
@@ -6391,7 +6391,7 @@ glusterd_create_essential_dir_files(glusterd_volinfo_t *volinfo, dict_t *dict,
                        "Unable to create %s"
                        ". Error : %s",
                        buf, strerror(errno));
-        if (len < 0) {
+        if (IS_ERROR(len)) {
             strcpy(errmsg, "<error>");
         }
         *op_errstr = gf_strdup(errmsg);
@@ -6402,7 +6402,7 @@ glusterd_create_essential_dir_files(glusterd_volinfo_t *volinfo, dict_t *dict,
 
     ret = snprintf(buf, PATH_MAX, "%s/" GEOREP "/%s", conf->logdir,
                    volinfo->volname);
-    if ((ret < 0) || (ret >= PATH_MAX)) {
+    if (IS_ERROR(ret) || (ret >= PATH_MAX)) {
         ret = -1;
         goto out;
     }
@@ -6412,7 +6412,7 @@ glusterd_create_essential_dir_files(glusterd_volinfo_t *volinfo, dict_t *dict,
                        "Unable to create %s"
                        ". Error : %s",
                        buf, strerror(errno));
-        if (len < 0) {
+        if (IS_ERROR(len)) {
             strcpy(errmsg, "<error>");
         }
         *op_errstr = gf_strdup(errmsg);
@@ -6514,7 +6514,7 @@ glusterd_op_gsync_create(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
 
     len = snprintf(common_pem_file, sizeof(common_pem_file),
                    "%s" GLUSTERD_COMMON_PEM_PUB_FILE, conf->workdir);
-    if ((len < 0) || (len >= sizeof(common_pem_file))) {
+    if (IS_ERROR(len) || (len >= sizeof(common_pem_file))) {
         ret = -1;
         goto out;
     }
@@ -6576,7 +6576,7 @@ glusterd_op_gsync_create(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     }
 
     ret = dict_get_int32(dict, "ssh_port", &ssh_port);
-    if (ret < 0 && ret != -ENOENT) {
+    if (IS_ERROR(ret) && ret != -ENOENT) {
         snprintf(errmsg, sizeof(errmsg), "Fetching ssh_port failed");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED, "%s",
                errmsg);
@@ -6602,7 +6602,7 @@ glusterd_op_gsync_create(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                        "slave_ip=%s,slave_vol=%s,ssh_port=%d",
                        is_pem_push, common_pem_file, slave_user, slave_ip,
                        slave_vol, ssh_port);
-        if ((len < 0) || (len >= sizeof(hooks_args))) {
+        if (IS_ERROR(len) || (len >= sizeof(hooks_args))) {
             ret = -1;
             goto out;
         }
@@ -6687,7 +6687,7 @@ create_essentials:
                                "failed! Error: %s",
                                old_working_dir, new_working_dir,
                                strerror(errno));
-                if (len < 0) {
+                if (IS_ERROR(len)) {
                     strcpy(errmsg, "<error>");
                 }
                 gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_FORCE_CREATE_SESSION,

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc-helper.c
@@ -134,7 +134,7 @@ out:
         *tmpvol = NULL;
     }
 
-    if (tmp_fd >= 0)
+    if (IS_SUCCESS(tmp_fd))
         sys_close(tmp_fd);
 
     return ret;

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc-helper.c
@@ -44,7 +44,7 @@ glusterd_svc_build_gfproxyd_socket_filepath(glusterd_volinfo_t *volinfo,
     glusterd_svc_build_gfproxyd_rundir(volinfo, rundir, sizeof(rundir));
     len = snprintf(sockfilepath, sizeof(sockfilepath), "%s/run-%s", rundir,
                    uuid_utoa(MY_UUID));
-    if ((len < 0) || (len >= sizeof(sockfilepath))) {
+    if (IS_ERROR(len) || (len >= sizeof(sockfilepath))) {
         sockfilepath[0] = 0;
     }
 
@@ -108,13 +108,13 @@ glusterd_svc_get_gfproxyd_volfile(glusterd_volinfo_t *volinfo, char *svc_name,
     glusterd_svc_build_gfproxyd_volfile_path(volinfo, orgvol, path_len);
 
     ret = gf_asprintf(tmpvol, "/tmp/g%s-XXXXXX", svc_name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
     /* coverity[SECURE_TEMP] mkstemp uses 0600 as the mode and is safe */
     tmp_fd = mkstemp(*tmpvol);
-    if (tmp_fd < 0) {
+    if (IS_ERROR(tmp_fd)) {
         gf_msg("glusterd", GF_LOG_WARNING, errno, GD_MSG_FILE_OP_FAILED,
                "Unable to create temp file"
                " %s:(%s)",
@@ -126,10 +126,10 @@ glusterd_svc_get_gfproxyd_volfile(glusterd_volinfo_t *volinfo, char *svc_name,
     need_unlink = 1;
     ret = glusterd_build_gfproxyd_volfile(volinfo, *tmpvol);
 out:
-    if (need_unlink && ret < 0)
+    if (need_unlink && IS_ERROR(ret))
         sys_unlink(*tmpvol);
 
-    if ((ret < 0) && (*tmpvol != NULL)) {
+    if (IS_ERROR(ret) && (*tmpvol != NULL)) {
         GF_FREE(*tmpvol);
         *tmpvol = NULL;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-gfproxyd-svc.c
@@ -85,7 +85,7 @@ glusterd_gfproxydsvc_init(glusterd_volinfo_t *volinfo)
     svc = &(volinfo->gfproxyd.svc);
 
     ret = snprintf(svc->name, sizeof(svc->name), "%s", gfproxyd_svc_name);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     notify = glusterd_svc_common_rpc_notify;
@@ -106,7 +106,7 @@ glusterd_gfproxydsvc_init(glusterd_volinfo_t *volinfo)
     glusterd_svc_build_gfproxyd_logdir(logdir, volinfo->volname,
                                        sizeof(logdir));
     ret = mkdir_p(logdir, 0755, _gf_true);
-    if ((ret == -1) && (EEXIST != errno)) {
+    if (IS_ERROR(ret) && (EEXIST != errno)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create logdir %s", logdir);
         goto out;
@@ -114,7 +114,7 @@ glusterd_gfproxydsvc_init(glusterd_volinfo_t *volinfo)
     glusterd_svc_build_gfproxyd_logfile(logfile, logdir, sizeof(logfile));
     len = snprintf(volfileid, sizeof(volfileid), "gfproxyd/%s",
                    volinfo->volname);
-    if ((len < 0) || (len >= sizeof(volfileid))) {
+    if (IS_ERROR(len) || (len >= sizeof(volfileid))) {
         ret = -1;
         goto out;
     }
@@ -185,7 +185,7 @@ glusterd_gfproxydsvc_manager(glusterd_svc_t *svc, void *data, int flags)
     }
 
     ret = glusterd_is_gfproxyd_enabled(volinfo);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_VOLINFO_GET_FAIL,
                "Failed to read volume "
                "options");
@@ -313,7 +313,7 @@ glusterd_gfproxydsvc_start(glusterd_svc_t *svc, int flags)
     if (this->ctx->cmd_args.valgrind) {
         len = snprintf(valgrind_logfile, PATH_MAX, "%s/valgrind-%s",
                        svc->proc.logdir, svc->proc.logfile);
-        if ((len < 0) || (len >= PATH_MAX)) {
+        if (IS_ERROR(len) || (len >= PATH_MAX)) {
             ret = -1;
             goto out;
         }

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -473,7 +473,7 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
         };
         len = snprintf(brick, sizeof(brick), "%s:%s", brickinfo->hostname,
                        brickinfo->path);
-        if ((len < 0) || (len >= sizeof(brick))) {
+        if (IS_ERROR((len)) || (len >= sizeof(brick))) {
             ret = -1;
             goto out;
         }
@@ -499,7 +499,7 @@ glusterd_add_volume_detail_to_dict(glusterd_volinfo_t *volinfo, dict_t *volumes,
                                         glusterd_brickinfo_t, brick_list);
         len = snprintf(ta_brick, sizeof(ta_brick), "%s:%s",
                        ta_brickinfo->hostname, ta_brickinfo->path);
-        if ((len < 0) || (len >= sizeof(ta_brick))) {
+        if (IS_ERROR((len)) || (len >= sizeof(ta_brick))) {
             ret = -1;
             goto out;
         }
@@ -716,7 +716,7 @@ __glusterd_handle_cluster_lock(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &lock_req,
                          (xdrproc_t)xdr_gd1_mgmt_cluster_lock_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode lock "
                "request received from peer");
@@ -870,7 +870,7 @@ __glusterd_handle_stage_op(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &op_req,
                          (xdrproc_t)xdr_gd1_mgmt_stage_op_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode stage "
                "request received from peer");
@@ -968,7 +968,7 @@ __glusterd_handle_commit_op(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &op_req,
                          (xdrproc_t)xdr_gd1_mgmt_commit_op_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode commit "
                "request received from peer");
@@ -1036,7 +1036,7 @@ __glusterd_handle_cli_probe(rpcsvc_request_t *req)
     this = THIS;
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "xdr decoding error");
@@ -1049,7 +1049,7 @@ __glusterd_handle_cli_probe(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "Failed to "
                    "unserialize req-buffer to dictionary");
@@ -1124,7 +1124,7 @@ __glusterd_handle_cli_probe(rpcsvc_request_t *req)
         run_fsm = _gf_false;
         ret = 0;
 
-    } else if (ret == -1) {
+    } else if (IS_ERROR(ret)) {
         glusterd_xfer_cli_probe_resp(req, -1, op_errno, NULL, hostname, port,
                                      dict);
         goto out;
@@ -1177,7 +1177,7 @@ __glusterd_handle_cli_deprobe(rpcsvc_request_t *req)
     GF_ASSERT(req);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
@@ -1198,7 +1198,7 @@ __glusterd_handle_cli_deprobe(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "Failed to "
                    "unserialize req-buffer to dictionary");
@@ -1329,7 +1329,7 @@ __glusterd_handle_cli_list_friends(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &cli_req,
                          (xdrproc_t)xdr_gf1_cli_peer_list_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
@@ -1347,7 +1347,7 @@ __glusterd_handle_cli_list_friends(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -1390,7 +1390,7 @@ __glusterd_handle_cli_get_volume(rpcsvc_request_t *req)
     this = THIS;
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
@@ -1408,7 +1408,7 @@ __glusterd_handle_cli_get_volume(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -1467,7 +1467,7 @@ __glusterd_handle_cli_uuid_reset(rpcsvc_request_t *req)
     GF_ASSERT(priv);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
@@ -1484,7 +1484,7 @@ __glusterd_handle_cli_uuid_reset(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -1588,7 +1588,7 @@ __glusterd_handle_cli_uuid_get(rpcsvc_request_t *req)
     GF_ASSERT(priv);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
                "request received from cli");
@@ -1607,7 +1607,7 @@ __glusterd_handle_cli_uuid_get(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -1776,7 +1776,7 @@ __glusterd_handle_ganesha_cmd(rpcsvc_request_t *req)
     GF_ASSERT(req);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to decode "
                  "request received from cli");
@@ -1796,7 +1796,7 @@ __glusterd_handle_ganesha_cmd(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -1854,7 +1854,7 @@ __glusterd_handle_reset_volume(rpcsvc_request_t *req)
     gf_msg(this->name, GF_LOG_INFO, 0, 0, "Received reset vol req");
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to decode request "
                  "received from cli");
@@ -1870,7 +1870,7 @@ __glusterd_handle_reset_volume(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -1940,7 +1940,7 @@ __glusterd_handle_set_volume(rpcsvc_request_t *req)
     GF_ASSERT(req);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to decode "
                  "request received from cli");
@@ -1956,7 +1956,7 @@ __glusterd_handle_set_volume(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, errno,
                    GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
@@ -2057,7 +2057,7 @@ __glusterd_handle_sync_volume(rpcsvc_request_t *req)
     GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL, "%s",
                "Failed to decode "
@@ -2072,7 +2072,7 @@ __glusterd_handle_sync_volume(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -2157,7 +2157,7 @@ glusterd_fsm_log_send_resp(rpcsvc_request_t *req, int op_ret, char *op_errstr,
     if (rsp.op_ret == 0) {
         ret = dict_allocate_and_serialize(dict, &rsp.fsm_log.fsm_log_val,
                                           &rsp.fsm_log.fsm_log_len);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, 0,
                    GD_MSG_DICT_SERL_LENGTH_GET_FAIL,
                    "failed to get serialized length of dict");
@@ -2194,7 +2194,7 @@ __glusterd_handle_fsm_log(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &cli_req,
                          (xdrproc_t)xdr_gf1_cli_fsm_log_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
@@ -2357,7 +2357,7 @@ __glusterd_handle_cluster_unlock(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &unlock_req,
                          (xdrproc_t)xdr_gd1_mgmt_cluster_unlock_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode unlock "
                "request received from peer");
@@ -2431,7 +2431,7 @@ glusterd_op_stage_send_resp(rpcsvc_request_t *req, int32_t op, int32_t status,
 
     ret = dict_allocate_and_serialize(rsp_dict, &rsp.dict.dict_val,
                                       &rsp.dict.dict_len);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SERL_LENGTH_GET_FAIL,
                "failed to get serialized length of dict");
         return ret;
@@ -2471,7 +2471,7 @@ glusterd_op_commit_send_resp(rpcsvc_request_t *req, int32_t op, int32_t status,
     if (rsp_dict) {
         ret = dict_allocate_and_serialize(rsp_dict, &rsp.dict.dict_val,
                                           &rsp.dict.dict_len);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0,
                    GD_MSG_DICT_SERL_LENGTH_GET_FAIL,
                    "failed to get serialized length of dict");
@@ -2501,7 +2501,7 @@ __glusterd_handle_incoming_friend_req(rpcsvc_request_t *req)
     GF_ASSERT(req);
     ret = xdr_to_generic(req->msg[0], &friend_req,
                          (xdrproc_t)xdr_gd1_mgmt_friend_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
@@ -2553,7 +2553,7 @@ __glusterd_handle_incoming_unfriend_req(rpcsvc_request_t *req)
     GF_ASSERT(req);
     ret = xdr_to_generic(req->msg[0], &friend_req,
                          (xdrproc_t)xdr_gd1_mgmt_friend_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
@@ -2671,7 +2671,7 @@ __glusterd_handle_friend_update(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &friend_req,
                          (xdrproc_t)xdr_gd1_mgmt_friend_update);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
@@ -2704,7 +2704,7 @@ __glusterd_handle_friend_update(rpcsvc_request_t *req)
 
         ret = dict_unserialize(friend_req.friends.friends_val,
                                friend_req.friends.friends_len, &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -2850,7 +2850,7 @@ __glusterd_handle_probe_query(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &probe_req,
                          (xdrproc_t)xdr_gd1_mgmt_probe_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode probe "
@@ -2968,7 +2968,7 @@ __glusterd_handle_cli_profile_volume(rpcsvc_request_t *req)
     GF_VALIDATE_OR_GOTO(this->name, conf, out);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
@@ -3093,7 +3093,7 @@ __glusterd_handle_mount(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &mnt_req,
                          (xdrproc_t)xdr_gf1_cli_mount_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode mount "
@@ -3113,7 +3113,7 @@ __glusterd_handle_mount(rpcsvc_request_t *req)
 
         ret = dict_unserialize(mnt_req.dict.dict_val, mnt_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -3185,7 +3185,7 @@ __glusterd_handle_umount(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &umnt_req,
                          (xdrproc_t)xdr_gf1_cli_umount_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode umount"
@@ -4258,7 +4258,7 @@ respond:
 
     ret = 0;
 out:
-    if (ret_bkp == -1) {
+    if (IS_ERROR(ret_bkp)) {
         rsp.op_ret = ret_bkp;
         rsp.op_errstr = "Volume does not exist";
         rsp.op_errno = EG_NOVOL;
@@ -4300,7 +4300,7 @@ __glusterd_handle_status_volume(rpcsvc_request_t *req)
     GF_ASSERT(conf);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
@@ -4315,7 +4315,7 @@ __glusterd_handle_status_volume(rpcsvc_request_t *req)
             goto out;
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize buffer");
@@ -4438,7 +4438,7 @@ __glusterd_handle_cli_clearlocks_volume(rpcsvc_request_t *req)
 
     ret = -1;
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
                "request received from cli");
@@ -4451,7 +4451,7 @@ __glusterd_handle_cli_clearlocks_volume(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to unserialize req-buffer to"
                    " dictionary");
@@ -4565,7 +4565,7 @@ __glusterd_handle_barrier(rpcsvc_request_t *req)
     GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
                "request received from cli");
@@ -4584,7 +4584,7 @@ __glusterd_handle_barrier(rpcsvc_request_t *req)
         goto out;
     }
     ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len, &dict);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                "Failed to unserialize "
                "request dictionary.");
@@ -4956,7 +4956,7 @@ __glusterd_handle_get_vol_opt(rpcsvc_request_t *req)
     GF_ASSERT(req);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to decode "
                  "request received from cli");
@@ -4972,7 +4972,7 @@ __glusterd_handle_get_vol_opt(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -5481,7 +5481,7 @@ glusterd_get_state(rpcsvc_request_t *req, dict_t *dict)
     ret = gf_asprintf(&ofilepath, "%s%s%s", odir,
                       ((odir[odirlen - 1] != '/') ? "/" : ""), filename);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         GF_FREE(odir);
         GF_FREE(filename);
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
@@ -5852,7 +5852,7 @@ __glusterd_handle_get_state(rpcsvc_request_t *req)
            "Received request to get state for glusterd");
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to decode "
                  "request received from cli");
@@ -5868,7 +5868,7 @@ __glusterd_handle_get_state(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -5990,7 +5990,7 @@ __glusterd_brick_rpc_notify(struct rpc_clnt *rpc, void *mydata,
              * is a restored brick with a snapshot pending. If so, we
              * need to stop the brick
              */
-            if (brickinfo->snap_status == -1) {
+            if (IS_ERROR(brickinfo->snap_status)) {
                 gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_SNAPSHOT_PENDING,
                        "Snapshot is pending on %s:%s. "
                        "Hence not starting the brick",

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -242,7 +242,7 @@ build_volfile_path(char *volume_id, char *path, size_t path_len,
         volid_ptr++;
 
         ret = glusterd_volinfo_find(volid_ptr, &volinfo);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_VOLINFO_GET_FAIL,
                    "Couldn't find volinfo");
             goto out;
@@ -277,7 +277,7 @@ build_volfile_path(char *volume_id, char *path, size_t path_len,
         volid_ptr++;
 
         ret = glusterd_volinfo_find(volid_ptr, &volinfo);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_log(this->name, GF_LOG_ERROR, "Couldn't find volinfo");
             goto out;
         }
@@ -298,7 +298,7 @@ build_volfile_path(char *volume_id, char *path, size_t path_len,
         volid_ptr++;
 
         ret = glusterd_volinfo_find(volid_ptr, &volinfo);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_log(this->name, GF_LOG_ERROR, "Couldn't find volinfo");
             goto out;
         }
@@ -318,7 +318,7 @@ build_volfile_path(char *volume_id, char *path, size_t path_len,
         volid_ptr++;
 
         ret = glusterd_volinfo_find(volid_ptr, &volinfo);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_VOLINFO_GET_FAIL,
                    "Couldn't find volinfo for volid=%s", volid_ptr);
             goto out;
@@ -327,7 +327,7 @@ build_volfile_path(char *volume_id, char *path, size_t path_len,
         glusterd_svc_build_shd_volfile_path(volinfo, path, path_len);
 
         ret = glusterd_svc_set_shd_pidfile(volinfo, dict);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SET_FAILED,
                    "Couldn't set pidfile in dict for volid=%s", volid_ptr);
             goto out;
@@ -354,7 +354,7 @@ build_volfile_path(char *volume_id, char *path, size_t path_len,
         /* this is to ensure that volname recvd from
            get_snap_volname_and_volinfo is free'd */
         free_ptr = volname;
-        if ((len < 0) || (len >= sizeof(path_prefix))) {
+        if (IS_ERROR(len) || (len >= sizeof(path_prefix))) {
             ret = -1;
             goto out;
         }
@@ -372,7 +372,7 @@ build_volfile_path(char *volume_id, char *path, size_t path_len,
         volid_ptr++;
 
         ret = glusterd_volinfo_find(volid_ptr, &volinfo);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_VOLINFO_GET_FAIL,
                    "Couldn't find volinfo");
             goto out;
@@ -406,14 +406,14 @@ build_volfile_path(char *volume_id, char *path, size_t path_len,
             goto out;
         }
         ret = glusterd_volinfo_find(vol, &volinfo);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_VOLINFO_GET_FAIL,
                    "Couldn't find volinfo");
             goto out;
         }
         ret = glusterd_get_client_per_brick_volfile(volinfo, volid_ptr, path,
                                                     path_len);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_NO_MEMORY,
                    "failed to get volinfo path");
             goto out;
@@ -436,7 +436,7 @@ build_volfile_path(char *volume_id, char *path, size_t path_len,
     }
 
     len = snprintf(path_prefix, sizeof(path_prefix), "%s/vols", priv->workdir);
-    if ((len < 0) || (len >= sizeof(path_prefix))) {
+    if (IS_ERROR(len) || (len >= sizeof(path_prefix))) {
         ret = -1;
         goto out;
     }
@@ -466,12 +466,12 @@ gotvolinfo:
 
     ret = snprintf(path, path_len, "%s/%s/%s.vol", path_prefix,
                    volinfo->volname, volid_ptr);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = sys_stat(path, &stbuf);
 
-    if ((ret == -1) && (errno == ENOENT)) {
+    if (IS_ERROR(ret) && (errno == ENOENT)) {
         if (snprintf(dup_volid, PATH_MAX, "%s", volid_ptr) >= PATH_MAX)
             goto out;
         if (!strchr(dup_volid, '.')) {
@@ -922,7 +922,7 @@ __server_getspec(rpcsvc_request_t *req)
 
     conf = this->private;
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_gf_getspec_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
@@ -953,7 +953,7 @@ __server_getspec(rpcsvc_request_t *req)
     else
         ret = snprintf(peerinfo->volname, sizeof(peerinfo->volname), "%s",
                        volume);
-    if (ret < 0 || ret >= sizeof(peerinfo->volname)) {
+    if (IS_ERROR(ret) || ret >= sizeof(peerinfo->volname)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_VOLINFO_GET_FAIL,
                "peerinfo->volname %s truncated or error occurred: "
                "(ret: %d)",
@@ -1059,14 +1059,14 @@ __server_getspec(rpcsvc_request_t *req)
 
         /* to allocate the proper buffer to hold the file data */
         ret = sys_stat(filename, &stbuf);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
                    "Unable to stat %s (%s)", filename, strerror(errno));
             goto fail;
         }
 
         spec_fd = open(filename, O_RDONLY);
-        if (spec_fd < 0) {
+        if (IS_ERROR(spec_fd)) {
             gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
                    "Unable to open %s (%s)", filename, strerror(errno));
             goto fail;
@@ -1106,7 +1106,7 @@ fail:
     GF_FREE(brick_name);
 
     rsp.op_ret = ret;
-    if (rsp.op_ret < 0)
+    if (IS_ERROR(rsp.op_ret))
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_MOUNT_REQ_FAIL,
                "Failed to mount the volume");
 
@@ -1156,7 +1156,7 @@ __server_event_notify(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &args,
                          (xdrproc_t)xdr_gf_event_notify_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto fail;
     }
@@ -1354,7 +1354,7 @@ __glusterd_mgmt_hndsk_versions(rpcsvc_request_t *req)
     conf = this->private;
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_gf_mgmt_hndsk_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         goto out;
@@ -1454,7 +1454,7 @@ __glusterd_mgmt_hndsk_versions_ack(rpcsvc_request_t *req)
     conf = this->private;
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_gf_mgmt_hndsk_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         goto out;
@@ -1531,7 +1531,7 @@ __server_get_volume_info(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &vol_info_req,
                          (xdrproc_t)xdr_gf_get_volume_info_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /* failed to decode msg */
         req->rpc_err = GARBAGE_ARGS;
         goto out;
@@ -1552,7 +1552,7 @@ __server_get_volume_info(rpcsvc_request_t *req)
 
         ret = dict_unserialize(vol_info_req.dict.dict_val,
                                vol_info_req.dict.dict_len, &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -1676,7 +1676,7 @@ __server_get_snap_info(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &snap_info_req,
                          (xdrproc_t)xdr_gf_getsnap_name_uuid_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode management handshake response");
@@ -1693,7 +1693,7 @@ __server_get_snap_info(rpcsvc_request_t *req)
 
         ret = dict_unserialize(snap_info_req.dict.dict_val,
                                snap_info_req.dict.dict_len, &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, EINVAL,
                    GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "Failed to unserialize dictionary");
@@ -1941,7 +1941,8 @@ gd_validate_peer_op_version(xlator_t *this, glusterd_peerinfo_t *peerinfo,
 out:
     if (peerinfo)
         gf_msg_debug((this ? this->name : "glusterd"), 0, "Peer %s %s",
-                     peerinfo->hostname, ((ret < 0) ? "rejected" : "accepted"));
+                     peerinfo->hostname,
+                     (IS_ERROR(ret) ? "rejected" : "accepted"));
     return ret;
 }
 
@@ -1974,7 +1975,7 @@ __glusterd_mgmt_hndsk_version_ack_cbk(struct rpc_req *req, struct iovec *iov,
         goto out;
     }
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         snprintf(msg, sizeof(msg),
                  "Error through RPC layer, retry again later");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_RPC_LAYER_ERROR, "%s", msg);
@@ -1983,14 +1984,14 @@ __glusterd_mgmt_hndsk_version_ack_cbk(struct rpc_req *req, struct iovec *iov,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_mgmt_hndsk_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(msg, sizeof(msg), "Failed to decode XDR");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL, "%s", msg);
         peerctx->errstr = gf_strdup(msg);
         goto out;
     }
 
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         ret = -1;
         snprintf(msg, sizeof(msg),
                  "Failed to get handshake ack from remote server");
@@ -2084,7 +2085,7 @@ __glusterd_mgmt_hndsk_version_cbk(struct rpc_req *req, struct iovec *iov,
         goto out;
     }
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         ret = -1;
         snprintf(msg, sizeof(msg),
                  "Error through RPC layer, retry again later");
@@ -2094,7 +2095,7 @@ __glusterd_mgmt_hndsk_version_cbk(struct rpc_req *req, struct iovec *iov,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_mgmt_hndsk_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(msg, sizeof(msg),
                  "Failed to decode management "
                  "handshake response");
@@ -2107,7 +2108,7 @@ __glusterd_mgmt_hndsk_version_cbk(struct rpc_req *req, struct iovec *iov,
                                  rsp.hndsk.hndsk_len, ret, op_errno, out);
 
     op_errno = rsp.op_errno;
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, GD_MSG_VERS_GET_FAIL,
                "failed to get the 'versions' from peer (%s)",
                req->conn->trans->peerinfo.identifier);
@@ -2116,7 +2117,7 @@ __glusterd_mgmt_hndsk_version_cbk(struct rpc_req *req, struct iovec *iov,
 
     /* Check if peer can be part of cluster */
     ret = gd_validate_peer_op_version(this, peerinfo, dict, &peerctx->errstr);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_OP_VERSION_MISMATCH,
                "failed to validate the operating version of peer (%s)",
                peerinfo->hostname);
@@ -2354,7 +2355,7 @@ __glusterd_peer_dump_version_cbk(struct rpc_req *req, struct iovec *iov,
         goto out;
     }
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         snprintf(msg, sizeof(msg),
                  "Error through RPC layer, retry again later");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_RPC_LAYER_ERROR, "%s", msg);
@@ -2363,13 +2364,13 @@ __glusterd_peer_dump_version_cbk(struct rpc_req *req, struct iovec *iov,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_dump_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(msg, sizeof(msg), "Failed to decode XDR");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL, "%s", msg);
         peerctx->errstr = gf_strdup(msg);
         goto out;
     }
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         snprintf(msg, sizeof(msg),
                  "Failed to get the 'versions' from remote server");
         gf_msg(frame->this->name, GF_LOG_ERROR, 0, GD_MSG_VERS_GET_FAIL, "%s",

--- a/xlators/mgmt/glusterd/src/glusterd-handshake.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handshake.c
@@ -1100,7 +1100,7 @@ __server_getspec(rpcsvc_request_t *req)
     }
     /* convert to XDR */
 fail:
-    if (spec_fd >= 0)
+    if (IS_SUCCESS(spec_fd))
         sys_close(spec_fd);
 
     GF_FREE(brick_name);

--- a/xlators/mgmt/glusterd/src/glusterd-hooks.c
+++ b/xlators/mgmt/glusterd/src/glusterd-hooks.c
@@ -111,7 +111,7 @@ glusterd_hooks_create_hooks_directory(char *basedir)
             continue;
 
         len = snprintf(path, sizeof(path), "%s/%s", version_dir, cmd_subdir);
-        if ((len < 0) || (len >= sizeof(path))) {
+        if (IS_ERROR((len)) || (len >= sizeof(path))) {
             ret = -1;
             goto out;
         }
@@ -125,7 +125,7 @@ glusterd_hooks_create_hooks_directory(char *basedir)
         for (type = GD_COMMIT_HOOK_PRE; type < GD_COMMIT_HOOK_MAX; type++) {
             len = snprintf(path, sizeof(path), "%s/%s/%s", version_dir,
                            cmd_subdir, type_subdir[type]);
-            if ((len < 0) || (len >= sizeof(path))) {
+            if (IS_ERROR((len)) || (len >= sizeof(path))) {
                 ret = -1;
                 goto out;
             }

--- a/xlators/mgmt/glusterd/src/glusterd-hooks.h
+++ b/xlators/mgmt/glusterd/src/glusterd-hooks.h
@@ -16,7 +16,7 @@
     do {                                                                       \
         int32_t len;                                                           \
         len = snprintf(path, PATH_MAX, "%s/hooks/%d", priv->workdir, version); \
-        if (len < 0) {                                                         \
+        if (IS_ERROR(len)) {                                                   \
             path[0] = 0;                                                       \
         }                                                                      \
     } while (0)

--- a/xlators/mgmt/glusterd/src/glusterd-log-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-log-ops.c
@@ -40,7 +40,7 @@ __glusterd_handle_log_rotate(rpcsvc_request_t *req)
     GF_ASSERT(this);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         goto out;
@@ -52,7 +52,7 @@ __glusterd_handle_log_rotate(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt-handler.c
@@ -141,7 +141,7 @@ glusterd_handle_mgmt_v3_lock_fn(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &lock_req,
                          (xdrproc_t)xdr_gd1_mgmt_v3_lock_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode lock "
                "request received from peer");
@@ -263,7 +263,7 @@ glusterd_mgmt_v3_pre_validate_send_resp(rpcsvc_request_t *req, int32_t op,
 
     ret = dict_allocate_and_serialize(rsp_dict, &rsp.dict.dict_val,
                                       &rsp.dict.dict_len);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SERL_LENGTH_GET_FAIL,
                "failed to get serialized length of dict");
         goto out;
@@ -297,7 +297,7 @@ glusterd_handle_pre_validate_fn(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &op_req,
                          (xdrproc_t)xdr_gd1_mgmt_v3_pre_val_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode pre validation "
                "request received from peer");
@@ -390,7 +390,7 @@ glusterd_mgmt_v3_brick_op_send_resp(rpcsvc_request_t *req, int32_t op,
 
     ret = dict_allocate_and_serialize(rsp_dict, &rsp.dict.dict_val,
                                       &rsp.dict.dict_len);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SERL_LENGTH_GET_FAIL,
                "failed to get serialized length of dict");
         goto out;
@@ -423,7 +423,7 @@ glusterd_handle_brick_op_fn(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &op_req,
                          (xdrproc_t)xdr_gd1_mgmt_v3_brick_op_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode brick op "
                "request received from peer");
@@ -517,7 +517,7 @@ glusterd_mgmt_v3_commit_send_resp(rpcsvc_request_t *req, int32_t op,
 
     ret = dict_allocate_and_serialize(rsp_dict, &rsp.dict.dict_val,
                                       &rsp.dict.dict_len);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SERL_LENGTH_GET_FAIL,
                "failed to get serialized length of dict");
         goto out;
@@ -551,7 +551,7 @@ glusterd_handle_commit_fn(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &op_req,
                          (xdrproc_t)xdr_gd1_mgmt_v3_commit_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode commit "
                "request received from peer");
@@ -645,7 +645,7 @@ glusterd_mgmt_v3_post_validate_send_resp(rpcsvc_request_t *req, int32_t op,
 
     ret = dict_allocate_and_serialize(rsp_dict, &rsp.dict.dict_val,
                                       &rsp.dict.dict_len);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_SERL_LENGTH_GET_FAIL,
                "failed to get serialized length of dict");
         goto out;
@@ -678,7 +678,7 @@ glusterd_handle_post_validate_fn(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &op_req,
                          (xdrproc_t)xdr_gd1_mgmt_v3_post_val_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode post validation "
                "request received from peer");
@@ -843,7 +843,7 @@ glusterd_handle_mgmt_v3_unlock_fn(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &lock_req,
                          (xdrproc_t)xdr_gd1_mgmt_v3_unlock_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode unlock "
                "request received from peer");

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.c
@@ -105,7 +105,7 @@ gd_mgmt_v3_collate_errors(struct syncargs *args, int op_ret, int op_errno,
         if (args->errstr) {
             len = snprintf(err_str, sizeof(err_str), "%s\n%s", args->errstr,
                            op_err);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(err_str, "<error>");
             }
             GF_FREE(args->errstr);
@@ -523,7 +523,7 @@ gd_mgmt_v3_lock_cbk_fn(struct rpc_req *req, struct iovec *iov, int count,
     frame->local = NULL;
     frame->cookie = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         op_errno = ENOTCONN;
         goto out;
     }
@@ -531,7 +531,7 @@ gd_mgmt_v3_lock_cbk_fn(struct rpc_req *req, struct iovec *iov, int count,
     GF_VALIDATE_OR_GOTO_WITH_ERROR(this->name, iov, out, op_errno, EINVAL);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_v3_lock_rsp);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     gf_uuid_copy(args->uuid, rsp.uuid);
@@ -700,7 +700,7 @@ out:
                           "Another transaction is in progress. "
                           "Please try again after some time.");
 
-        if (ret == -1)
+        if (IS_ERROR(ret))
             *op_errstr = NULL;
 
         ret = -1;
@@ -803,7 +803,7 @@ gd_mgmt_v3_pre_validate_cbk_fn(struct rpc_req *req, struct iovec *iov,
     frame->local = NULL;
     frame->cookie = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         op_errno = ENOTCONN;
         goto out;
     }
@@ -811,7 +811,7 @@ gd_mgmt_v3_pre_validate_cbk_fn(struct rpc_req *req, struct iovec *iov,
     GF_VALIDATE_OR_GOTO_WITH_ERROR(this->name, iov, out, op_errno, EINVAL);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_v3_pre_val_rsp);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (rsp.dict.dict_len) {
@@ -819,7 +819,7 @@ gd_mgmt_v3_pre_validate_cbk_fn(struct rpc_req *req, struct iovec *iov,
         rsp_dict = dict_new();
 
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &rsp_dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             free(rsp.dict.dict_val);
             goto out;
         } else {
@@ -972,7 +972,7 @@ glusterd_mgmt_v3_pre_validate(glusterd_op_t op, dict_t *req_dict,
                               "Pre-validation failed "
                               "on localhost. Please "
                               "check log file for details");
-            if (ret == -1)
+            if (IS_ERROR(ret))
                 *op_errstr = NULL;
 
             ret = -1;
@@ -1160,7 +1160,7 @@ gd_mgmt_v3_brick_op_cbk_fn(struct rpc_req *req, struct iovec *iov, int count,
        status of the operation and then worry about iov (if the status of
        the command is success)
     */
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         op_errno = ENOTCONN;
         goto out;
     }
@@ -1168,7 +1168,7 @@ gd_mgmt_v3_brick_op_cbk_fn(struct rpc_req *req, struct iovec *iov, int count,
     GF_VALIDATE_OR_GOTO_WITH_ERROR(this->name, iov, out, op_errno, EINVAL);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_v3_brick_op_rsp);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (rsp.dict.dict_len) {
@@ -1176,7 +1176,7 @@ gd_mgmt_v3_brick_op_cbk_fn(struct rpc_req *req, struct iovec *iov, int count,
         rsp_dict = dict_new();
 
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &rsp_dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         } else {
             rsp_dict->extra_stdfree = rsp.dict.dict_val;
@@ -1320,7 +1320,7 @@ glusterd_mgmt_v3_brick_op(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
                               "Brick ops failed "
                               "on localhost. Please "
                               "check log file for details");
-            if (ret == -1)
+            if (IS_ERROR(ret))
                 *op_errstr = NULL;
 
             ret = -1;
@@ -1421,7 +1421,7 @@ gd_mgmt_v3_commit_cbk_fn(struct rpc_req *req, struct iovec *iov, int count,
     frame->local = NULL;
     frame->cookie = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         op_errno = ENOTCONN;
         goto out;
     }
@@ -1429,7 +1429,7 @@ gd_mgmt_v3_commit_cbk_fn(struct rpc_req *req, struct iovec *iov, int count,
     GF_VALIDATE_OR_GOTO_WITH_ERROR(this->name, iov, out, op_errno, EINVAL);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_v3_commit_rsp);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (rsp.dict.dict_len) {
@@ -1437,7 +1437,7 @@ gd_mgmt_v3_commit_cbk_fn(struct rpc_req *req, struct iovec *iov, int count,
         rsp_dict = dict_new();
 
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &rsp_dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             free(rsp.dict.dict_val);
             goto out;
         } else {
@@ -1587,7 +1587,7 @@ glusterd_mgmt_v3_commit(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
                               "Commit failed "
                               "on localhost. Please "
                               "check log file for details.");
-            if (ret == -1)
+            if (IS_ERROR(ret))
                 *op_errstr = NULL;
 
             ret = -1;
@@ -1687,7 +1687,7 @@ gd_mgmt_v3_post_validate_cbk_fn(struct rpc_req *req, struct iovec *iov,
     frame->local = NULL;
     frame->cookie = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         op_errno = ENOTCONN;
         goto out;
     }
@@ -1695,7 +1695,7 @@ gd_mgmt_v3_post_validate_cbk_fn(struct rpc_req *req, struct iovec *iov,
     GF_VALIDATE_OR_GOTO_WITH_ERROR(this->name, iov, out, op_errno, EINVAL);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_v3_post_val_rsp);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     gf_uuid_copy(args->uuid, rsp.uuid);
@@ -1817,7 +1817,7 @@ glusterd_mgmt_v3_post_validate(glusterd_op_t op, int32_t op_ret, dict_t *dict,
                               "Post-validation failed "
                               "on localhost. Please check "
                               "log file for details");
-            if (ret == -1)
+            if (IS_ERROR(ret))
                 *op_errstr = NULL;
 
             ret = -1;
@@ -1908,7 +1908,7 @@ gd_mgmt_v3_unlock_cbk_fn(struct rpc_req *req, struct iovec *iov, int count,
     frame->local = NULL;
     frame->cookie = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         op_errno = ENOTCONN;
         goto out;
     }
@@ -1916,7 +1916,7 @@ gd_mgmt_v3_unlock_cbk_fn(struct rpc_req *req, struct iovec *iov, int count,
     GF_VALIDATE_OR_GOTO_WITH_ERROR(this->name, iov, out, op_errno, EINVAL);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_v3_unlock_rsp);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     gf_uuid_copy(args->uuid, rsp.uuid);

--- a/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
@@ -159,7 +159,7 @@ parse_mount_pattern_desc(gf_mount_spec_t *mspec, char *pdesc)
                     pnum++;
             }
         }
-        if (incl >= 0) {
+        if (IS_SUCCESS(incl)) {
             pnc = 0;
             for (pcc = mspec->patterns[incl].components; *pcc; pcc++)
                 pnc++;
@@ -174,7 +174,7 @@ parse_mount_pattern_desc(gf_mount_spec_t *mspec, char *pdesc)
 
         cc = pat->components;
         /* copy over included component set */
-        if (incl >= 0) {
+        if (IS_SUCCESS(incl)) {
             memcpy(pat->components, mspec->patterns[incl].components,
                    pnc * sizeof(*pat->components));
             cc += pnc;
@@ -410,7 +410,7 @@ _arg_parse_uid(char *val, void *data)
     if (!pw)
         return -EINVAL;
 
-    if (*(int *)data >= 0)
+    if (IS_SUCCESS(*(int *)data))
         /* uid ambiguity, already found */
         return -EINVAL;
 
@@ -661,7 +661,7 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
          move it over to the final place */
     *cookieswitch = '/';
     ret = sys_symlink(mntlink, mtptemp);
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         ret = sys_rename(mtptemp, cookie);
     *cookieswitch = '\0';
     if (IS_ERROR(ret)) {

--- a/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mountbroker.c
@@ -288,7 +288,7 @@ make_georep_mountspec(gf_mount_spec_t *mspec, const char *volnames, char *user,
 
     ret = gf_asprintf(&georep_mnt_desc, georep_mnt_desc_template,
                       GF_CLIENT_PID_GSYNCD, user, logdir, meetspec);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         georep_mnt_desc = NULL;
         goto out;
     }
@@ -547,7 +547,7 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
         uid = evaluate_mount_request(this, mspec, argdict);
         break;
     }
-    if (uid < 0) {
+    if (IS_ERROR(uid)) {
         *op_errno = -uid;
         if (!found_label) {
             gf_msg(this->name, GF_LOG_ERROR, *op_errno,
@@ -583,7 +583,7 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
          creation, see below */
     ret = gf_asprintf(&mtptemp, "%s/user%d/mtpt-%s-XXXXXX/cookie",
                       mountbroker_root, uid, label);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         mtptemp = NULL;
         *op_errno = ENOMEM;
         goto out;
@@ -599,14 +599,14 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
         ret = sys_chown(mtptemp, uid, 0);
     else if (errno == EEXIST)
         ret = 0;
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         *op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, *op_errno, GD_MSG_SYSCALL_FAIL,
                "Mountbroker User directory creation failed");
         goto out;
     }
     ret = sys_lstat(mtptemp, &st);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         *op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, *op_errno, GD_MSG_SYSCALL_FAIL,
                "stat on mountbroker user directory failed");
@@ -632,7 +632,7 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
 
     /*** occupy an entry in the hive dir via mkstemp */
     ret = gf_asprintf(&cookie, "%s/" MB_HIVE "/mntXXXXXX", mountbroker_root);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         cookie = NULL;
         *op_errno = ENOMEM;
         goto out;
@@ -640,7 +640,7 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
     orig_umask = umask(S_IRWXG | S_IRWXO);
     ret = mkstemp(cookie);
     umask(orig_umask);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         *op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, *op_errno, GD_MSG_SYSCALL_FAIL,
                "Mountbroker cookie file creation failed");
@@ -652,7 +652,7 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
     sla = strchr(sla - 1, '/');
     GF_ASSERT(sla);
     ret = gf_asprintf(&mntlink, "../user%d%s", uid, sla);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         *op_errno = ENOMEM;
         goto out;
     }
@@ -661,10 +661,10 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
          move it over to the final place */
     *cookieswitch = '/';
     ret = sys_symlink(mntlink, mtptemp);
-    if (ret != -1)
+    if (ret >= 0)
         ret = sys_rename(mtptemp, cookie);
     *cookieswitch = '\0';
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         *op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, *op_errno, GD_MSG_SYSCALL_FAIL,
                "symlink or rename failed");
@@ -678,7 +678,7 @@ glusterd_do_mount(char *label, dict_t *argdict, char **path, int *op_errno)
     seq_dict_foreach(argdict, _runner_add, &runner);
     runner_add_arg(&runner, mtptemp);
     ret = runner_run_reuse(&runner);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         *op_errno = EIO; /* XXX hacky fake */
         runner_log(&runner, "", GF_LOG_ERROR, "command failed");
     }

--- a/xlators/mgmt/glusterd/src/glusterd-op-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-op-sm.c
@@ -377,7 +377,7 @@ static char *glusterd_op_sm_event_names[] = {
 char *
 glusterd_op_sm_state_name_get(int state)
 {
-    if (state < 0 || state >= GD_OP_STATE_MAX)
+    if (IS_ERROR(state) || state >= GD_OP_STATE_MAX)
         return glusterd_op_sm_state_names[GD_OP_STATE_MAX];
     return glusterd_op_sm_state_names[state];
 }
@@ -385,7 +385,7 @@ glusterd_op_sm_state_name_get(int state)
 char *
 glusterd_op_sm_event_name_get(int event)
 {
-    if (event < 0 || event >= GD_OP_EVENT_MAX)
+    if (IS_ERROR(event) || event >= GD_OP_EVENT_MAX)
         return glusterd_op_sm_event_names[GD_OP_EVENT_MAX];
     return glusterd_op_sm_event_names[event];
 }
@@ -778,7 +778,7 @@ glusterd_validate_shared_storage(char *value, char *errstr)
 
     len = snprintf(hook_script, sizeof(hook_script),
                    "%s" GLUSTERD_SHRD_STRG_HOOK_SCRIPT, conf->workdir);
-    if ((len < 0) || (len >= sizeof(hook_script))) {
+    if (IS_ERROR((len)) || (len >= sizeof(hook_script))) {
         ret = -1;
         goto out;
     }
@@ -791,7 +791,7 @@ glusterd_validate_shared_storage(char *value, char *errstr)
                        "Please install the hook-script "
                        "and retry",
                        hook_script);
-        if (len < 0) {
+        if (IS_ERROR(len)) {
             strncpy(errstr, "<error>", PATH_MAX);
         }
         gf_msg(this->name, GF_LOG_ERROR, ENOENT, GD_MSG_FILE_OP_FAILED, "%s",
@@ -1139,7 +1139,7 @@ glusterd_op_stage_set_volume(dict_t *dict, char **op_errstr)
             goto out;
 
         exists = glusterd_check_option_exists(key, &key_fixed);
-        if (exists == -1) {
+        if (IS_ERROR(exists)) {
             ret = -1;
             goto out;
         }
@@ -1536,7 +1536,7 @@ glusterd_op_stage_reset_volume(dict_t *dict, char **op_errstr)
 
     if (strcmp(key, "all")) {
         exists = glusterd_check_option_exists(key, &key_fixed);
-        if (exists == -1) {
+        if (IS_ERROR(exists)) {
             ret = -1;
             goto out;
         }
@@ -2203,7 +2203,7 @@ glusterd_op_reset_volume(dict_t *dict, char **op_rspstr)
         quorum_action = _gf_true;
 
     ret = glusterd_options_reset(volinfo, key, &is_force);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_asprintf(op_rspstr, "Volume reset : failed");
     } else if (is_force & GD_OP_PROTECTED) {
         if (is_force & GD_OP_UNPROTECTED) {
@@ -2647,7 +2647,7 @@ glusterd_set_shared_storage(dict_t *dict, char *key, char *value,
     }
 
     ret = mkdir_p(GLUSTER_SHARED_STORAGE_BRICK_DIR, 0755, _gf_true);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         snprintf(errstr, PATH_MAX,
                  "Failed to create shared "
                  "storage brick(%s). "
@@ -2667,7 +2667,7 @@ glusterd_set_shared_storage(dict_t *dict, char *key, char *value,
                        "is_originator=0,local_node_hostname=%s",
                        local_node_hostname);
     }
-    if ((len < 0) || (len >= sizeof(hooks_args))) {
+    if (IS_ERROR((len)) || (len >= sizeof(hooks_args))) {
         ret = -1;
         goto out;
     }
@@ -2763,7 +2763,7 @@ glusterd_op_set_volume(dict_t *dict, char **errstr)
         }
     }
 
-    for (count = 1; ret != -1; count++) {
+    for (count = 1; !IS_ERROR(ret); count++) {
         keylen = snprintf(keystr, sizeof(keystr), "key%d", count);
         ret = dict_get_strn(dict, keystr, keylen, &key);
         if (ret)
@@ -2780,7 +2780,7 @@ glusterd_op_set_volume(dict_t *dict, char **errstr)
 
         if (strcmp(key, "config.memory-accounting") == 0) {
             ret = gf_string2boolean(value, &volinfo->memory_accounting);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 gf_msg(this->name, GF_LOG_ERROR, EINVAL, GD_MSG_INVALID_ENTRY,
                        "Invalid value in key-value pair.");
                 goto out;
@@ -2806,7 +2806,7 @@ glusterd_op_set_volume(dict_t *dict, char **errstr)
         }
 
         ret = glusterd_check_ganesha_cmd(key, value, errstr, dict);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto out;
 
         if (!is_key_glusterd_hooks_friendly(key)) {
@@ -3231,7 +3231,7 @@ _add_remove_bricks_to_dict(dict_t *dict, glusterd_volinfo_t *volinfo,
 
         keylen = snprintf(dict_key, sizeof(dict_key), "%s.%s", prefix,
                           brick_key);
-        if ((keylen < 0) || (keylen >= sizeof(dict_key))) {
+        if (IS_ERROR((keylen)) || (keylen >= sizeof(dict_key))) {
             ret = -1;
             goto out;
         }
@@ -4953,7 +4953,7 @@ glusterd_op_commit_hook(glusterd_op_t op, dict_t *op_ctx,
     GLUSTERD_GET_HOOKS_DIR(hookdir, GLUSTERD_HOOK_VER, priv);
     len = snprintf(scriptdir, sizeof(scriptdir), "%s/%s/%s", hookdir,
                    cmd_subdir, type_subdir);
-    if ((len < 0) || (len >= sizeof(scriptdir))) {
+    if (IS_ERROR((len)) || (len >= sizeof(scriptdir))) {
         return -1;
     }
 
@@ -6346,7 +6346,7 @@ _add_hxlator_to_dict(dict_t *dict, glusterd_volinfo_t *volinfo, int index,
     }
     keylen = snprintf(key, sizeof(key), "xl-%d", count);
     ret = gf_asprintf(&xname, "%s-%s-%d", volinfo->volname, xl_type, index);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_set_dynstrn(dict, key, keylen, xname);
@@ -6590,7 +6590,7 @@ fill_shd_status_for_local_bricks(dict_t *dict, glusterd_volinfo_t *volinfo,
     if (type == PER_HEAL_XL) {
         cmd_replica_index = get_replica_index_for_per_replica_cmd(volinfo,
                                                                   req_dict);
-        if (cmd_replica_index == -1) {
+        if (IS_ERROR(cmd_replica_index)) {
             gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_REPLICA_INDEX_GET_FAIL,
                    "Could not find the "
                    "replica index for per replica type command");
@@ -6769,13 +6769,13 @@ glusterd_bricks_select_heal_volume(dict_t *dict, char **op_errstr,
     }
     ret = glusterd_shd_select_brick_xlator(dict, heal_op, volinfo, &index,
                                            &hxlator_count, rsp_dict);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
     if (!hxlator_count)
         goto out;
-    if (hxlator_count == -1) {
+    if (IS_ERROR(hxlator_count)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_XLATOR_COUNT_GET_FAIL,
                "Could not determine the"
                "translator count");

--- a/xlators/mgmt/glusterd/src/glusterd-pmap.c
+++ b/xlators/mgmt/glusterd/src/glusterd-pmap.c
@@ -38,7 +38,7 @@ pmap_port_isfree(int port)
     sin.sin_port = hton16(port);
 
     sock = socket(PF_INET, SOCK_STREAM, 0);
-    if (sock == -1)
+    if (IS_ERROR(sock))
         return -1;
 
     ret = bind(sock, (struct sockaddr *)&sin, sizeof(sin));
@@ -436,7 +436,7 @@ __gluster_pmap_portbybrick(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &args,
                          (xdrproc_t)xdr_pmap_port_by_brick_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto fail;
     }
@@ -478,7 +478,7 @@ __gluster_pmap_brickbyport(rpcsvc_request_t *req)
 
     ret = xdr_to_generic(req->msg[0], &args,
                          (xdrproc_t)xdr_pmap_brick_by_port_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto fail;
     }
@@ -515,7 +515,7 @@ __gluster_pmap_signin(rpcsvc_request_t *req)
     glusterd_brickinfo_t *brickinfo = NULL;
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_pmap_signin_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto fail;
     }
@@ -567,7 +567,7 @@ __gluster_pmap_signout(rpcsvc_request_t *req)
     GF_VALIDATE_OR_GOTO(this->name, conf, fail);
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_pmap_signout_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         goto fail;

--- a/xlators/mgmt/glusterd/src/glusterd-proc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-proc-mgmt.c
@@ -28,32 +28,32 @@ glusterd_proc_init(glusterd_proc_t *proc, char *name, char *pidfile,
     int ret = -1;
 
     ret = snprintf(proc->name, sizeof(proc->name), "%s", name);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = snprintf(proc->pidfile, sizeof(proc->pidfile), "%s", pidfile);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = snprintf(proc->logdir, sizeof(proc->logdir), "%s", logdir);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = snprintf(proc->logfile, sizeof(proc->logfile), "%s", logfile);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = snprintf(proc->volfile, sizeof(proc->volfile), "%s", volfile);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = snprintf(proc->volfileid, sizeof(proc->volfileid), "%s", volfileid);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = snprintf(proc->volfileserver, sizeof(proc->volfileserver), "%s",
                    volfileserver);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
 out:

--- a/xlators/mgmt/glusterd/src/glusterd-quota.c
+++ b/xlators/mgmt/glusterd/src/glusterd-quota.c
@@ -65,7 +65,7 @@
         else                                                                   \
             _crawl_pid_len = snprintf(piddir, PATH_MAX,                        \
                                       "%s/run/quota/disable", _volpath);       \
-        if ((_crawl_pid_len < 0) || (_crawl_pid_len >= PATH_MAX)) {            \
+        if (IS_ERROR((_crawl_pid_len)) || (_crawl_pid_len >= PATH_MAX)) {      \
             piddir[0] = 0;                                                     \
         }                                                                      \
     } while (0)
@@ -182,7 +182,7 @@ __glusterd_handle_quota(rpcsvc_request_t *req)
     GF_ASSERT(conf);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         goto out;
@@ -194,7 +194,7 @@ __glusterd_handle_quota(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -260,7 +260,7 @@ glusterd_check_if_quota_trans_enabled(glusterd_volinfo_t *volinfo)
     int flag = _gf_false;
 
     flag = glusterd_volinfo_get_boolean(volinfo, VKEY_FEATURES_QUOTA);
-    if (flag == -1) {
+    if (IS_ERROR(flag)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_QUOTA_GET_STAT_FAIL,
                "failed to get the quota status");
         ret = -1;
@@ -331,7 +331,7 @@ _glusterd_quota_initiate_fs_crawl(glusterd_conf_t *priv,
     GLUSTERD_REMOVE_SLASH_FROM_PATH(brick->path, brickpath);
     len = snprintf(logfile, sizeof(logfile),
                    DEFAULT_QUOTA_CRAWL_LOG_DIRECTORY "/%s.log", brickpath);
-    if ((len < 0) || (len >= sizeof(vol_id))) {
+    if (IS_ERROR((len)) || (len >= sizeof(vol_id))) {
         ret = -1;
         goto out;
     }
@@ -343,7 +343,7 @@ _glusterd_quota_initiate_fs_crawl(glusterd_conf_t *priv,
 
     len = snprintf(vol_id, sizeof(vol_id), "client_per_brick/%s.%s.%s.%s.vol",
                    volinfo->volname, "client", brick->hostname, brickpath);
-    if ((len < 0) || (len >= sizeof(vol_id))) {
+    if (IS_ERROR((len)) || (len >= sizeof(vol_id))) {
         ret = -1;
         goto out;
     }
@@ -365,14 +365,14 @@ _glusterd_quota_initiate_fs_crawl(glusterd_conf_t *priv,
     synclock_unlock(&priv->big_lock);
     ret = runner_run_reuse(&runner);
     synclock_lock(&priv->big_lock);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         runner_log(&runner, "glusterd", GF_LOG_DEBUG, "command failed");
         runner_end(&runner);
         goto out;
     }
     runner_end(&runner);
-
-    if ((pid = fork()) < 0) {
+    pid = fork();
+    if (IS_ERROR(pid)) {
         gf_msg(THIS->name, GF_LOG_WARNING, 0, GD_MSG_FORK_FAIL,
                "fork from parent failed");
         gf_umount_lazy("glusterd", mountdir, 1);
@@ -383,7 +383,7 @@ _glusterd_quota_initiate_fs_crawl(glusterd_conf_t *priv,
          * blocking call below
          */
         pid = fork();
-        if (pid < 0) {
+        if (IS_ERROR(pid)) {
             gf_umount_lazy("glusterd", mountdir, 1);
             _exit(EXIT_FAILURE);
         } else if (pid > 0) {
@@ -391,7 +391,7 @@ _glusterd_quota_initiate_fs_crawl(glusterd_conf_t *priv,
         }
 
         ret = chdir(mountdir);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(THIS->name, GF_LOG_WARNING, errno, GD_MSG_DIR_OP_FAILED,
                    "chdir %s failed", mountdir);
             gf_umount_lazy("glusterd", mountdir, 1);
@@ -421,7 +421,7 @@ _glusterd_quota_initiate_fs_crawl(glusterd_conf_t *priv,
 #endif
         }
 
-        if (runner_start(&runner) == -1) {
+        if (IS_ERROR(runner_start(&runner))) {
             gf_umount_lazy("glusterd", mountdir, 1);
             _exit(EXIT_FAILURE);
         }
@@ -749,7 +749,7 @@ glusterd_quota_disable(glusterd_volinfo_t *volinfo, char **op_errstr,
     GF_VALIDATE_OR_GOTO(this->name, op_errstr, out);
 
     ret = glusterd_check_if_quota_trans_enabled(volinfo);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         *op_errstr = gf_strdup("Quota is already disabled");
         goto out;
     }
@@ -832,7 +832,7 @@ glusterd_set_quota_limit(char *volname, char *path, char *hard_limit,
     if (!soft_limit) {
         ret = sys_lgetxattr(abspath, key, (void *)&existing_limit,
                             sizeof(existing_limit));
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             switch (errno) {
 #if defined(ENOATTR) && (ENOATTR != ENODATA)
                 case ENODATA: /* FALLTHROUGH */
@@ -870,7 +870,7 @@ glusterd_set_quota_limit(char *volname, char *path, char *hard_limit,
 
     ret = sys_lsetxattr(abspath, key, (char *)(void *)&new_limit,
                         sizeof(new_limit), 0);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_asprintf(op_errstr,
                     "setxattr of %s failed on %s."
                     " Reason : %s",
@@ -1026,7 +1026,7 @@ glusterd_copy_to_tmp_file(int src_fd, int dst_fd, int qconf_line_sz)
             goto out;
         }
         ret = sys_write(dst_fd, (void *)buf, bytes_read);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, errno,
                    GD_MSG_QUOTA_CONF_WRITE_FAIL,
                    "write into quota.conf failed.");
@@ -1057,13 +1057,13 @@ glusterd_store_quota_conf_upgrade(glusterd_volinfo_t *volinfo)
     GF_ASSERT(this);
 
     fd = gf_store_mkstemp(volinfo->quota_conf_shandle);
-    if (fd < 0) {
+    if (IS_ERROR(fd)) {
         ret = -1;
         goto out;
     }
 
     conf_fd = open(volinfo->quota_conf_shandle->path, O_RDONLY);
-    if (conf_fd == -1) {
+    if (IS_ERROR(conf_fd)) {
         ret = -1;
         goto out;
     }
@@ -1080,12 +1080,12 @@ glusterd_store_quota_conf_upgrade(glusterd_volinfo_t *volinfo)
         ret = quota_conf_read_gfid(conf_fd, gfid, &type, 1.1);
         if (ret == 0)
             break;
-        else if (ret < 0)
+        else if (IS_ERROR(ret))
             goto out;
 
         ret = glusterd_quota_conf_write_gfid(fd, gfid,
                                              GF_QUOTA_CONF_TYPE_USAGE);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 
@@ -1155,7 +1155,7 @@ glusterd_store_quota_config(glusterd_volinfo_t *volinfo, char *path,
     glusterd_store_create_quota_conf_sh_on_absence(volinfo);
 
     conf_fd = open(volinfo->quota_conf_shandle->path, O_RDONLY);
-    if (conf_fd == -1) {
+    if (IS_ERROR(conf_fd)) {
         ret = -1;
         goto out;
     }
@@ -1179,7 +1179,7 @@ glusterd_store_quota_config(glusterd_volinfo_t *volinfo, char *path,
         }
 
         conf_fd = open(volinfo->quota_conf_shandle->path, O_RDONLY);
-        if (conf_fd == -1) {
+        if (IS_ERROR(conf_fd)) {
             ret = -1;
             goto out;
         }
@@ -1208,7 +1208,7 @@ glusterd_store_quota_config(glusterd_volinfo_t *volinfo, char *path,
     }
 
     fd = gf_store_mkstemp(volinfo->quota_conf_shandle);
-    if (fd < 0) {
+    if (IS_ERROR(fd)) {
         ret = -1;
         goto out;
     }
@@ -1262,7 +1262,7 @@ glusterd_store_quota_config(glusterd_volinfo_t *volinfo, char *path,
                                          &bytes_to_write);
 
         ret = sys_write(fd, (void *)buf, bytes_to_write);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, errno,
                    GD_MSG_QUOTA_CONF_WRITE_FAIL,
                    "write into quota.conf failed.");
@@ -1287,7 +1287,7 @@ glusterd_store_quota_config(glusterd_volinfo_t *volinfo, char *path,
             if (!found) {
                 ret = glusterd_quota_conf_write_gfid(fd, gfid,
                                                      GF_QUOTA_CONF_TYPE_USAGE);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     gf_msg(this->name, GF_LOG_ERROR, errno,
                            GD_MSG_QUOTA_CONF_WRITE_FAIL,
                            "write into quota.conf failed. ");
@@ -1300,7 +1300,7 @@ glusterd_store_quota_config(glusterd_volinfo_t *volinfo, char *path,
             if (!found) {
                 ret = glusterd_quota_conf_write_gfid(
                     fd, gfid, GF_QUOTA_CONF_TYPE_OBJECTS);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     gf_msg(this->name, GF_LOG_ERROR, errno,
                            GD_MSG_QUOTA_CONF_WRITE_FAIL,
                            "write into quota.conf failed. ");
@@ -1395,7 +1395,7 @@ glusterd_quota_limit_usage(glusterd_volinfo_t *volinfo, dict_t *dict,
     GF_VALIDATE_OR_GOTO(this->name, op_errstr, out);
 
     ret = glusterd_check_if_quota_trans_enabled(volinfo);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         *op_errstr = gf_strdup(
             "Quota is disabled, please enable "
             "quota");
@@ -1539,7 +1539,7 @@ glusterd_quota_remove_limits(glusterd_volinfo_t *volinfo, dict_t *dict,
     GF_VALIDATE_OR_GOTO(this->name, op_errstr, out);
 
     ret = glusterd_check_if_quota_trans_enabled(volinfo);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         *op_errstr = gf_strdup(
             "Quota is disabled, please enable "
             "quota");
@@ -1597,7 +1597,7 @@ glusterd_set_quota_option(glusterd_volinfo_t *volinfo, dict_t *dict, char *key,
     GF_ASSERT(this);
 
     ret = glusterd_check_if_quota_trans_enabled(volinfo);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_asprintf(op_errstr,
                     "Cannot set %s. Quota on volume %s is "
                     "disabled",
@@ -1696,19 +1696,19 @@ glusterd_op_quota(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     switch (type) {
         case GF_QUOTA_OPTION_TYPE_ENABLE:
             ret = glusterd_quota_enable(volinfo, op_errstr, &start_crawl);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
             break;
 
         case GF_QUOTA_OPTION_TYPE_ENABLE_OBJECTS:
             ret = glusterd_inode_quota_enable(volinfo, op_errstr, &start_crawl);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
             break;
 
         case GF_QUOTA_OPTION_TYPE_DISABLE:
             ret = glusterd_quota_disable(volinfo, op_errstr, &start_crawl);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
 
             break;
@@ -1727,7 +1727,7 @@ glusterd_op_quota(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         case GF_QUOTA_OPTION_TYPE_LIST:
         case GF_QUOTA_OPTION_TYPE_LIST_OBJECTS:
             ret = glusterd_check_if_quota_trans_enabled(volinfo);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 *op_errstr = gf_strdup(
                     "Cannot list limits, "
                     "quota is disabled");
@@ -1899,7 +1899,7 @@ glusterd_get_gfid_from_brick(dict_t *dict, glusterd_volinfo_t *volinfo,
             continue;
         }
         ret = sys_lgetxattr(backend_path, GFID_XATTR_KEY, gfid, 16);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_INFO, errno, GD_MSG_SETXATTR_FAIL,
                    "Failed to get "
                    "extended attribute %s for directory %s. ",
@@ -2067,7 +2067,7 @@ glusterd_create_quota_auxiliary_mount(xlator_t *this, char *volname, int type)
          * can get into a deadlock situation.
          */
         ret = sys_stat(mountdir, &buf);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             ret = -errno;
     } else {
         ret = -errno;
@@ -2207,7 +2207,7 @@ glusterd_op_stage_quota(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
             }
             ret = gf_string2bytesize_int64(hard_limit_str, &hard_limit);
             if (ret) {
-                if (errno == ERANGE || hard_limit < 0)
+                if (errno == ERANGE || IS_ERROR(hard_limit))
                     gf_asprintf(op_errstr,
                                 "Hard-limit "
                                 "value out of range (0 - %" PRId64 "): %s",

--- a/xlators/mgmt/glusterd/src/glusterd-quota.c
+++ b/xlators/mgmt/glusterd/src/glusterd-quota.c
@@ -428,7 +428,7 @@ _glusterd_quota_initiate_fs_crawl(glusterd_conf_t *priv,
 
         len = snprintf(pidfile, sizeof(pidfile), "%s/%s.pid", pid_dir,
                        brickpath);
-        if ((len >= 0) && (len < sizeof(pidfile))) {
+        if (IS_SUCCESS((len)) && (len < sizeof(pidfile))) {
             pidfp = fopen(pidfile, "w");
             if (pidfp != NULL) {
                 fprintf(pidfp, "%d\n", runner.chpid);
@@ -482,7 +482,7 @@ glusterd_stop_all_quota_crawl_service(glusterd_conf_t *priv,
     while (entry) {
         len = snprintf(pidfile, sizeof(pidfile), "%s/%s", pid_dir,
                        entry->d_name);
-        if ((len >= 0) && (len < sizeof(pidfile))) {
+        if (IS_SUCCESS((len)) && (len < sizeof(pidfile))) {
             glusterd_service_stop_nolock("quota_crawl", pidfile, SIGKILL,
                                          _gf_true);
             sys_unlink(pidfile);

--- a/xlators/mgmt/glusterd/src/glusterd-rebalance.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rebalance.c
@@ -44,7 +44,7 @@
             tmppath, PATH_MAX,                                                 \
             DEFAULT_VAR_RUN_DIRECTORY "/gluster-%s-%s-%s.sock", "rebalance",   \
             volinfo->volname, uuid_utoa(MY_UUID));                             \
-        if ((_defrag_sockfile_len < 0) ||                                      \
+        if (IS_ERROR((_defrag_sockfile_len)) ||                                \
             (_defrag_sockfile_len >= PATH_MAX)) {                              \
             path[0] = 0;                                                       \
         } else {                                                               \
@@ -494,7 +494,7 @@ __glusterd_handle_defrag_volume(rpcsvc_request_t *req)
     GF_ASSERT(priv);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         goto out;
@@ -506,7 +506,7 @@ __glusterd_handle_defrag_volume(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -820,7 +820,7 @@ glusterd_mgmt_v3_op_stage_rebalance(dict_t *dict, char **op_errstr)
 
                 ret = dict_foreach_fnmatch(dict, "brick*",
                                            glusterd_brick_validation, volinfo);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     snprintf(msg, sizeof(msg),
                              "Incorrect brick"
                              " for volume %s",
@@ -1138,7 +1138,7 @@ glusterd_op_stage_rebalance(dict_t *dict, char **op_errstr)
 
                 ret = dict_foreach_fnmatch(dict, "brick*",
                                            glusterd_brick_validation, volinfo);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     snprintf(msg, sizeof(msg),
                              "Incorrect brick"
                              " for volume %s",

--- a/xlators/mgmt/glusterd/src/glusterd-replace-brick.c
+++ b/xlators/mgmt/glusterd/src/glusterd-replace-brick.c
@@ -56,7 +56,7 @@ __glusterd_handle_replace_brick(rpcsvc_request_t *req)
     conf = this->private;
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "Failed to decode "
@@ -74,7 +74,7 @@ __glusterd_handle_replace_brick(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -436,7 +436,7 @@ glusterd_op_perform_replace_brick(glusterd_volinfo_t *volinfo, char *old_brick,
         if (!gf_uuid_compare(new_brickinfo->uuid, MY_UUID)) {
             ret = glusterd_handle_replicate_brick_ops(volinfo, new_brickinfo,
                                                       GD_OP_REPLACE_BRICK);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
         }
     }

--- a/xlators/mgmt/glusterd/src/glusterd-reset-brick.c
+++ b/xlators/mgmt/glusterd/src/glusterd-reset-brick.c
@@ -116,7 +116,7 @@ glusterd_reset_brick_prevalidate(dict_t *dict, char **op_errstr,
         ret = sys_lgetxattr(dst_brickinfo->path, GF_XATTR_VOL_ID_KEY, volume_id,
                             16);
         if (gf_uuid_compare(dst_brickinfo->uuid, src_brickinfo->uuid) ||
-            (ret >= 0 && is_force == _gf_false)) {
+            (IS_SUCCESS(ret) && is_force == _gf_false)) {
             ret = -1;
             *op_errstr = gf_strdup(
                 "Brick not available."

--- a/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-rpc-ops.c
@@ -182,7 +182,7 @@ glusterd_op_send_cli_response(glusterd_op_t op, int32_t op_ret,
     if (ctx) {
         ret = dict_allocate_and_serialize(ctx, &rsp.dict.dict_val,
                                           &rsp.dict.dict_len);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg(this->name, GF_LOG_ERROR, 0,
                    GD_MSG_DICT_SERL_LENGTH_GET_FAIL,
                    "failed to "
@@ -234,7 +234,7 @@ __glusterd_probe_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xlator_t *this = NULL;
     glusterd_conf_t *conf = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         goto out;
     }
 
@@ -244,7 +244,7 @@ __glusterd_probe_cbk(struct rpc_req *req, struct iovec *iov, int count,
     GF_VALIDATE_OR_GOTO(this->name, (conf != NULL), out);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_probe_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_RES_DECODE_FAIL, "error");
         // rsp.op_ret   = -1;
         // rsp.op_errno = EINVAL;
@@ -452,14 +452,14 @@ __glusterd_friend_add_cbk(struct rpc_req *req, struct iovec *iov, int count,
     glusterd_probe_ctx_t *ctx = NULL;
     glusterd_friend_update_ctx_t *ev_ctx = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_friend_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_RES_DECODE_FAIL,
                "error");
         rsp.op_ret = -1;
@@ -573,7 +573,7 @@ __glusterd_friend_remove_cbk(struct rpc_req *req, struct iovec *iov, int count,
                "Unable to get glusterd probe context");
         goto out;
     }
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
         move_sm_now = _gf_false;
@@ -581,7 +581,7 @@ __glusterd_friend_remove_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_friend_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_RES_DECODE_FAIL,
                "error");
         rsp.op_ret = -1;
@@ -670,13 +670,13 @@ __glusterd_friend_update_cbk(struct rpc_req *req, struct iovec *iov, int count,
     GF_ASSERT(req);
     this = THIS;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_RPC_FAILURE, "RPC Error");
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_friend_update_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_RES_DECODE_FAIL,
                "Failed to serialize friend"
                " update response");
@@ -724,7 +724,7 @@ __glusterd_cluster_lock_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     txn_id = &priv->global_txn_id;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_NO_LOCK_RESP_FROM_PEER,
                "Lock response is not "
                "received from one of the peer");
@@ -735,7 +735,7 @@ __glusterd_cluster_lock_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_cluster_lock_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_RES_DECODE_FAIL,
                "Failed to decode "
                "cluster lock response received from peer");
@@ -839,7 +839,7 @@ glusterd_mgmt_v3_lock_peers_cbk_fn(struct rpc_req *req, struct iovec *iov,
     txn_id = frame->cookie;
     frame->cookie = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_NO_LOCK_RESP_FROM_PEER,
                "Lock response is not "
                "received from one of the peer");
@@ -850,7 +850,7 @@ glusterd_mgmt_v3_lock_peers_cbk_fn(struct rpc_req *req, struct iovec *iov,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_v3_lock_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_RES_DECODE_FAIL,
                "Failed to decode "
                "mgmt_v3 lock response received from peer");
@@ -947,7 +947,7 @@ glusterd_mgmt_v3_unlock_peers_cbk_fn(struct rpc_req *req, struct iovec *iov,
     txn_id = frame->cookie;
     frame->cookie = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         err_str = "Unlock response not received from one of the peer.";
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_CLUSTER_UNLOCK_FAILED,
                "UnLock response is not received from one of the peer");
@@ -957,7 +957,7 @@ glusterd_mgmt_v3_unlock_peers_cbk_fn(struct rpc_req *req, struct iovec *iov,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_v3_unlock_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_CLUSTER_UNLOCK_FAILED,
                "Failed to decode mgmt_v3 unlock response received from"
                "peer");
@@ -1056,7 +1056,7 @@ __glusterd_cluster_unlock_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     txn_id = &priv->global_txn_id;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         err_str = "Unlock response not received from one of the peer.";
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_CLUSTER_UNLOCK_FAILED,
                "UnLock response is not received from one of the peer");
@@ -1067,7 +1067,7 @@ __glusterd_cluster_unlock_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp,
                          (xdrproc_t)xdr_gd1_mgmt_cluster_unlock_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_CLUSTER_UNLOCK_FAILED,
                "Failed to decode unlock response received from peer");
         err_str =
@@ -1161,7 +1161,7 @@ __glusterd_stage_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     txn_id = frame->cookie;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
         /* use standard allocation because to keep uniformity
@@ -1171,7 +1171,7 @@ __glusterd_stage_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_stage_op_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_RES_DECODE_FAIL,
                "Failed to decode stage "
                "response received from peer");
@@ -1190,7 +1190,7 @@ __glusterd_stage_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
         dict = dict_new();
 
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize rsp-buffer to dictionary");
@@ -1306,7 +1306,7 @@ __glusterd_commit_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     txn_id = frame->cookie;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
         /* use standard allocation because to keep uniformity
@@ -1317,7 +1317,7 @@ __glusterd_commit_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_commit_op_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_RES_DECODE_FAIL,
                "Failed to decode commit "
                "response received from peer");
@@ -1337,7 +1337,7 @@ __glusterd_commit_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
         dict = dict_new();
 
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize rsp-buffer to dictionary");
@@ -2111,7 +2111,7 @@ __glusterd_brick_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     req_ctx = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
         /* use standard allocation because to keep uniformity
@@ -2122,7 +2122,7 @@ __glusterd_brick_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_brick_op_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_RES_DECODE_FAIL,
                "Failed to decode brick op "
                "response received");
@@ -2139,7 +2139,7 @@ __glusterd_brick_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
         ret = dict_unserialize(rsp.output.output_val, rsp.output.output_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "Failed to "
                    "unserialize rsp-buffer to dictionary");

--- a/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
+++ b/xlators/mgmt/glusterd/src/glusterd-server-quorum.c
@@ -34,7 +34,7 @@ glusterd_is_get_op(xlator_t *this, glusterd_op_t op, dict_t *dict)
         if (volname && ((strcmp(volname, "help") == 0) ||
                         (strcmp(volname, "help-xml") == 0))) {
             ret = dict_get_str(dict, "key1", &key);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 return _gf_true;
         }
     }

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc-helper.c
@@ -33,7 +33,7 @@ glusterd_svc_build_shd_socket_filepath(glusterd_volinfo_t *volinfo, char *path,
     GLUSTERD_GET_SHD_RUNDIR(rundir, volinfo, priv);
     len = snprintf(sockfilepath, sizeof(sockfilepath), "%s/run-%s", rundir,
                    uuid_utoa(MY_UUID));
-    if ((len < 0) || (len >= sizeof(sockfilepath))) {
+    if (IS_ERROR((len)) || (len >= sizeof(sockfilepath))) {
         sockfilepath[0] = 0;
     }
 

--- a/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-shd-svc.c
@@ -26,7 +26,7 @@ glusterd_shdsvc_build(glusterd_svc_t *svc)
 {
     int ret = -1;
     ret = snprintf(svc->name, sizeof(svc->name), "%s", shd_svc_name);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return;
 
     CDS_INIT_LIST_HEAD(&svc->mux_svc);
@@ -81,7 +81,7 @@ glusterd_shdsvc_init(void *data, glusterd_conn_t *mux_conn,
     svc = &(volinfo->shd.svc);
 
     ret = snprintf(svc->name, sizeof(svc->name), "%s", shd_svc_name);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     notify = glusterd_muxsvc_common_rpc_notify;
@@ -101,11 +101,11 @@ glusterd_shdsvc_init(void *data, glusterd_conn_t *mux_conn,
         svc->conn.rpc = rpc_clnt_ref(mux_svc->rpc);
         ret = snprintf(svc->conn.sockpath, sizeof(svc->conn.sockpath), "%s",
                        mux_conn->sockpath);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     } else {
         ret = mkdir_p(priv->logdir, 0755, _gf_true);
-        if ((ret == -1) && (EEXIST != errno)) {
+        if (IS_ERROR(ret) && (EEXIST != errno)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_CREATE_DIR_FAILED,
                    "Unable to create logdir %s", logdir);
             goto out;
@@ -126,7 +126,7 @@ glusterd_shdsvc_init(void *data, glusterd_conn_t *mux_conn,
     glusterd_svc_build_shd_pidfile(volinfo, pidfile, sizeof(pidfile));
     glusterd_svc_build_shd_volfile_path(volinfo, volfile, PATH_MAX);
     len = snprintf(volfileid, sizeof(volfileid), "shd/%s", volinfo->volname);
-    if ((len < 0) || (len >= sizeof(volfileid))) {
+    if (IS_ERROR(len) || (len >= sizeof(volfileid))) {
         ret = -1;
         goto out;
     }
@@ -353,16 +353,16 @@ glusterd_new_shd_svc_start(glusterd_svc_t *svc, int flags)
 
     ret = snprintf(glusterd_uuid_option, sizeof(glusterd_uuid_option),
                    "*replicate*.node-uuid=%s", uuid_utoa(MY_UUID));
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = snprintf(client_pid, sizeof(client_pid), "--client-pid=%d",
                    GF_CLIENT_PID_SELF_HEALD);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = dict_set_str(cmdline, "arg", client_pid);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     /* Pass cmdline arguments as key-value pair. The key is merely

--- a/xlators/mgmt/glusterd/src/glusterd-sm.c
+++ b/xlators/mgmt/glusterd/src/glusterd-sm.c
@@ -75,7 +75,7 @@ static char *glusterd_friend_sm_event_names[] = {
 char *
 glusterd_friend_sm_state_name_get(int state)
 {
-    if (state < 0 || state >= GD_FRIEND_STATE_MAX)
+    if (IS_ERROR(state) || state >= GD_FRIEND_STATE_MAX)
         return glusterd_friend_sm_state_names[GD_FRIEND_STATE_MAX];
     return glusterd_friend_sm_state_names[state];
 }
@@ -83,7 +83,7 @@ glusterd_friend_sm_state_name_get(int state)
 char *
 glusterd_friend_sm_event_name_get(int event)
 {
-    if (event < 0 || event >= GD_FRIEND_EVENT_MAX)
+    if (IS_ERROR(event) || event >= GD_FRIEND_EVENT_MAX)
         return glusterd_friend_sm_event_names[GD_FRIEND_EVENT_MAX];
     return glusterd_friend_sm_event_names[event];
 }

--- a/xlators/mgmt/glusterd/src/glusterd-snapd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapd-svc-helper.c
@@ -40,7 +40,7 @@ glusterd_svc_build_snapd_socket_filepath(glusterd_volinfo_t *volinfo,
     glusterd_svc_build_snapd_rundir(volinfo, rundir, sizeof(rundir));
     len = snprintf(sockfilepath, sizeof(sockfilepath), "%s/run-%s", rundir,
                    uuid_utoa(MY_UUID));
-    if ((len < 0) || (len >= sizeof(sockfilepath))) {
+    if (IS_ERROR((len)) || (len >= sizeof(sockfilepath))) {
         sockfilepath[0] = 0;
     }
 

--- a/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapd-svc.c
@@ -87,7 +87,7 @@ glusterd_snapdsvc_init(void *data)
     svc = &(volinfo->snapd.svc);
 
     ret = snprintf(svc->name, sizeof(svc->name), "%s", snapd_svc_name);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     notify = glusterd_snapdsvc_rpc_notify;
@@ -107,14 +107,14 @@ glusterd_snapdsvc_init(void *data)
     glusterd_svc_build_snapd_volfile(volinfo, volfile, sizeof(volfile));
     glusterd_svc_build_snapd_logdir(logdir, volinfo->volname, sizeof(logdir));
     ret = mkdir_p(logdir, 0755, _gf_true);
-    if ((ret == -1) && (EEXIST != errno)) {
+    if (IS_ERROR(ret) && (EEXIST != errno)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create logdir %s", logdir);
         goto out;
     }
     glusterd_svc_build_snapd_logfile(logfile, logdir, sizeof(logfile));
     len = snprintf(volfileid, sizeof(volfileid), "snapd/%s", volinfo->volname);
-    if ((len < 0) || (len >= sizeof(volfileid))) {
+    if (IS_ERROR(len) || (len >= sizeof(volfileid))) {
         ret = -1;
         goto out;
     }
@@ -159,7 +159,7 @@ glusterd_snapdsvc_manager(glusterd_svc_t *svc, void *data, int flags)
     }
 
     ret = glusterd_is_snapd_enabled(volinfo);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_VOLINFO_GET_FAIL,
                "Failed to read volume "
                "options");
@@ -304,7 +304,7 @@ glusterd_snapdsvc_start(glusterd_svc_t *svc, int flags)
     if (this->ctx->cmd_args.valgrind) {
         len = snprintf(valgrind_logfile, PATH_MAX, "%s/valgrind-snapd.log",
                        svc->proc.logdir);
-        if ((len < 0) || (len >= PATH_MAX)) {
+        if (IS_ERROR(len) || (len >= PATH_MAX)) {
             ret = -1;
             goto out;
         }

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.c
@@ -154,7 +154,7 @@ glusterd_snap_geo_rep_restore(glusterd_volinfo_t *snap_volinfo,
      */
     geo_rep_indexing_on = glusterd_volinfo_get_boolean(new_volinfo,
                                                        VKEY_MARKER_XTIME);
-    if (geo_rep_indexing_on == -1) {
+    if (IS_ERROR(geo_rep_indexing_on)) {
         gf_msg_debug(this->name, 0,
                      "Failed"
                      " to check whether geo-rep-indexing enabled or not");
@@ -281,7 +281,7 @@ glusterd_snap_volinfo_restore(dict_t *dict, dict_t *rsp_dict,
             ret = sys_lsetxattr(new_brickinfo->path, GF_XATTR_VOL_ID_KEY,
                                 new_volinfo->volume_id,
                                 sizeof(new_volinfo->volume_id), XATTR_REPLACE);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SETXATTR_FAIL,
                        "Failed to "
                        "set extended attribute %s on %s. "
@@ -295,7 +295,7 @@ glusterd_snap_volinfo_restore(dict_t *dict, dict_t *rsp_dict,
         /* If a snapshot is pending for this brick then
          * restore should also be pending
          */
-        if (brickinfo->snap_status == -1) {
+        if (IS_ERROR(brickinfo->snap_status)) {
             /* Adding missed delete to the dict */
             ret = glusterd_add_missed_snaps_to_dict(
                 rsp_dict, snap_volinfo, brickinfo, brick_count,
@@ -2769,7 +2769,7 @@ glusterd_mount_lvm_snapshot(glusterd_brickinfo_t *brickinfo,
     runinit(&runner);
     len = snprintf(msg, sizeof(msg), "mount %s %s", brickinfo->device_path,
                    brick_mount_path);
-    if (len < 0) {
+    if (IS_ERROR(len)) {
         strcpy(msg, "<error>");
     }
 
@@ -3405,7 +3405,7 @@ glusterd_snap_unmount(xlator_t *this, glusterd_volinfo_t *volinfo)
             continue;
         }
         /* If snapshot is pending, we continue */
-        if (brickinfo->snap_status == -1) {
+        if (IS_ERROR(brickinfo->snap_status)) {
             continue;
         }
 
@@ -3506,7 +3506,7 @@ glusterd_copy_file(const char *source, const char *destination)
     dest_mode = stbuf.st_mode & 0777;
 
     src_fd = open(source, O_RDONLY);
-    if (src_fd == -1) {
+    if (IS_ERROR(src_fd)) {
         ret = -1;
         gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
                "Unable to open file %s", source);
@@ -3514,7 +3514,7 @@ glusterd_copy_file(const char *source, const char *destination)
     }
 
     dest_fd = sys_creat(destination, dest_mode);
-    if (dest_fd < 0) {
+    if (IS_ERROR(dest_fd)) {
         ret = -1;
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_FILE_OP_FAILED,
                "Unble to open a file %s", destination);
@@ -3523,7 +3523,7 @@ glusterd_copy_file(const char *source, const char *destination)
 
     do {
         ret = sys_read(src_fd, buffer, sizeof(buffer));
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
                    "Error reading file "
                    "%s",
@@ -3594,12 +3594,12 @@ glusterd_copy_folder(const char *source, const char *destination)
             continue;
         ret = snprintf(src_path, sizeof(src_path), "%s/%s", source,
                        entry->d_name);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = snprintf(dest_path, sizeof(dest_path), "%s/%s", destination,
                        entry->d_name);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = glusterd_copy_file(src_path, dest_path);
@@ -3701,11 +3701,11 @@ glusterd_get_geo_rep_session(char *slave_key, char *origin_volname,
 
     ret = snprintf(session, PATH_MAX, "%s_%s_%s", origin_volname, ip_i,
                    slave_temp);
-    if (ret < 0) /* Negative value is an error */
+    if (IS_ERROR(ret)) /* Negative value is an error */
         goto out;
 
     ret = snprintf(slave, PATH_MAX, "%s::%s", ip, slave_temp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -3756,7 +3756,7 @@ glusterd_copy_quota_files(glusterd_volinfo_t *src_vol,
     GLUSTERD_GET_VOLUME_DIR(dest_dir, dest_vol, priv);
 
     ret = snprintf(src_path, sizeof(src_path), "%s/quota.conf", src_dir);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     /* quota.conf is not present if quota is not enabled, Hence ignoring
@@ -3770,7 +3770,7 @@ glusterd_copy_quota_files(glusterd_volinfo_t *src_vol,
     }
 
     ret = snprintf(dest_path, sizeof(dest_path), "%s/quota.conf", dest_dir);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = glusterd_copy_file(src_path, dest_path);
@@ -3781,7 +3781,7 @@ glusterd_copy_quota_files(glusterd_volinfo_t *src_vol,
     }
 
     ret = snprintf(src_path, sizeof(src_path), "%s/quota.cksum", src_dir);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     /* if quota.conf is present, quota.cksum has to be present. *
@@ -3795,7 +3795,7 @@ glusterd_copy_quota_files(glusterd_volinfo_t *src_vol,
     }
 
     ret = snprintf(dest_path, sizeof(dest_path), "%s/quota.cksum", dest_dir);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = glusterd_copy_file(src_path, dest_path);
@@ -3870,7 +3870,7 @@ glusterd_copy_nfs_ganesha_file(glusterd_volinfo_t *src_vol,
         ret = snprintf(src_path, PATH_MAX, "%s/export.%s.conf",
                        GANESHA_EXPORT_DIRECTORY, src_vol->volname);
     }
-    if (ret < 0 || ret >= PATH_MAX)
+    if (IS_ERROR(ret) || ret >= PATH_MAX)
         goto out;
 
     ret = sys_lstat(src_path, &stbuf);
@@ -3890,7 +3890,7 @@ glusterd_copy_nfs_ganesha_file(glusterd_volinfo_t *src_vol,
         GLUSTERD_GET_SNAP_DIR(snap_dir, dest_vol->snapshot, priv);
         ret = snprintf(dest_path, sizeof(dest_path), "%s/export.%s.conf",
                        snap_dir, dest_vol->snapshot->snapname);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = glusterd_copy_file(src_path, dest_path);
@@ -3903,7 +3903,7 @@ glusterd_copy_nfs_ganesha_file(glusterd_volinfo_t *src_vol,
     } else {
         ret = snprintf(dest_path, sizeof(dest_path), "%s/export.%s.conf",
                        GANESHA_EXPORT_DIRECTORY, dest_vol->volname);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         src = fopen(src_path, "r");
@@ -3992,7 +3992,7 @@ glusterd_restore_geo_rep_files(glusterd_volinfo_t *snap_vol)
 
     for (i = 1; i <= snap_vol->gsync_slaves->count; i++) {
         ret = snprintf(key, sizeof(key), "slave%d", i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -4016,12 +4016,12 @@ glusterd_restore_geo_rep_files(glusterd_volinfo_t *snap_vol)
         GLUSTERD_GET_SNAP_GEO_REP_DIR(snapgeo_dir, snap_vol->snapshot, priv);
         ret = snprintf(src_path, sizeof(src_path), "%s/%s", snapgeo_dir,
                        session);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = snprintf(dest_path, sizeof(dest_path), "%s/%s/%s", priv->workdir,
                        GEOREP, session);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = glusterd_copy_folder(src_path, dest_path);
@@ -4066,7 +4066,7 @@ glusterd_restore_nfs_ganesha_file(glusterd_volinfo_t *src_vol,
 
     ret = snprintf(src_path, sizeof(src_path), "%s/export.%s.conf", snap_dir,
                    snap->snapname);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = sys_lstat(src_path, &stbuf);
@@ -4082,7 +4082,7 @@ glusterd_restore_nfs_ganesha_file(glusterd_volinfo_t *src_vol,
 
     ret = snprintf(dest_path, sizeof(dest_path), "%s/export.%s.conf",
                    GANESHA_EXPORT_DIRECTORY, src_vol->volname);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = glusterd_copy_file(src_path, dest_path);
@@ -4109,7 +4109,7 @@ glusterd_is_snapd_enabled(glusterd_volinfo_t *volinfo)
                      volinfo->volname);
         ret = 0;
 
-    } else if (ret == -1) {
+    } else if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_GET_FAILED,
                "Failed to get 'features.uss'"
                " from dict for volume %s",

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.h
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot-utils.h
@@ -15,7 +15,7 @@
         int32_t _snap_dir_len;                                                 \
         _snap_dir_len = snprintf(path, PATH_MAX, "%s/snaps/%s", priv->workdir, \
                                  snap->snapname);                              \
-        if ((_snap_dir_len < 0) || (_snap_dir_len >= PATH_MAX)) {              \
+        if (IS_ERROR((_snap_dir_len)) || (_snap_dir_len >= PATH_MAX)) {        \
             path[0] = 0;                                                       \
         }                                                                      \
     } while (0)

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -141,7 +141,7 @@ glusterd_build_snap_device_path(char *device, char *snapname,
     snprintf(msg, sizeof(msg), "Get volume group for device %s", device);
     runner_log(&runner, this->name, GF_LOG_DEBUG, msg);
     ret = runner_start(&runner);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_VG_GET_FAIL,
                "Failed to get volume group "
                "for device %s",
@@ -295,7 +295,7 @@ snap_max_limits_display_commit(dict_t *rsp_dict, char *volname, char *op_errstr,
             ret = dict_set_strn(rsp_dict, key, keylen, volinfo->volname);
             if (ret) {
                 len = snprintf(err_str, PATH_MAX, "Failed to set %s", key);
-                if (len < 0) {
+                if (IS_ERROR(len)) {
                     strcpy(err_str, "<error>");
                 }
                 goto out;
@@ -306,7 +306,7 @@ snap_max_limits_display_commit(dict_t *rsp_dict, char *volname, char *op_errstr,
             ret = dict_set_uint64(rsp_dict, key, snap_max_limit);
             if (ret) {
                 len = snprintf(err_str, PATH_MAX, "Failed to set %s", key);
-                if (len < 0) {
+                if (IS_ERROR(len)) {
                     strcpy(err_str, "<error>");
                 }
                 goto out;
@@ -317,7 +317,7 @@ snap_max_limits_display_commit(dict_t *rsp_dict, char *volname, char *op_errstr,
             ret = dict_set_uint64(rsp_dict, key, active_hard_limit);
             if (ret) {
                 len = snprintf(err_str, PATH_MAX, "Failed to set %s", key);
-                if (len < 0) {
+                if (IS_ERROR(len)) {
                     strcpy(err_str, "<error>");
                 }
                 goto out;
@@ -328,7 +328,7 @@ snap_max_limits_display_commit(dict_t *rsp_dict, char *volname, char *op_errstr,
             ret = dict_set_uint64(rsp_dict, key, soft_limit_value);
             if (ret) {
                 len = snprintf(err_str, PATH_MAX, "Failed to set %s", key);
-                if (len < 0) {
+                if (IS_ERROR(len)) {
                     strcpy(err_str, "<error>");
                 }
                 goto out;
@@ -364,7 +364,7 @@ snap_max_limits_display_commit(dict_t *rsp_dict, char *volname, char *op_errstr,
         ret = dict_set_strn(rsp_dict, key, keylen, volinfo->volname);
         if (ret) {
             len = snprintf(err_str, PATH_MAX, "Failed to set %s", key);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(err_str, "<error>");
             }
             goto out;
@@ -375,7 +375,7 @@ snap_max_limits_display_commit(dict_t *rsp_dict, char *volname, char *op_errstr,
         ret = dict_set_uint64(rsp_dict, key, snap_max_limit);
         if (ret) {
             len = snprintf(err_str, PATH_MAX, "Failed to set %s", key);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(err_str, "<error>");
             }
             goto out;
@@ -386,7 +386,7 @@ snap_max_limits_display_commit(dict_t *rsp_dict, char *volname, char *op_errstr,
         ret = dict_set_uint64(rsp_dict, key, active_hard_limit);
         if (ret) {
             len = snprintf(err_str, PATH_MAX, "Failed to set %s", key);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(err_str, "<error>");
             }
             goto out;
@@ -397,7 +397,7 @@ snap_max_limits_display_commit(dict_t *rsp_dict, char *volname, char *op_errstr,
         ret = dict_set_uint64(rsp_dict, key, soft_limit_value);
         if (ret) {
             len = snprintf(err_str, PATH_MAX, "Failed to set %s", key);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(err_str, "<error>");
             }
             goto out;
@@ -513,14 +513,14 @@ glusterd_copy_geo_rep_session_files(char *session, glusterd_volinfo_t *snap_vol)
 
     ret = snprintf(georep_session_dir, sizeof(georep_session_dir), "%s/%s/%s",
                    priv->workdir, GEOREP, session);
-    if (ret < 0) { /* Negative value is an error */
+    if (IS_ERROR(ret)) { /* Negative value is an error */
         goto out;
     }
 
     ret = snprintf(snap_session_dir, sizeof(snap_session_dir), "%s/%s/%s/%s/%s",
                    priv->workdir, GLUSTERD_VOL_SNAP_DIR_PREFIX,
                    snap_vol->snapshot->snapname, GEOREP, session);
-    if (ret < 0) { /* Negative value is an error */
+    if (IS_ERROR(ret)) { /* Negative value is an error */
         goto out;
     }
 
@@ -567,13 +567,13 @@ glusterd_copy_geo_rep_session_files(char *session, glusterd_volinfo_t *snap_vol)
 
         ret = snprintf(src_path, sizeof(src_path), "%s/%s", georep_session_dir,
                        files[i]->d_name);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
         ret = snprintf(dest_path, sizeof(dest_path), "%s/%s", snap_session_dir,
                        files[i]->d_name);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -631,13 +631,13 @@ glusterd_snapshot_backup_vol(glusterd_volinfo_t *volinfo)
     len = snprintf(delete_path, sizeof(delete_path),
                    "%s/" GLUSTERD_TRASH "/vols-%s.deleted", priv->workdir,
                    volinfo->volname);
-    if ((len < 0) || (len >= sizeof(delete_path))) {
+    if (IS_ERROR((len)) || (len >= sizeof(delete_path))) {
         goto out;
     }
 
     len = snprintf(trashdir, sizeof(trashdir), "%s/" GLUSTERD_TRASH,
                    priv->workdir);
-    if ((len < 0) || (len >= sizeof(delete_path))) {
+    if (IS_ERROR((len)) || (len >= sizeof(delete_path))) {
         goto out;
     }
 
@@ -745,7 +745,7 @@ glusterd_copy_geo_rep_files(glusterd_volinfo_t *origin_vol,
 
     for (i = 1; i <= origin_vol->gsync_slaves->count; i++) {
         ret = snprintf(key, sizeof(key), "slave%d", i);
-        if (ret < 0) /* Negative value is an error */
+        if (IS_ERROR(ret)) /* Negative value is an error */
             goto out;
 
         ret = glusterd_get_geo_rep_session(
@@ -810,7 +810,7 @@ glusterd_snapshot_restore(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
     snap = glusterd_find_snap_by_name(snapname);
     if (NULL == snap) {
         ret = gf_asprintf(op_errstr, "Snapshot (%s) does not exist", snapname);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SNAP_NOT_FOUND, "%s",
@@ -961,7 +961,7 @@ glusterd_snapshot_restore_prevalidate(dict_t *dict, char **op_errstr,
     if (NULL == snap) {
         ret = gf_asprintf(op_errstr, "Snapshot (%s) does not exist", snapname);
         *op_errno = EG_SNAPEXST;
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
         gf_msg(this->name, GF_LOG_ERROR, EINVAL, GD_MSG_SNAP_NOT_FOUND, "%s",
@@ -977,7 +977,7 @@ glusterd_snapshot_restore_prevalidate(dict_t *dict, char **op_errstr,
                           "Snapshot (%s) is already "
                           "restored",
                           snapname);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SNAPSHOT_OP_FAILED, "%s",
@@ -1022,7 +1022,7 @@ glusterd_snapshot_restore_prevalidate(dict_t *dict, char **op_errstr,
                               "does not exist",
                               volname);
             *op_errno = EG_NOVOL;
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 goto out;
             }
             gf_msg(this->name, GF_LOG_ERROR, EINVAL, GD_MSG_VOL_NOT_FOUND, "%s",
@@ -1039,7 +1039,7 @@ glusterd_snapshot_restore_prevalidate(dict_t *dict, char **op_errstr,
                 "a snapshot.",
                 volname);
             *op_errno = EG_VOLRUN;
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 goto out;
             }
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SNAPSHOT_OP_FAILED, "%s",
@@ -1313,7 +1313,7 @@ glusterd_snapshot_config_prevalidate(dict_t *dict, char **op_errstr,
                   SLEN(GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE))) {
         req_auto_delete = dict_get_str_boolean(
             dict, GLUSTERD_STORE_KEY_SNAP_AUTO_DELETE, _gf_false);
-        if (req_auto_delete < 0) {
+        if (IS_ERROR(req_auto_delete)) {
             ret = -1;
             snprintf(err_str, sizeof(err_str),
                      "Please enter a "
@@ -1342,7 +1342,7 @@ glusterd_snapshot_config_prevalidate(dict_t *dict, char **op_errstr,
                          SLEN(GLUSTERD_STORE_KEY_SNAP_ACTIVATE))) {
         req_snap_activate = dict_get_str_boolean(
             dict, GLUSTERD_STORE_KEY_SNAP_ACTIVATE, _gf_false);
-        if (req_snap_activate < 0) {
+        if (IS_ERROR(req_snap_activate)) {
             ret = -1;
             snprintf(err_str, sizeof(err_str),
                      "Please enter a "
@@ -1879,7 +1879,7 @@ glusterd_is_thinp_brick(char *device, uint32_t *op_errno)
     runner_log(&runner, this->name, GF_LOG_DEBUG, msg);
 
     ret = runner_start(&runner);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_TPOOL_GET_FAIL,
                "Failed to get thin pool "
                "name for device %s",
@@ -1996,7 +1996,7 @@ glusterd_snap_create_clone_common_prevalidate(
                            "getting device name for the brick "
                            "%s:%s failed",
                            brickinfo->hostname, brickinfo->path);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(err_str, "<error>");
             }
             ret = -1;
@@ -2652,7 +2652,7 @@ glusterd_do_lvm_snapshot_remove(glusterd_volinfo_t *snap_vol,
                    "remove snapshot of the brick %s:%s, "
                    "device: %s",
                    brickinfo->hostname, brickinfo->path, snap_device);
-    if (len < 0) {
+    if (IS_ERROR(len)) {
         strcpy(msg, "<error>");
     }
     runner_add_args(&runner, LVM_REMOVE, "-f", snap_device, NULL);
@@ -2736,7 +2736,7 @@ glusterd_lvm_snapshot_remove(dict_t *rsp_dict, glusterd_volinfo_t *snap_vol)
             }
         }
 
-        if (brickinfo->snap_status == -1) {
+        if (IS_ERROR(brickinfo->snap_status)) {
             gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_SNAPSHOT_PENDING,
                    "snapshot was pending. lvm not present "
                    "for brick %s:%s of the snap %s.",
@@ -3879,7 +3879,7 @@ glusterd_handle_snapshot_create(rpcsvc_request_t *req, glusterd_op_t op,
     }
 
     timestamp = dict_get_str_boolean(dict, "no-timestamp", _gf_false);
-    if (timestamp == -1) {
+    if (IS_ERROR(timestamp)) {
         gf_log(this->name, GF_LOG_ERROR,
                "Failed to get "
                "no-timestamp flag ");
@@ -4450,7 +4450,7 @@ glusterd_add_missed_snaps_to_dict(dict_t *rsp_dict,
                    "%s:%s=%s:%d:%s:%d:%d", uuid_utoa(brickinfo->uuid),
                    snap_uuid, snap_vol->volname, brick_number, brickinfo->path,
                    op, GD_MISSED_SNAP_PENDING);
-    if ((len < 0) || (len >= sizeof(missed_snap_entry))) {
+    if (IS_ERROR((len)) || (len >= sizeof(missed_snap_entry))) {
         goto out;
     }
 
@@ -4609,7 +4609,7 @@ glusterd_snap_brick_create(glusterd_volinfo_t *snap_volinfo,
                        "%s/%s/brick%d", snap_mount_dir, snap_volinfo->volname,
                        brick_count + 1);
     }
-    if ((len < 0) || (len >= sizeof(snap_brick_mount_path))) {
+    if (IS_ERROR((len)) || (len >= sizeof(snap_brick_mount_path))) {
         goto out;
     }
 
@@ -4646,7 +4646,7 @@ glusterd_snap_brick_create(glusterd_volinfo_t *snap_volinfo,
     }
     ret = sys_lsetxattr(brickinfo->path, GF_XATTR_VOL_ID_KEY,
                         snap_volinfo->volume_id, 16, XATTR_REPLACE);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_SETXATTR_FAIL,
                "Failed to set "
                "extended attribute %s on %s. Reason: "
@@ -4808,7 +4808,7 @@ glusterd_add_brick_to_snap_volume(dict_t *dict, dict_t *rsp_dict,
                        "%s/%s/brick%d%s", snap_mount_dir, snap_vol->volname,
                        brick_count + 1, snap_brick_dir);
     }
-    if ((len < 0) || (len >= sizeof(snap_brick_path))) {
+    if (IS_ERROR((len)) || (len >= sizeof(snap_brick_path))) {
         ret = -1;
         goto out;
     }
@@ -4924,7 +4924,7 @@ glusterd_update_fs_label(glusterd_brickinfo_t *brickinfo)
                        "Changing filesystem label "
                        "of %s brick to %s",
                        brickinfo->path, label);
-        if (len < 0) {
+        if (IS_ERROR(len)) {
             strcpy(msg, "<error>");
         }
         /* Run the run xfs_admin tool to change the label
@@ -4941,7 +4941,7 @@ glusterd_update_fs_label(glusterd_brickinfo_t *brickinfo)
                        "Changing filesystem label "
                        "of %s brick to %s",
                        brickinfo->path, label);
-        if (len < 0) {
+        if (IS_ERROR(len)) {
             strcpy(msg, "<error>");
         }
         /* For ext2/ext3/ext4 run tune2fs to change the
@@ -5536,7 +5536,7 @@ glusterd_handle_snapshot_delete_all(dict_t *dict)
          */
         i++;
         ret = snprintf(key, sizeof(key), "snapname%d", i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -5842,7 +5842,7 @@ glusterd_snapshot_status_prevalidate(dict_t *dict, char **op_errstr,
                                   "does not exist",
                                   snapname);
                 *op_errno = EG_NOSNAP;
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     goto out;
                 }
                 ret = -1;
@@ -5867,7 +5867,7 @@ glusterd_snapshot_status_prevalidate(dict_t *dict, char **op_errstr,
                                   "does not exist",
                                   volname);
                 *op_errno = EG_NOVOL;
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     goto out;
                 }
                 ret = -1;
@@ -6436,7 +6436,7 @@ glusterd_schedule_brick_snapshot(dict_t *dict, dict_t *rsp_dict,
             }
 
             if ((gf_uuid_compare(brickinfo->uuid, MY_UUID)) ||
-                (brickinfo->snap_status == -1)) {
+                (IS_ERROR(brickinfo->snap_status))) {
                 if (!gf_uuid_compare(brickinfo->uuid, MY_UUID)) {
                     brickcount++;
                     keylen = snprintf(key, sizeof(key),
@@ -7188,7 +7188,7 @@ glusterd_get_brick_lvm_details(dict_t *rsp_dict,
                 goto end;
             }
             ret = snprintf(key, sizeof(key), "%s.vgname", key_prefix);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 goto end;
             }
 
@@ -7208,7 +7208,7 @@ glusterd_get_brick_lvm_details(dict_t *rsp_dict,
                 goto end;
             }
             ret = snprintf(key, sizeof(key), "%s.data", key_prefix);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 goto end;
             }
 
@@ -7227,7 +7227,7 @@ glusterd_get_brick_lvm_details(dict_t *rsp_dict,
                 goto end;
             }
             ret = snprintf(key, sizeof(key), "%s.lvsize", key_prefix);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 goto end;
             }
 
@@ -7286,14 +7286,14 @@ glusterd_get_single_brick_status(char **op_errstr, dict_t *rsp_dict,
     GF_ASSERT(brickinfo);
 
     keylen = snprintf(key, sizeof(key), "%s.brick%d.path", keyprefix, index);
-    if (keylen < 0) {
+    if (IS_ERROR(keylen)) {
         ret = -1;
         goto out;
     }
 
     ret = snprintf(brick_path, sizeof(brick_path), "%s:%s", brickinfo->hostname,
                    brickinfo->path);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -7312,7 +7312,7 @@ glusterd_get_single_brick_status(char **op_errstr, dict_t *rsp_dict,
         goto out;
     }
 
-    if (brickinfo->snap_status == -1) {
+    if (IS_ERROR(brickinfo->snap_status)) {
         /* Setting vgname as "Pending Snapshot" */
         value = gf_strdup("Pending Snapshot");
         if (!value) {
@@ -7335,7 +7335,7 @@ glusterd_get_single_brick_status(char **op_errstr, dict_t *rsp_dict,
     value = NULL;
 
     keylen = snprintf(key, sizeof(key), "%s.brick%d.status", keyprefix, index);
-    if (keylen < 0) {
+    if (IS_ERROR(keylen)) {
         ret = -1;
         goto out;
     }
@@ -7372,7 +7372,7 @@ glusterd_get_single_brick_status(char **op_errstr, dict_t *rsp_dict,
         if (gf_is_service_running(pidfile, &pid)) {
             keylen = snprintf(key, sizeof(key), "%s.brick%d.pid", keyprefix,
                               index);
-            if (keylen < 0) {
+            if (IS_ERROR(keylen)) {
                 ret = -1;
                 goto out;
             }
@@ -7387,7 +7387,7 @@ glusterd_get_single_brick_status(char **op_errstr, dict_t *rsp_dict,
     }
 
     keylen = snprintf(key, sizeof(key), "%s.brick%d", keyprefix, index);
-    if (keylen < 0) {
+    if (IS_ERROR(keylen)) {
         ret = -1;
         goto out;
     }
@@ -7458,7 +7458,7 @@ glusterd_get_single_snap_status(char **op_errstr, dict_t *rsp_dict,
                                  vol_list)
     {
         keylen = snprintf(key, sizeof(key), "%s.vol%d", keyprefix, volcount);
-        if (keylen < 0) {
+        if (IS_ERROR(keylen)) {
             ret = -1;
             goto out;
         }
@@ -7481,7 +7481,7 @@ glusterd_get_single_snap_status(char **op_errstr, dict_t *rsp_dict,
             brickcount++;
         }
         keylen = snprintf(brickkey, sizeof(brickkey), "%s.brickcount", key);
-        if (keylen < 0) {
+        if (IS_ERROR(keylen)) {
             goto out;
         }
 
@@ -7495,7 +7495,7 @@ glusterd_get_single_snap_status(char **op_errstr, dict_t *rsp_dict,
     }
 
     keylen = snprintf(key, sizeof(key), "%s.volcount", keyprefix);
-    if (keylen < 0) {
+    if (IS_ERROR(keylen)) {
         ret = -1;
         goto out;
     }
@@ -7534,7 +7534,7 @@ glusterd_get_each_snap_object_status(char **op_errstr, dict_t *rsp_dict,
      * as of now, There will be only one snapvolinfo per snap object
      */
     keylen = snprintf(key, sizeof(key), "%s.snapname", keyprefix);
-    if (keylen < 0) {
+    if (IS_ERROR(keylen)) {
         ret = -1;
         goto out;
     }
@@ -7555,7 +7555,7 @@ glusterd_get_each_snap_object_status(char **op_errstr, dict_t *rsp_dict,
     temp = NULL;
 
     keylen = snprintf(key, sizeof(key), "%s.uuid", keyprefix);
-    if (keylen < 0) {
+    if (IS_ERROR(keylen)) {
         ret = -1;
         goto out;
     }
@@ -7584,7 +7584,7 @@ glusterd_get_each_snap_object_status(char **op_errstr, dict_t *rsp_dict,
     }
 
     keylen = snprintf(key, sizeof(key), "%s.volcount", keyprefix);
-    if (keylen < 0) {
+    if (IS_ERROR(keylen)) {
         ret = keylen;
         goto out;
     }
@@ -7638,7 +7638,7 @@ glusterd_get_snap_status_of_volume(char **op_errstr, dict_t *rsp_dict,
                                  &volinfo->snap_volumes, snapvol_list)
     {
         ret = snprintf(key, sizeof(key), "status.snap%d.snapname", i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -7689,7 +7689,7 @@ glusterd_get_all_snapshot_status(dict_t *dict, char **op_errstr,
     cds_list_for_each_entry_safe(snap, tmp_snap, &priv->snapshots, snap_list)
     {
         ret = snprintf(key, sizeof(key), "status.snap%d.snapname", i);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
 
@@ -7778,7 +7778,7 @@ glusterd_snapshot_status_commit(dict_t *dict, char **op_errstr,
                                   "Snapshot (%s) "
                                   "does not exist",
                                   snapname);
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     goto out;
                 }
                 ret = -1;
@@ -8616,7 +8616,7 @@ glusterd_remove_trashpath(char *volname)
     len = snprintf(delete_path, sizeof(delete_path),
                    "%s/" GLUSTERD_TRASH "/vols-%s.deleted", priv->workdir,
                    volname);
-    if ((len < 0) || (len >= sizeof(delete_path))) {
+    if (IS_ERROR((len)) || (len >= sizeof(delete_path))) {
         goto out;
     }
 
@@ -8732,7 +8732,7 @@ glusterd_snapshot_revert_partial_restored_vol(glusterd_volinfo_t *volinfo)
     len = snprintf(trash_path, sizeof(trash_path),
                    "%s/" GLUSTERD_TRASH "/vols-%s.deleted", priv->workdir,
                    volinfo->volname);
-    if ((len < 0) || (len >= sizeof(trash_path))) {
+    if (IS_ERROR((len)) || (len >= sizeof(trash_path))) {
         ret = -1;
         goto out;
     }
@@ -8792,7 +8792,7 @@ glusterd_snapshot_revert_partial_restored_vol(glusterd_volinfo_t *volinfo)
                 ret = sys_lsetxattr(brickinfo->path, GF_XATTR_VOL_ID_KEY,
                                     snap_vol->volume_id,
                                     sizeof(snap_vol->volume_id), XATTR_REPLACE);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SETXATTR_FAIL,
                            "Failed to set extended "
                            "attribute %s on %s. "
@@ -9176,7 +9176,7 @@ glusterd_handle_snapshot_fn(rpcsvc_request_t *req)
     GF_ASSERT(conf);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto out;
     }
@@ -9188,7 +9188,7 @@ glusterd_handle_snapshot_fn(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -9233,7 +9233,7 @@ glusterd_handle_snapshot_fn(rpcsvc_request_t *req)
     }
 
     ret = dict_get_int32n(dict, "type", SLEN("type"), &type);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(err_str, sizeof(err_str), "Command type not found");
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_COMMAND_NOT_FOUND, "%s",
                err_str);

--- a/xlators/mgmt/glusterd/src/glusterd-statedump.c
+++ b/xlators/mgmt/glusterd/src/glusterd-statedump.c
@@ -150,7 +150,7 @@ glusterd_dict_mgmt_v3_lock_statedump(dict_t *dict)
                 uuid_utoa(((glusterd_mgmt_v3_lock_obj *)(trav->value->data))
                               ->lock_owner));
         }
-        if ((ret == -1) || !ret)
+        if (IS_ERROR(ret) || !ret)
             return;
         dumplen += ret;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -1913,7 +1913,7 @@ glusterd_store_global_info(xlator_t *this)
     ret = gf_store_rename_tmppath(handle);
 out:
     if (handle) {
-        if (ret && (handle->fd >= 0))
+        if (IS_SUCCESS(ret && (handle->fd)))
             gf_store_unlink_tmppath(handle);
     }
 
@@ -1982,7 +1982,7 @@ glusterd_store_max_op_version(xlator_t *this)
     ret = gf_store_rename_tmppath(handle);
 out:
     if (handle) {
-        if (ret && (handle->fd >= 0))
+        if (IS_SUCCESS(ret && (handle->fd)))
             gf_store_unlink_tmppath(handle);
     }
 

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -60,7 +60,7 @@
                                   priv->workdir, GLUSTERD_VOLUME_DIR_PREFIX,   \
                                   volinfo->volname, GLUSTERD_BRICK_INFO_DIR);  \
         }                                                                      \
-        if ((_brick_len < 0) || (_brick_len >= PATH_MAX)) {                    \
+        if (IS_ERROR(_brick_len) || (_brick_len >= PATH_MAX)) {                \
             path[0] = 0;                                                       \
         }                                                                      \
     } while (0)
@@ -344,7 +344,7 @@ gd_store_brick_snap_details_write(int fd, glusterd_brickinfo_t *brickinfo)
         ret = snprintf(value + total_len, sizeof(value) - total_len, "%s=%s\n",
                        GLUSTERD_STORE_KEY_BRICK_DEVICE_PATH,
                        brickinfo->device_path);
-        if (ret < 0 || ret >= sizeof(value) - total_len) {
+        if (IS_ERROR(ret) || ret >= sizeof(value) - total_len) {
             ret = -1;
             goto err;
         }
@@ -355,7 +355,7 @@ gd_store_brick_snap_details_write(int fd, glusterd_brickinfo_t *brickinfo)
         ret = snprintf(value + total_len, sizeof(value) - total_len, "%s=%s\n",
                        GLUSTERD_STORE_KEY_BRICK_MOUNT_DIR,
                        brickinfo->mount_dir);
-        if (ret < 0 || ret >= sizeof(value) - total_len) {
+        if (IS_ERROR(ret) || ret >= sizeof(value) - total_len) {
             ret = -1;
             goto err;
         }
@@ -365,7 +365,7 @@ gd_store_brick_snap_details_write(int fd, glusterd_brickinfo_t *brickinfo)
     if (brickinfo->fstype[0] != '\0') {
         ret = snprintf(value + total_len, sizeof(value) - total_len, "%s=%s\n",
                        GLUSTERD_STORE_KEY_BRICK_FSTYPE, brickinfo->fstype);
-        if (ret < 0 || ret >= sizeof(value) - total_len) {
+        if (IS_ERROR(ret) || ret >= sizeof(value) - total_len) {
             ret = -1;
             goto err;
         }
@@ -375,7 +375,7 @@ gd_store_brick_snap_details_write(int fd, glusterd_brickinfo_t *brickinfo)
     if (brickinfo->mnt_opts[0] != '\0') {
         ret = snprintf(value + total_len, sizeof(value) - total_len, "%s=%s\n",
                        GLUSTERD_STORE_KEY_BRICK_MNTOPTS, brickinfo->mnt_opts);
-        if (ret < 0 || ret >= sizeof(value) - total_len) {
+        if (IS_ERROR(ret) || ret >= sizeof(value) - total_len) {
             ret = -1;
             goto err;
         }
@@ -385,7 +385,7 @@ gd_store_brick_snap_details_write(int fd, glusterd_brickinfo_t *brickinfo)
     ret = snprintf(value + total_len, sizeof(value) - total_len, "%s=%d\n",
                    GLUSTERD_STORE_KEY_BRICK_SNAP_STATUS,
                    brickinfo->snap_status);
-    if (ret < 0 || ret >= sizeof(value) - total_len) {
+    if (IS_ERROR(ret) || ret >= sizeof(value) - total_len) {
         ret = -1;
         goto err;
     }
@@ -394,7 +394,7 @@ gd_store_brick_snap_details_write(int fd, glusterd_brickinfo_t *brickinfo)
     ret = snprintf(value + total_len, sizeof(value) - total_len,
                    "%s=%" PRIu64 "\n", GLUSTERD_STORE_KEY_BRICK_FSID,
                    brickinfo->statfs_fsid);
-    if (ret < 0 || ret >= sizeof(value) - total_len) {
+    if (IS_ERROR(ret) || ret >= sizeof(value) - total_len) {
         ret = -1;
         goto err;
     }
@@ -432,7 +432,7 @@ glusterd_store_brickinfo_write(int fd, glusterd_brickinfo_t *brickinfo)
                    brickinfo->decommissioned, GLUSTERD_STORE_KEY_BRICK_ID,
                    brickinfo->brick_id);
 
-    if (ret < 0 || ret >= sizeof(value)) {
+    if (IS_ERROR(ret) || ret >= sizeof(value)) {
         ret = -1;
         goto out;
     }
@@ -642,7 +642,7 @@ glusterd_store_delete_brick(glusterd_brickinfo_t *brickinfo, char *delete_path)
 
     ret = sys_unlink(brickpath);
 
-    if ((ret < 0) && (errno != ENOENT)) {
+    if (IS_ERROR(ret) && (errno != ENOENT)) {
         gf_msg_debug(this->name, 0, "Unlink failed on %s", brickpath);
         ret = -1;
         goto out;
@@ -776,7 +776,7 @@ glusterd_volume_write_snap_details(int fd, glusterd_volinfo_t *volinfo)
                    uuid_utoa(volinfo->restored_from_snap),
                    GLUSTERD_STORE_KEY_SNAP_MAX_HARD_LIMIT,
                    volinfo->snap_max_hard_limit);
-    if (ret < 0 || ret >= sizeof(buf)) {
+    if (IS_ERROR(ret) || ret >= sizeof(buf)) {
         ret = -1;
         goto err;
     }
@@ -820,7 +820,7 @@ glusterd_volume_exclude_options_write(int fd, glusterd_volinfo_t *volinfo)
                    GLUSTERD_STORE_KEY_VOL_SUB_COUNT, volinfo->sub_count,
                    GLUSTERD_STORE_KEY_VOL_STRIPE_CNT, volinfo->stripe_count,
                    GLUSTERD_STORE_KEY_VOL_REPLICA_CNT, volinfo->replica_count);
-    if (ret < 0 || ret >= sizeof(buf) - total_len) {
+    if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
         ret = -1;
         goto out;
     }
@@ -830,7 +830,7 @@ glusterd_volume_exclude_options_write(int fd, glusterd_volinfo_t *volinfo)
         ret = snprintf(buf + total_len, sizeof(buf) - total_len, "%s=%d\n",
                        GLUSTERD_STORE_KEY_VOL_ARBITER_CNT,
                        volinfo->arbiter_count);
-        if (ret < 0 || ret >= sizeof(buf) - total_len) {
+        if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
             ret = -1;
             goto out;
         }
@@ -842,7 +842,7 @@ glusterd_volume_exclude_options_write(int fd, glusterd_volinfo_t *volinfo)
             buf + total_len, sizeof(buf) - total_len, "%s=%d\n%s=%d\n",
             GLUSTERD_STORE_KEY_VOL_DISPERSE_CNT, volinfo->disperse_count,
             GLUSTERD_STORE_KEY_VOL_REDUNDANCY_CNT, volinfo->redundancy_count);
-        if (ret < 0 || ret >= sizeof(buf) - total_len) {
+        if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
             ret = -1;
             goto out;
         }
@@ -854,7 +854,7 @@ glusterd_volume_exclude_options_write(int fd, glusterd_volinfo_t *volinfo)
                    volinfo->version, GLUSTERD_STORE_KEY_VOL_TRANSPORT,
                    volinfo->transport_type, GLUSTERD_STORE_KEY_VOL_ID,
                    uuid_utoa(volinfo->volume_id));
-    if (ret < 0 || ret >= sizeof(buf) - total_len) {
+    if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
         ret = -1;
         goto out;
     }
@@ -864,7 +864,7 @@ glusterd_volume_exclude_options_write(int fd, glusterd_volinfo_t *volinfo)
     if (str) {
         ret = snprintf(buf + total_len, sizeof(buf) - total_len, "%s=%s\n",
                        GLUSTERD_STORE_KEY_USERNAME, str);
-        if (ret < 0 || ret >= sizeof(buf) - total_len) {
+        if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
             ret = -1;
             goto out;
         }
@@ -875,7 +875,7 @@ glusterd_volume_exclude_options_write(int fd, glusterd_volinfo_t *volinfo)
     if (str) {
         ret = snprintf(buf + total_len, sizeof(buf) - total_len, "%s=%s\n",
                        GLUSTERD_STORE_KEY_PASSWORD, str);
-        if (ret < 0 || ret >= sizeof(buf) - total_len) {
+        if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
             ret = -1;
             goto out;
         }
@@ -886,7 +886,7 @@ glusterd_volume_exclude_options_write(int fd, glusterd_volinfo_t *volinfo)
                    GLUSTERD_STORE_KEY_VOL_OP_VERSION, volinfo->op_version,
                    GLUSTERD_STORE_KEY_VOL_CLIENT_OP_VERSION,
                    volinfo->client_op_version);
-    if (ret < 0 || ret >= sizeof(buf) - total_len) {
+    if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
         ret = -1;
         goto out;
     }
@@ -896,7 +896,7 @@ glusterd_volume_exclude_options_write(int fd, glusterd_volinfo_t *volinfo)
         ret = snprintf(buf + total_len, sizeof(buf) - total_len, "%s=%d\n",
                        GLUSTERD_STORE_KEY_VOL_QUOTA_VERSION,
                        volinfo->quota_xattr_version);
-        if (ret < 0 || ret >= sizeof(buf) - total_len) {
+        if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
             ret = -1;
             goto out;
         }
@@ -905,7 +905,7 @@ glusterd_volume_exclude_options_write(int fd, glusterd_volinfo_t *volinfo)
     if (conf->op_version >= GD_OP_VERSION_3_10_0) {
         ret = snprintf(buf + total_len, sizeof(buf) - total_len, "%s=0\n",
                        GF_TIER_ENABLED);
-        if (ret < 0 || ret >= sizeof(buf) - total_len) {
+        if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
             ret = -1;
             goto out;
         }
@@ -917,7 +917,7 @@ glusterd_volume_exclude_options_write(int fd, glusterd_volinfo_t *volinfo)
         ret = snprintf(buf + total_len, sizeof(buf) - total_len, "%s=%d\n",
                        GLUSTERD_STORE_KEY_VOL_THIN_ARBITER_CNT,
                        volinfo->thin_arbiter_count);
-        if (ret < 0 || ret >= sizeof(buf) - total_len) {
+        if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
             ret = -1;
             goto out;
         }
@@ -1056,7 +1056,7 @@ glusterd_store_snapinfo_write(glusterd_snap_t *snap)
                    uuid_utoa(snap->snap_id), GLUSTERD_STORE_KEY_SNAP_STATUS,
                    snap->snap_status, GLUSTERD_STORE_KEY_SNAP_RESTORED,
                    snap->snap_restored);
-    if (ret < 0 || ret >= sizeof(buf) - total_len) {
+    if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
         ret = -1;
         goto out;
     }
@@ -1065,7 +1065,7 @@ glusterd_store_snapinfo_write(glusterd_snap_t *snap)
     if (snap->description) {
         ret = snprintf(buf + total_len, sizeof(buf) - total_len, "%s=%s\n",
                        GLUSTERD_STORE_KEY_SNAP_DESC, snap->description);
-        if (ret < 0 || ret >= sizeof(buf) - total_len) {
+        if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
             ret = -1;
             goto out;
         }
@@ -1074,7 +1074,7 @@ glusterd_store_snapinfo_write(glusterd_snap_t *snap)
 
     ret = snprintf(buf + total_len, sizeof(buf) - total_len, "%s=%ld\n",
                    GLUSTERD_STORE_KEY_SNAP_TIMESTAMP, snap->time_stamp);
-    if (ret < 0 || ret >= sizeof(buf) - total_len) {
+    if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
         ret = -1;
         goto out;
     }
@@ -1305,7 +1305,7 @@ glusterd_store_node_state_write(int fd, glusterd_volinfo_t *volinfo)
                    GLUSTERD_STORE_KEY_VOL_DEFRAG_STATUS,
                    volinfo->rebal.defrag_status, GLUSTERD_STORE_KEY_DEFRAG_OP,
                    volinfo->rebal.op, GF_REBALANCE_TID_KEY, uuid);
-    if (ret < 0 || ret >= sizeof(buf) - total_len) {
+    if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
         ret = -1;
         goto out;
     }
@@ -1322,7 +1322,7 @@ glusterd_store_node_state_write(int fd, glusterd_volinfo_t *volinfo)
         volinfo->rebal.rebalance_failures,
         GLUSTERD_STORE_KEY_VOL_DEFRAG_SKIPPED, volinfo->rebal.skipped_files,
         GLUSTERD_STORE_KEY_VOL_DEFRAG_RUN_TIME, volinfo->rebal.rebalance_time);
-    if (ret < 0 || ret >= sizeof(buf) - total_len) {
+    if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
         ret = -1;
         goto out;
     }
@@ -1659,13 +1659,13 @@ glusterd_store_delete_volume(glusterd_volinfo_t *volinfo)
     len = snprintf(delete_path, sizeof(delete_path),
                    "%s/" GLUSTERD_TRASH "/%s.deleted", priv->workdir,
                    uuid_utoa(volinfo->volume_id));
-    if ((len < 0) || (len >= sizeof(delete_path))) {
+    if (IS_ERROR(len) || (len >= sizeof(delete_path))) {
         goto out;
     }
 
     len = snprintf(trashdir, sizeof(trashdir), "%s/" GLUSTERD_TRASH,
                    priv->workdir);
-    if ((len < 0) || (len >= sizeof(trashdir))) {
+    if (IS_ERROR(len) || (len >= sizeof(trashdir))) {
         goto out;
     }
 
@@ -1746,13 +1746,13 @@ glusterd_store_delete_snap(glusterd_snap_t *snap)
     len = snprintf(delete_path, sizeof(delete_path),
                    "%s/" GLUSTERD_TRASH "/snap-%s.deleted", priv->workdir,
                    uuid_utoa(snap->snap_id));
-    if ((len < 0) || (len >= sizeof(delete_path))) {
+    if (IS_ERROR(len) || (len >= sizeof(delete_path))) {
         goto out;
     }
 
     len = snprintf(trashdir, sizeof(trashdir), "%s/" GLUSTERD_TRASH,
                    priv->workdir);
-    if ((len < 0) || (len >= sizeof(trashdir))) {
+    if (IS_ERROR(len) || (len >= sizeof(trashdir))) {
         goto out;
     }
 
@@ -1784,11 +1784,11 @@ glusterd_store_delete_snap(glusterd_snap_t *snap)
     GF_SKIP_IRRELEVANT_ENTRIES(entry, dir, scratch);
     while (entry) {
         len = snprintf(path, PATH_MAX, "%s/%s", delete_path, entry->d_name);
-        if ((len < 0) || (len >= PATH_MAX)) {
+        if (IS_ERROR(len) || (len >= PATH_MAX)) {
             goto stat_failed;
         }
         ret = sys_stat(path, &st);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg_debug(this->name, 0,
                          "Failed to stat "
                          "entry %s",
@@ -1859,7 +1859,7 @@ glusterd_store_global_info(xlator_t *this)
     if (!conf->handle) {
         ret = snprintf(buf, sizeof(buf), "%s/%s", conf->workdir,
                        GLUSTERD_INFO_FILE);
-        if ((ret < 0) || (ret >= sizeof(buf))) {
+        if (IS_ERROR(ret) || (ret >= sizeof(buf))) {
             ret = -1;
             goto out;
         }
@@ -1883,14 +1883,14 @@ glusterd_store_global_info(xlator_t *this)
     }
 
     handle->fd = gf_store_mkstemp(handle);
-    if (handle->fd < 0) {
+    if (IS_ERROR(handle->fd)) {
         ret = -1;
         goto out;
     }
 
     ret = snprintf(buf, sizeof(buf), "%s=%s\n", GLUSTERD_STORE_UUID_KEY,
                    uuid_str);
-    if (ret < 0 || ret >= sizeof(buf)) {
+    if (IS_ERROR(ret) || ret >= sizeof(buf)) {
         ret = -1;
         goto out;
     }
@@ -1898,7 +1898,7 @@ glusterd_store_global_info(xlator_t *this)
 
     ret = snprintf(buf + total_len, sizeof(buf) - total_len, "%s=%d\n",
                    GD_OP_VERSION_KEY, conf->op_version);
-    if (ret < 0 || ret >= sizeof(buf) - total_len) {
+    if (IS_ERROR(ret) || ret >= sizeof(buf) - total_len) {
         ret = -1;
         goto out;
     }
@@ -1946,7 +1946,7 @@ glusterd_store_max_op_version(xlator_t *this)
 
     len = snprintf(path, PATH_MAX, "%s/%s", conf->workdir,
                    GLUSTERD_UPGRADE_FILE);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         goto out;
     }
     ret = gf_store_handle_new(path, &handle);
@@ -1965,7 +1965,7 @@ glusterd_store_max_op_version(xlator_t *this)
     }
 
     handle->fd = gf_store_mkstemp(handle);
-    if (handle->fd < 0) {
+    if (IS_ERROR(handle->fd)) {
         ret = -1;
         goto out;
     }
@@ -2013,7 +2013,7 @@ glusterd_retrieve_max_op_version(xlator_t *this, int *op_version)
 
     len = snprintf(path, PATH_MAX, "%s/%s", priv->workdir,
                    GLUSTERD_UPGRADE_FILE);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         goto out;
     }
     ret = gf_store_handle_retrieve(path, &handle);
@@ -2069,7 +2069,7 @@ glusterd_retrieve_op_version(xlator_t *this, int *op_version)
     if (!priv->handle) {
         len = snprintf(path, PATH_MAX, "%s/%s", priv->workdir,
                        GLUSTERD_INFO_FILE);
-        if ((len < 0) || (len >= PATH_MAX)) {
+        if (IS_ERROR(len) || (len >= PATH_MAX)) {
             goto out;
         }
         ret = gf_store_handle_retrieve(path, &handle);
@@ -2183,7 +2183,7 @@ glusterd_retrieve_uuid()
     if (!priv->handle) {
         len = snprintf(path, PATH_MAX, "%s/%s", priv->workdir,
                        GLUSTERD_INFO_FILE);
-        if ((len < 0) || (len >= PATH_MAX)) {
+        if (IS_ERROR(len) || (len >= PATH_MAX)) {
             goto out;
         }
         ret = gf_store_handle_retrieve(path, &handle);
@@ -2267,7 +2267,7 @@ glusterd_store_retrieve_snapd(glusterd_volinfo_t *volinfo)
 
     len = snprintf(path, sizeof(path), "%s/%s", volpath,
                    GLUSTERD_VOLUME_SNAPD_INFO_FILE);
-    if ((len < 0) || (len >= sizeof(path))) {
+    if (IS_ERROR(len) || (len >= sizeof(path))) {
         goto out;
     }
 
@@ -2376,7 +2376,7 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
         len = snprintf(path, sizeof(path), "%s/%s", brickdir, tmpvalue);
         GF_FREE(tmpvalue);
         tmpvalue = NULL;
-        if ((len < 0) || (len >= sizeof(path))) {
+        if (IS_ERROR(len) || (len >= sizeof(path))) {
             ret = -1;
             goto out;
         }
@@ -2431,7 +2431,7 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
             } else if (!strncmp(key, GLUSTERD_STORE_KEY_BRICK_PORT,
                                 SLEN(GLUSTERD_STORE_KEY_BRICK_PORT))) {
                 ret = gf_string2int(value, &brickinfo->port);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     gf_msg(this->name, GF_LOG_ERROR, EINVAL,
                            GD_MSG_INCOMPATIBLE_VALUE,
                            "Failed to convert "
@@ -2452,7 +2452,7 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
             } else if (!strncmp(key, GLUSTERD_STORE_KEY_BRICK_RDMA_PORT,
                                 SLEN(GLUSTERD_STORE_KEY_BRICK_RDMA_PORT))) {
                 ret = gf_string2int(value, &brickinfo->rdma_port);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     gf_msg(this->name, GF_LOG_ERROR, EINVAL,
                            GD_MSG_INCOMPATIBLE_VALUE,
                            "Failed to convert "
@@ -2475,7 +2475,7 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
                            key, GLUSTERD_STORE_KEY_BRICK_DECOMMISSIONED,
                            SLEN(GLUSTERD_STORE_KEY_BRICK_DECOMMISSIONED))) {
                 ret = gf_string2int(value, &brickinfo->decommissioned);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     gf_msg(this->name, GF_LOG_ERROR, EINVAL,
                            GD_MSG_INCOMPATIBLE_VALUE,
                            "Failed to convert "
@@ -2504,7 +2504,7 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
             } else if (!strncmp(key, GLUSTERD_STORE_KEY_BRICK_SNAP_STATUS,
                                 SLEN(GLUSTERD_STORE_KEY_BRICK_SNAP_STATUS))) {
                 ret = gf_string2int(value, &brickinfo->snap_status);
-                if (ret == -1) {
+                if (IS_ERROR(ret)) {
                     gf_msg(this->name, GF_LOG_ERROR, EINVAL,
                            GD_MSG_INCOMPATIBLE_VALUE,
                            "Failed to convert "
@@ -2660,7 +2660,7 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
             len = snprintf(path, sizeof(path), "%s/%s", brickdir, tmpvalue);
             GF_FREE(tmpvalue);
             tmpvalue = NULL;
-            if ((len < 0) || (len >= sizeof(path))) {
+            if (IS_ERROR(len) || (len >= sizeof(path))) {
                 ret = -1;
                 goto out;
             }
@@ -2720,7 +2720,7 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
                 } else if (!strncmp(key, GLUSTERD_STORE_KEY_BRICK_PORT,
                                     SLEN(GLUSTERD_STORE_KEY_BRICK_PORT))) {
                     ret = gf_string2int(value, &ta_brickinfo->port);
-                    if (ret == -1) {
+                    if (IS_ERROR(ret)) {
                         gf_msg(this->name, GF_LOG_ERROR, EINVAL,
                                GD_MSG_INCOMPATIBLE_VALUE,
                                "Failed to convert "
@@ -2735,7 +2735,7 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
                 } else if (!strncmp(key, GLUSTERD_STORE_KEY_BRICK_RDMA_PORT,
                                     SLEN(GLUSTERD_STORE_KEY_BRICK_RDMA_PORT))) {
                     ret = gf_string2int(value, &ta_brickinfo->rdma_port);
-                    if (ret == -1) {
+                    if (IS_ERROR(ret)) {
                         gf_msg(this->name, GF_LOG_ERROR, EINVAL,
                                GD_MSG_INCOMPATIBLE_VALUE,
                                "Failed to convert "
@@ -2751,7 +2751,7 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
                                key, GLUSTERD_STORE_KEY_BRICK_DECOMMISSIONED,
                                SLEN(GLUSTERD_STORE_KEY_BRICK_DECOMMISSIONED))) {
                     ret = gf_string2int(value, &ta_brickinfo->decommissioned);
-                    if (ret == -1) {
+                    if (IS_ERROR(ret)) {
                         gf_msg(this->name, GF_LOG_ERROR, EINVAL,
                                GD_MSG_INCOMPATIBLE_VALUE,
                                "Failed to convert "
@@ -2784,7 +2784,7 @@ glusterd_store_retrieve_bricks(glusterd_volinfo_t *volinfo)
                                key, GLUSTERD_STORE_KEY_BRICK_SNAP_STATUS,
                                SLEN(GLUSTERD_STORE_KEY_BRICK_SNAP_STATUS))) {
                     ret = gf_string2int(value, &ta_brickinfo->snap_status);
-                    if (ret == -1) {
+                    if (IS_ERROR(ret)) {
                         gf_msg(this->name, GF_LOG_ERROR, EINVAL,
                                GD_MSG_INCOMPATIBLE_VALUE,
                                "Failed to convert "
@@ -2862,7 +2862,7 @@ glusterd_store_retrieve_node_state(glusterd_volinfo_t *volinfo)
     GLUSTERD_GET_VOLUME_DIR(volpath, volinfo, priv);
     len = snprintf(path, sizeof(path), "%s/%s", volpath,
                    GLUSTERD_NODE_STATE_FILE);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         goto out;
     }
 
@@ -3003,7 +3003,7 @@ glusterd_store_update_volinfo(glusterd_volinfo_t *volinfo)
 
     len = snprintf(path, sizeof(path), "%s/%s", volpath,
                    GLUSTERD_VOLUME_INFO_FILE);
-    if ((len < 0) || (len >= sizeof(path))) {
+    if (IS_ERROR(len) || (len >= sizeof(path))) {
         goto out;
     }
 
@@ -3379,7 +3379,7 @@ glusterd_store_options(xlator_t *this, dict_t *opts)
     if (ret)
         goto out;
 out:
-    if ((ret < 0) && (fd > 0))
+    if (IS_ERROR(ret) && (fd > 0))
         gf_store_unlink_tmppath(shandle);
     gf_store_handle_destroy(shandle);
     return ret;
@@ -3466,7 +3466,7 @@ glusterd_store_retrieve_volumes(xlator_t *this, glusterd_snap_t *snap)
     else
         len = snprintf(path, PATH_MAX, "%s/%s", priv->workdir,
                        GLUSTERD_VOLUME_DIR_PREFIX);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         goto out;
     }
 
@@ -3486,11 +3486,11 @@ glusterd_store_retrieve_volumes(xlator_t *this, glusterd_snap_t *snap)
             goto next;
 
         len = snprintf(entry_path, PATH_MAX, "%s/%s", path, entry->d_name);
-        if ((len < 0) || (len >= PATH_MAX)) {
+        if (IS_ERROR(len) || (len >= PATH_MAX)) {
             goto next;
         }
         ret = sys_lstat(entry_path, &st);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_INVALID_ENTRY,
                    "Failed to stat entry %s : %s", path, strerror(errno));
             goto next;
@@ -3679,7 +3679,7 @@ glusterd_recreate_vol_brick_mounts(xlator_t *this, glusterd_volinfo_t *volinfo)
          * a snapshotted brick, we continue
          */
         if ((gf_uuid_compare(brickinfo->uuid, MY_UUID)) ||
-            (brickinfo->snap_status == -1) ||
+            (IS_ERROR(brickinfo->snap_status)) ||
             (strlen(brickinfo->device_path) == 0))
             continue;
 
@@ -3814,7 +3814,7 @@ glusterd_store_update_snap(glusterd_snap_t *snap)
 
     len = snprintf(path, sizeof(path), "%s/%s", snappath,
                    GLUSTERD_SNAP_INFO_FILE);
-    if ((len < 0) || (len >= sizeof(path))) {
+    if (IS_ERROR(len) || (len >= sizeof(path))) {
         goto out;
     }
 
@@ -4055,7 +4055,7 @@ glusterd_store_retrieve_snaps(xlator_t *this)
     GF_ASSERT(priv);
 
     len = snprintf(path, PATH_MAX, "%s/snaps", priv->workdir);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         ret = -1;
         goto out;
     }
@@ -4235,7 +4235,7 @@ glusterd_store_delete_peerinfo(glusterd_peerinfo_t *peerinfo)
     priv = this->private;
 
     len = snprintf(peerdir, PATH_MAX, "%s/peers", priv->workdir);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         goto out;
     }
 
@@ -4243,7 +4243,7 @@ glusterd_store_delete_peerinfo(glusterd_peerinfo_t *peerinfo)
         if (peerinfo->hostname) {
             len = snprintf(filepath, PATH_MAX, "%s/%s", peerdir,
                            peerinfo->hostname);
-            if ((len < 0) || (len >= PATH_MAX)) {
+            if (IS_ERROR(len) || (len >= PATH_MAX)) {
                 goto out;
             }
         } else {
@@ -4253,12 +4253,12 @@ glusterd_store_delete_peerinfo(glusterd_peerinfo_t *peerinfo)
     } else {
         len = snprintf(filepath, PATH_MAX, "%s/%s", peerdir,
                        uuid_utoa(peerinfo->uuid));
-        if ((len < 0) || (len >= PATH_MAX)) {
+        if (IS_ERROR(len) || (len >= PATH_MAX)) {
             goto out;
         }
         len = snprintf(hostname_path, PATH_MAX, "%s/%s", peerdir,
                        peerinfo->hostname);
-        if ((len < 0) || (len >= PATH_MAX)) {
+        if (IS_ERROR(len) || (len >= PATH_MAX)) {
             goto out;
         }
 
@@ -4408,7 +4408,7 @@ glusterd_store_peer_write(int fd, glusterd_peerinfo_t *peerinfo)
     ret = snprintf(buf + total_len, sizeof(buf) - total_len, "%s=%s\n%s=%d\n",
                    GLUSTERD_STORE_KEY_PEER_UUID, uuid_utoa(peerinfo->uuid),
                    GLUSTERD_STORE_KEY_PEER_STATE, peerinfo->state.state);
-    if (ret < 0 || ret >= sizeof(buf)) {
+    if (IS_ERROR(ret) || ret >= sizeof(buf)) {
         ret = -1;
         goto out;
     }
@@ -4419,7 +4419,7 @@ glusterd_store_peer_write(int fd, glusterd_peerinfo_t *peerinfo)
         ret = snprintf(buf + total_len, sizeof(buf) - total_len,
                        GLUSTERD_STORE_KEY_PEER_HOSTNAME "%d=%s\n", i,
                        hostname->hostname);
-        if (ret < 0 || ret >= sizeof(buf)) {
+        if (IS_ERROR(ret) || ret >= sizeof(buf)) {
             ret = -1;
             goto out;
         }
@@ -4517,7 +4517,7 @@ glusterd_store_retrieve_peers(xlator_t *this)
 
     len = snprintf(path, PATH_MAX, "%s/%s", priv->workdir,
                    GLUSTERD_PEER_DIR_PREFIX);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         ret = -1;
         goto out;
     }
@@ -4543,7 +4543,7 @@ glusterd_store_retrieve_peers(xlator_t *this)
         }
         is_ok = _gf_false;
         len = snprintf(filepath, PATH_MAX, "%s/%s", path, entry->d_name);
-        if ((len < 0) || (len >= PATH_MAX)) {
+        if (IS_ERROR(len) || (len >= PATH_MAX)) {
             goto next;
         }
         ret = gf_store_handle_retrieve(filepath, &shandle);
@@ -4841,7 +4841,7 @@ glusterd_restore()
     this = THIS;
 
     ret = glusterd_options_init(this);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = glusterd_store_retrieve_volumes(this, NULL);
@@ -4915,7 +4915,7 @@ glusterd_store_retrieve_quota_version(glusterd_volinfo_t *volinfo)
     GLUSTERD_GET_VOLUME_DIR(path, volinfo, conf);
     len = snprintf(cksum_path, sizeof(cksum_path), "%s/%s", path,
                    GLUSTERD_VOL_QUOTA_CKSUM_FILE);
-    if ((len < 0) || (len >= sizeof(cksum_path))) {
+    if (IS_ERROR(len) || (len >= sizeof(cksum_path))) {
         goto out;
     }
 
@@ -4971,7 +4971,7 @@ glusterd_store_save_quota_version_and_cksum(glusterd_volinfo_t *volinfo)
     GLUSTERD_GET_VOLUME_DIR(path, volinfo, conf);
     len = snprintf(cksum_path, sizeof(cksum_path), "%s/%s", path,
                    GLUSTERD_VOL_QUOTA_CKSUM_FILE);
-    if ((len < 0) || (len >= sizeof(cksum_path))) {
+    if (IS_ERROR(len) || (len >= sizeof(cksum_path))) {
         goto out;
     }
 
@@ -4987,7 +4987,7 @@ glusterd_store_save_quota_version_and_cksum(glusterd_volinfo_t *volinfo)
 
     ret = snprintf(buf, sizeof(buf), "cksum=%u\nversion=%u\n",
                    volinfo->quota_conf_cksum, volinfo->quota_conf_version);
-    if (ret < 0 || ret >= sizeof(buf)) {
+    if (IS_ERROR(ret) || ret >= sizeof(buf)) {
         ret = -1;
         goto out;
     }
@@ -5004,7 +5004,7 @@ glusterd_store_save_quota_version_and_cksum(glusterd_volinfo_t *volinfo)
         goto out;
 
 out:
-    if ((ret < 0) && (fd > 0))
+    if (IS_ERROR(ret) && (fd > 0))
         gf_store_unlink_tmppath(shandle);
     gf_store_handle_destroy(shandle);
     return ret;
@@ -5040,7 +5040,7 @@ glusterd_quota_conf_write_header(int fd)
     ret = 0;
 
 out:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_msg_callingfn("quota", GF_LOG_ERROR, 0, GD_MSG_QUOTA_CONF_WRITE_FAIL,
                          "failed to write "
                          "header to a quota conf");
@@ -5078,7 +5078,7 @@ glusterd_quota_conf_write_gfid(int fd, void *buf, char type)
     ret = 0;
 
 out:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_msg_callingfn("quota", GF_LOG_ERROR, 0, GD_MSG_QUOTA_CONF_WRITE_FAIL,
                          "failed to write "
                          "gfid %s to a quota conf",

--- a/xlators/mgmt/glusterd/src/glusterd-store.c
+++ b/xlators/mgmt/glusterd/src/glusterd-store.c
@@ -1913,7 +1913,7 @@ glusterd_store_global_info(xlator_t *this)
     ret = gf_store_rename_tmppath(handle);
 out:
     if (handle) {
-        if (IS_SUCCESS(ret && (handle->fd)))
+        if (ret && IS_SUCCESS(handle->fd))
             gf_store_unlink_tmppath(handle);
     }
 
@@ -1982,7 +1982,7 @@ glusterd_store_max_op_version(xlator_t *this)
     ret = gf_store_rename_tmppath(handle);
 out:
     if (handle) {
-        if (IS_SUCCESS(ret && (handle->fd)))
+        if (ret && IS_SUCCESS(handle->fd))
             gf_store_unlink_tmppath(handle);
     }
 

--- a/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
@@ -189,13 +189,13 @@ glusterd_svc_check_volfile_identical(char *svc_name,
                                     sizeof(orgvol));
 
     ret = gf_asprintf(&tmpvol, "/tmp/g%s-XXXXXX", svc_name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
     /* coverity[SECURE_TEMP] mkstemp uses 0600 as the mode and is safe */
     tmp_fd = mkstemp(tmpvol);
-    if (tmp_fd < 0) {
+    if (IS_ERROR(tmp_fd)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, GD_MSG_FILE_OP_FAILED,
                "Unable to create temp file"
                " %s:(%s)",
@@ -251,13 +251,13 @@ glusterd_svc_check_topology_identical(char *svc_name,
 
     /* Create the temporary volfile */
     ret = gf_asprintf(&tmpvol, "/tmp/g%s-XXXXXX", svc_name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
     /* coverity[SECURE_TEMP] mkstemp uses 0600 as the mode and is safe */
     tmpfd = mkstemp(tmpvol);
-    if (tmpfd < 0) {
+    if (IS_ERROR(tmpfd)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, GD_MSG_FILE_OP_FAILED,
                "Unable to create temp file"
                " %s:(%s)",
@@ -308,13 +308,13 @@ glusterd_volume_svc_check_volfile_identical(
                                            sizeof(orgvol));
 
     ret = gf_asprintf(&tmpvol, "/tmp/g%s-XXXXXX", svc_name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
     /* coverity[SECURE_TEMP] mkstemp uses 0600 as the mode and is safe */
     tmp_fd = mkstemp(tmpvol);
-    if (tmp_fd < 0) {
+    if (IS_ERROR(tmp_fd)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, GD_MSG_FILE_OP_FAILED,
                "Unable to create temp file"
                " %s:(%s)",
@@ -369,13 +369,13 @@ glusterd_volume_svc_check_topology_identical(
                                            sizeof(orgvol));
     /* Create the temporary volfile */
     ret = gf_asprintf(&tmpvol, "/tmp/g%s-XXXXXX", svc_name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
     /* coverity[SECURE_TEMP] mkstemp uses 0600 as the mode and is safe */
     tmpfd = mkstemp(tmpvol);
-    if (tmpfd < 0) {
+    if (IS_ERROR(tmpfd)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, GD_MSG_FILE_OP_FAILED,
                "Unable to create temp file"
                " %s:(%s)",
@@ -513,12 +513,12 @@ glusterd_shd_svc_mux_init(glusterd_volinfo_t *volinfo, glusterd_svc_t *svc)
             glusterd_svc_build_shd_pidfile(volinfo, pidfile, sizeof(pidfile));
             ret = snprintf(svc->proc.name, sizeof(svc->proc.name), "%s",
                            "glustershd");
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto unlock;
 
             ret = snprintf(svc->proc.pidfile, sizeof(svc->proc.pidfile), "%s",
                            pidfile);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto unlock;
 
             if (gf_is_service_running(pidfile, &pid)) {
@@ -694,7 +694,7 @@ glusterd_svc_attach_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_getspec_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(frame->this->name, GF_LOG_ERROR, 0, GD_MSG_REQ_DECODE_FAIL,
                "XDR decoding error");
         ret = -1;
@@ -798,7 +798,7 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
         (void)build_volfile_path(volfile_id, path, sizeof(path), NULL, dict);
 
         ret = sys_stat(path, &stbuf);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SVC_ATTACH_FAIL,
                    "Unable to stat %s (%s)", path, strerror(errno));
             ret = -EINVAL;
@@ -812,7 +812,7 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
             goto *errlbl;
         }
         spec_fd = open(path, O_RDONLY);
-        if (spec_fd < 0) {
+        if (IS_ERROR(spec_fd)) {
             gf_msg(THIS->name, GF_LOG_WARNING, 0, GD_MSG_SVC_ATTACH_FAIL,
                    "failed to read volfile %s", path);
             ret = -EIO;
@@ -876,7 +876,7 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
 
     /* Create the xdr payload */
     ret = xdr_serialize_generic(iov, req, (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         goto *errlbl;
     }
     iov.iov_len = ret;

--- a/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-helper.c
@@ -218,7 +218,7 @@ out:
     if (tmpvol != NULL)
         GF_FREE(tmpvol);
 
-    if (tmp_fd >= 0)
+    if (IS_SUCCESS(tmp_fd))
         sys_close(tmp_fd);
 
     return ret;
@@ -275,7 +275,7 @@ glusterd_svc_check_topology_identical(char *svc_name,
     /* Compare the topology of volfiles */
     ret = glusterd_check_topology_identical(orgvol, tmpvol, identical);
 out:
-    if (tmpfd >= 0)
+    if (IS_SUCCESS(tmpfd))
         sys_close(tmpfd);
     if (tmpclean)
         sys_unlink(tmpvol);
@@ -337,7 +337,7 @@ out:
     if (tmpvol != NULL)
         GF_FREE(tmpvol);
 
-    if (tmp_fd >= 0)
+    if (IS_SUCCESS(tmp_fd))
         sys_close(tmp_fd);
 
     return ret;
@@ -393,7 +393,7 @@ glusterd_volume_svc_check_topology_identical(
     /* Compare the topology of volfiles */
     ret = glusterd_check_topology_identical(orgvol, tmpvol, identical);
 out:
-    if (tmpfd >= 0)
+    if (IS_SUCCESS(tmpfd))
         sys_close(tmpfd);
     if (tmpclean)
         sys_unlink(tmpvol);
@@ -888,7 +888,7 @@ __glusterd_send_svc_configure_req(glusterd_svc_t *svc, int flags,
     if (dict)
         dict_unref(dict);
     GF_FREE(volfile_content);
-    if (spec_fd >= 0)
+    if (IS_SUCCESS(spec_fd))
         sys_close(spec_fd);
     return ret;
 
@@ -905,7 +905,7 @@ err:
         GF_FREE(brick_req.dict.dict_val);
 
     GF_FREE(volfile_content);
-    if (spec_fd >= 0)
+    if (IS_SUCCESS(spec_fd))
         sys_close(spec_fd);
     if (frame)
         STACK_DESTROY(frame->root);

--- a/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-svc-mgmt.c
@@ -26,7 +26,7 @@ glusterd_svc_create_rundir(char *rundir)
     int ret = -1;
 
     ret = mkdir_p(rundir, 0755, _gf_true);
-    if ((ret == -1) && (EEXIST != errno)) {
+    if (IS_ERROR(ret) && (EEXIST != errno)) {
         gf_msg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create rundir %s", rundir);
     }
@@ -76,7 +76,7 @@ glusterd_svc_init_common(glusterd_svc_t *svc, char *svc_name, char *workdir,
     GF_ASSERT(priv);
 
     ret = snprintf(svc->name, sizeof(svc->name), "%s", svc_name);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (!notify)
@@ -190,7 +190,7 @@ glusterd_svc_start(glusterd_svc_t *svc, int flags, dict_t *cmdline)
         if (this->ctx->cmd_args.valgrind) {
             len = snprintf(valgrind_logfile, PATH_MAX, "%s/valgrind-%s.log",
                            svc->proc.logdir, svc->name);
-            if ((len < 0) || (len >= PATH_MAX)) {
+            if (IS_ERROR(len) || (len >= PATH_MAX)) {
                 ret = -1;
                 goto unlock;
             }
@@ -508,7 +508,7 @@ glusterd_muxsvc_conn_init(glusterd_conn_t *conn, glusterd_svc_proc_t *mux_proc,
         goto out;
 
     ret = snprintf(conn->sockpath, sizeof(conn->sockpath), "%s", sockpath);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
     else
         ret = 0;

--- a/xlators/mgmt/glusterd/src/glusterd-syncop.c
+++ b/xlators/mgmt/glusterd/src/glusterd-syncop.c
@@ -188,7 +188,7 @@ gd_syncop_submit_request(struct rpc_clnt *rpc, void *req, void *local,
 
     /* Create the xdr payload */
     ret = xdr_serialize_generic(iov, req, xdrproc);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     iov.iov_len = ret;
@@ -352,7 +352,7 @@ gd_syncop_mgmt_v3_lock_cbk_fn(struct rpc_req *req, struct iovec *iov, int count,
     frame->local = NULL;
     frame->cookie = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         op_errno = ENOTCONN;
         goto out;
     }
@@ -360,7 +360,7 @@ gd_syncop_mgmt_v3_lock_cbk_fn(struct rpc_req *req, struct iovec *iov, int count,
     GF_VALIDATE_OR_GOTO_WITH_ERROR(this->name, iov, out, op_errno, EINVAL);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_v3_lock_rsp);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     gf_uuid_copy(args->uuid, rsp.uuid);
@@ -453,7 +453,7 @@ gd_syncop_mgmt_v3_unlock_cbk_fn(struct rpc_req *req, struct iovec *iov,
     frame->local = NULL;
     frame->cookie = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         op_errno = ENOTCONN;
         goto out;
     }
@@ -461,7 +461,7 @@ gd_syncop_mgmt_v3_unlock_cbk_fn(struct rpc_req *req, struct iovec *iov,
     GF_VALIDATE_OR_GOTO_WITH_ERROR(this->name, iov, out, op_errno, EINVAL);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_v3_unlock_rsp);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     gf_uuid_copy(args->uuid, rsp.uuid);
@@ -552,7 +552,7 @@ _gd_syncop_mgmt_lock_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame->local = NULL;
     frame->cookie = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         op_errno = ENOTCONN;
         goto out;
     }
@@ -560,7 +560,7 @@ _gd_syncop_mgmt_lock_cbk(struct rpc_req *req, struct iovec *iov, int count,
     GF_VALIDATE_OR_GOTO_WITH_ERROR(this->name, iov, out, op_errno, EINVAL);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_cluster_lock_rsp);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     gf_uuid_copy(args->uuid, rsp.uuid);
@@ -653,7 +653,7 @@ _gd_syncop_mgmt_unlock_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame->local = NULL;
     frame->cookie = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         op_errno = ENOTCONN;
         goto out;
     }
@@ -662,7 +662,7 @@ _gd_syncop_mgmt_unlock_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_generic(*iov, &rsp,
                          (xdrproc_t)xdr_gd1_mgmt_cluster_unlock_rsp);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     gf_uuid_copy(args->uuid, rsp.uuid);
@@ -753,7 +753,7 @@ _gd_syncop_stage_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame->local = NULL;
     frame->cookie = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         op_errno = ENOTCONN;
         goto out;
     }
@@ -761,7 +761,7 @@ _gd_syncop_stage_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     GF_VALIDATE_OR_GOTO_WITH_ERROR(this->name, iov, out, op_errno, EINVAL);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_stage_op_rsp);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (rsp.dict.dict_len) {
@@ -769,7 +769,7 @@ _gd_syncop_stage_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
         rsp_dict = dict_new();
 
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &rsp_dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             GF_FREE(rsp.dict.dict_val);
             goto out;
         } else {
@@ -888,7 +888,7 @@ _gd_syncop_brick_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     args->op_ret = -1;
     args->op_errno = EINVAL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         args->op_errno = ENOTCONN;
         goto out;
     }
@@ -897,7 +897,7 @@ _gd_syncop_brick_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
                                    EINVAL);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_brick_op_rsp);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (rsp.output.output_len) {
@@ -910,7 +910,7 @@ _gd_syncop_brick_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
         ret = dict_unserialize(rsp.output.output_val, rsp.output.output_len,
                                &args->dict);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 
@@ -1054,7 +1054,7 @@ _gd_syncop_commit_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame->local = NULL;
     frame->cookie = NULL;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         op_errno = ENOTCONN;
         goto out;
     }
@@ -1062,7 +1062,7 @@ _gd_syncop_commit_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
     GF_VALIDATE_OR_GOTO_WITH_ERROR(this->name, iov, out, op_errno, EINVAL);
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gd1_mgmt_commit_op_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -1071,7 +1071,7 @@ _gd_syncop_commit_op_cbk(struct rpc_req *req, struct iovec *iov, int count,
         rsp_dict = dict_new();
 
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &rsp_dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             GF_FREE(rsp.dict.dict_val);
             goto out;
         } else {
@@ -1238,7 +1238,7 @@ gd_lock_op_phase(glusterd_conf_t *conf, glusterd_op_t op, dict_t *op_ctx,
                               "Another transaction "
                               "could be in progress. Please try "
                               "again after some time.");
-            if (ret == -1)
+            if (IS_ERROR(ret))
                 *op_errstr = NULL;
 
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_PEER_LOCK_FAIL,

--- a/xlators/mgmt/glusterd/src/glusterd-tierd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-tierd-svc-helper.c
@@ -44,7 +44,7 @@ glusterd_svc_build_tierd_socket_filepath(glusterd_volinfo_t *volinfo,
     glusterd_svc_build_tierd_rundir(volinfo, rundir, sizeof(rundir));
     len = snprintf(sockfilepath, sizeof(sockfilepath), "%s/run-%s", rundir,
                    uuid_utoa(MY_UUID));
-    if ((len < 0) || (len >= sizeof(sockfilepath))) {
+    if (IS_ERROR((len)) || (len >= sizeof(sockfilepath))) {
         sockfilepath[0] = 0;
     }
 
@@ -113,13 +113,13 @@ glusterd_svc_check_tier_volfile_identical(char *svc_name,
     glusterd_svc_build_tierd_volfile_path(volinfo, orgvol, sizeof(orgvol));
 
     ret = gf_asprintf(&tmpvol, "/tmp/g%s-XXXXXX", svc_name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
     /* coverity[SECURE_TEMP] mkstemp uses 0600 as the mode and is safe */
     tmp_fd = mkstemp(tmpvol);
-    if (tmp_fd < 0) {
+    if (IS_ERROR(tmp_fd)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, GD_MSG_FILE_OP_FAILED,
                "Unable to create temp file"
                " %s:(%s)",
@@ -174,13 +174,13 @@ glusterd_svc_check_tier_topology_identical(char *svc_name,
     glusterd_svc_build_tierd_volfile_path(volinfo, orgvol, sizeof(orgvol));
 
     ret = gf_asprintf(&tmpvol, "/tmp/g%s-XXXXXX", svc_name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
     /* coverity[SECURE_TEMP] mkstemp uses 0600 as the mode and is safe */
     tmpfd = mkstemp(tmpvol);
-    if (tmpfd < 0) {
+    if (IS_ERROR(tmpfd)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, GD_MSG_FILE_OP_FAILED,
                "Unable to create temp file"
                " %s:(%s)",

--- a/xlators/mgmt/glusterd/src/glusterd-tierd-svc-helper.c
+++ b/xlators/mgmt/glusterd/src/glusterd-tierd-svc-helper.c
@@ -144,7 +144,7 @@ out:
     if (tmpvol != NULL)
         GF_FREE(tmpvol);
 
-    if (tmp_fd >= 0)
+    if (IS_SUCCESS(tmp_fd))
         sys_close(tmp_fd);
 
     return ret;
@@ -197,7 +197,7 @@ glusterd_svc_check_tier_topology_identical(char *svc_name,
     /* Compare the topology of volfiles */
     ret = glusterd_check_topology_identical(orgvol, tmpvol, identical);
 out:
-    if (tmpfd >= 0)
+    if (IS_SUCCESS(tmpfd))
         sys_close(tmpfd);
     if (tmpclean)
         sys_unlink(tmpvol);

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -96,7 +96,7 @@
         int32_t _nfs_pid_len;                                                  \
         _nfs_pid_len = snprintf(pidfile, PATH_MAX, "%s/nfs/nfs.pid",           \
                                 priv->rundir);                                 \
-        if ((_nfs_pid_len < 0) || (_nfs_pid_len >= PATH_MAX)) {                \
+        if (IS_ERROR((_nfs_pid_len)) || (_nfs_pid_len >= PATH_MAX)) {          \
             pidfile[0] = 0;                                                    \
         }                                                                      \
     } while (0)
@@ -107,7 +107,7 @@
         int32_t _quotad_pid_len;                                               \
         _quotad_pid_len = snprintf(pidfile, PATH_MAX, "%s/quotad/quotad.pid",  \
                                    priv->rundir);                              \
-        if ((_quotad_pid_len < 0) || (_quotad_pid_len >= PATH_MAX)) {          \
+        if (IS_ERROR((_quotad_pid_len)) || (_quotad_pid_len >= PATH_MAX)) {    \
             pidfile[0] = 0;                                                    \
         }                                                                      \
     } while (0)
@@ -456,7 +456,7 @@ glusterd_submit_request(struct rpc_clnt *rpc, void *req, call_frame_t *frame,
 
         /* Create the xdr payload */
         ret = xdr_serialize_generic(iov, req, xdrproc);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             goto out;
         }
         iov.iov_len = ret;
@@ -511,7 +511,7 @@ glusterd_serialize_reply(rpcsvc_request_t *req, void *arg, struct iovec *outmsg,
      * need -1 for error notification during encoding.
      */
     retlen = xdr_serialize_generic(*outmsg, arg, xdrproc);
-    if (retlen == -1) {
+    if (IS_ERROR(retlen)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_ENCODE_FAIL,
                "Failed to encode message");
         goto ret;
@@ -519,7 +519,7 @@ glusterd_serialize_reply(rpcsvc_request_t *req, void *arg, struct iovec *outmsg,
 
     outmsg->iov_len = retlen;
 ret:
-    if (retlen == -1) {
+    if (IS_ERROR(retlen)) {
         iobuf_unref(iob);
         iob = NULL;
     }
@@ -569,7 +569,7 @@ glusterd_submit_reply(rpcsvc_request_t *req, void *arg, struct iovec *payload,
      * we can safely unref the iob in the hope that RPC layer must have
      * ref'ed the iob on receiving into the txlist.
      */
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_REPLY_SUBMIT_FAIL,
                "Reply submission failed");
         goto out;
@@ -1030,7 +1030,7 @@ glusterd_get_next_available_brickid(glusterd_volinfo_t *volinfo)
     {
         token = strrchr(brickinfo->brick_id, '-');
         ret = gf_string2int32(++token, &brickid);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(THIS->name, GF_LOG_ERROR, 0, GD_MSG_BRICK_ID_GEN_FAILED,
                    "Unable to generate brick ID");
             return ret;
@@ -1158,13 +1158,13 @@ glusterd_brickinfo_new_from_brick(char *brick, glusterd_brickinfo_t **brickinfo,
         goto out;
     ret = snprintf(new_brickinfo->hostname, sizeof(new_brickinfo->hostname),
                    "%s", hostname);
-    if (ret < 0 || ret >= sizeof(new_brickinfo->hostname)) {
+    if (IS_ERROR(ret) || ret >= sizeof(new_brickinfo->hostname)) {
         ret = -1;
         goto out;
     }
     ret = snprintf(new_brickinfo->path, sizeof(new_brickinfo->path), "%s",
                    path);
-    if (ret < 0 || ret >= sizeof(new_brickinfo->path)) {
+    if (IS_ERROR(ret) || ret >= sizeof(new_brickinfo->path)) {
         ret = -1;
         goto out;
     }
@@ -1377,7 +1377,7 @@ glusterd_validate_and_create_brickpath(glusterd_brickinfo_t *brickinfo,
     }
 
     len = snprintf(parentdir, sizeof(parentdir), "%s/..", brickinfo->path);
-    if ((len < 0) || (len >= sizeof(parentdir))) {
+    if (IS_ERROR((len)) || (len >= sizeof(parentdir))) {
         ret = -1;
         goto out;
     }
@@ -1439,7 +1439,7 @@ glusterd_validate_and_create_brickpath(glusterd_brickinfo_t *brickinfo,
             /* If --wignore-partition flag is used, ignore warnings
              * related to bricks being on root partition when 'force'
              * is not used */
-            if ((len < 0) || (len >= sizeof(msg)) || !ignore_partition) {
+            if (IS_ERROR((len)) || (len >= sizeof(msg)) || !ignore_partition) {
                 ret = -1;
                 goto out;
             }
@@ -1454,7 +1454,7 @@ glusterd_validate_and_create_brickpath(glusterd_brickinfo_t *brickinfo,
     /* create .glusterfs directory */
     len = snprintf(glusterfs_dir_path, sizeof(glusterfs_dir_path), "%s/%s",
                    brickinfo->path, ".glusterfs");
-    if ((len < 0) || (len >= sizeof(glusterfs_dir_path))) {
+    if (IS_ERROR((len)) || (len >= sizeof(glusterfs_dir_path))) {
         ret = -1;
         goto out;
     }
@@ -1472,7 +1472,7 @@ glusterd_validate_and_create_brickpath(glusterd_brickinfo_t *brickinfo,
     ret = 0;
 
 out:
-    if (len < 0) {
+    if (IS_ERROR(len)) {
         ret = -1;
     }
     if (ret && is_created) {
@@ -1758,7 +1758,7 @@ glusterd_service_stop_nolock(const char *service, char *pidfile, int sig,
         }
     }
 
-    if (kill(pid, 0) < 0) {
+    if (IS_ERROR(kill(pid, 0))) {
         ret = 0;
         gf_msg_debug(this->name, 0, "%s process not running: (%d) %s", service,
                      pid, strerror(errno));
@@ -1851,7 +1851,7 @@ glusterd_set_brick_socket_filepath(glusterd_volinfo_t *volinfo,
     GLUSTERD_REMOVE_SLASH_FROM_PATH(brickinfo->path, export_path);
     slen = snprintf(sock_filepath, PATH_MAX, "%s/run/%s-%s", volume_dir,
                     brickinfo->hostname, export_path);
-    if (slen < 0) {
+    if (IS_ERROR(slen)) {
         sock_filepath[0] = 0;
     }
     glusterd_set_socket_filepath(sock_filepath, sockpath, len);
@@ -1891,7 +1891,7 @@ glusterd_brick_connect(glusterd_volinfo_t *volinfo,
         uuid_utoa_r(volinfo->volume_id, volume_id_str);
         ret = gf_asprintf(&brickid, "%s:%s:%s", volume_id_str,
                           brickinfo->hostname, brickinfo->path);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         ret = glusterd_rpc_create(&rpc, options, glusterd_brick_rpc_notify,
@@ -1968,7 +1968,7 @@ glusterd_volume_start_glusterfs(glusterd_volinfo_t *volinfo,
     priv = this->private;
     GF_ASSERT(priv);
 
-    if (brickinfo->snap_status == -1) {
+    if (IS_ERROR(brickinfo->snap_status)) {
         gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_SNAPSHOT_PENDING,
                "Snapshot is pending on %s:%s. "
                "Hence not starting the brick",
@@ -2035,7 +2035,7 @@ retry:
                            "%s/bricks/valgrind-%s-%s.log", priv->logdir,
                            volinfo->volname, exp_path);
         }
-        if ((len < 0) || (len >= PATH_MAX)) {
+        if (IS_ERROR((len)) || (len >= PATH_MAX)) {
             ret = -1;
             goto out;
         }
@@ -2054,7 +2054,7 @@ retry:
         len = snprintf(volfile, PATH_MAX, "%s.%s.%s", volinfo->volname,
                        brickinfo->hostname, exp_path);
     }
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR((len)) || (len >= PATH_MAX)) {
         ret = -1;
         goto out;
     }
@@ -2066,7 +2066,7 @@ retry:
         len = snprintf(logfile, PATH_MAX, "%s/bricks/%s.log", priv->logdir,
                        exp_path);
     }
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR((len)) || (len >= PATH_MAX)) {
         ret = -1;
         goto out;
     }
@@ -2095,7 +2095,7 @@ retry:
     } else {
         len = snprintf(rdma_brick_path, sizeof(rdma_brick_path), "%s.rdma",
                        brickinfo->path);
-        if ((len < 0) || (len >= sizeof(rdma_brick_path))) {
+        if (IS_ERROR((len)) || (len >= sizeof(rdma_brick_path))) {
             ret = -1;
             goto out;
         }
@@ -2646,7 +2646,7 @@ glusterd_sort_and_redirect(const char *src_filepath, int dest_fd)
     int counter = 0;
     char **lines = NULL;
 
-    if (!src_filepath || dest_fd < 0)
+    if (!src_filepath || IS_ERROR(dest_fd))
         goto out;
 
     lines = glusterd_readin_file(src_filepath, &line_count);
@@ -2657,7 +2657,7 @@ glusterd_sort_and_redirect(const char *src_filepath, int dest_fd)
 
     for (counter = 0; lines[counter]; counter++) {
         ret = sys_write(dest_fd, lines[counter], strlen(lines[counter]));
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         GF_FREE(lines[counter]);
@@ -2690,7 +2690,7 @@ glusterd_volume_compute_cksum(glusterd_volinfo_t *volinfo, char *cksum_path,
     GF_ASSERT(priv);
 
     fd = open(cksum_path, O_RDWR | O_APPEND | O_CREAT | O_TRUNC, 0600);
-    if (-1 == fd) {
+    if (IS_ERROR(fd)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
                "Unable to open %s,"
                " errno: %d",
@@ -2706,7 +2706,7 @@ glusterd_volume_compute_cksum(glusterd_volinfo_t *volinfo, char *cksum_path,
         orig_umask = umask(S_IRWXG | S_IRWXO);
         sort_fd = mkstemp(sort_filepath);
         umask(orig_umask);
-        if (-1 == sort_fd) {
+        if (IS_ERROR(sort_fd)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
                    "Could not generate "
                    "temp file, reason: %s for volume: %s",
@@ -2797,7 +2797,7 @@ glusterd_compute_cksum(glusterd_volinfo_t *volinfo, gf_boolean_t is_quota_conf)
         len2 = snprintf(filepath, sizeof(filepath), "%s/%s", path,
                         GLUSTERD_VOLUME_INFO_FILE);
     }
-    if ((len1 < 0) || (len2 < 0) || (len1 >= sizeof(cksum_path)) ||
+    if (IS_ERROR(len1) || IS_ERROR(len2) || (len1 >= sizeof(cksum_path)) ||
         (len2 >= sizeof(filepath))) {
         goto out;
     }
@@ -2831,7 +2831,7 @@ _add_dict_to_prdict(dict_t *this, char *key, data_t *value, void *data)
 
     ret = snprintf(optkey, sizeof(optkey), "%s.%s%d", ctx->prefix,
                    ctx->key_name, ctx->opt_count);
-    if (ret < 0 || ret >= sizeof(optkey))
+    if (IS_ERROR(ret) || ret >= sizeof(optkey))
         return -1;
     ret = dict_set_strn(ctx->dict, optkey, ret, key);
     if (ret)
@@ -2839,7 +2839,7 @@ _add_dict_to_prdict(dict_t *this, char *key, data_t *value, void *data)
                "option add for %s%d %s", ctx->key_name, ctx->opt_count, key);
     ret = snprintf(optkey, sizeof(optkey), "%s.%s%d", ctx->prefix,
                    ctx->val_name, ctx->opt_count);
-    if (ret < 0 || ret >= sizeof(optkey))
+    if (IS_ERROR(ret) || ret >= sizeof(optkey))
         return -1;
     ret = dict_set_strn(ctx->dict, optkey, ret, value->data);
     if (ret)
@@ -2907,7 +2907,7 @@ glusterd_add_volume_to_dict(glusterd_volinfo_t *volinfo, dict_t *dict,
     GF_ASSERT(prefix);
 
     ret = snprintf(pfx, sizeof(pfx), "%s%d", prefix, count);
-    if (ret < 0 || ret >= sizeof(pfx)) {
+    if (IS_ERROR(ret) || ret >= sizeof(pfx)) {
         ret = -1;
         goto out;
     }
@@ -3217,7 +3217,7 @@ glusterd_vol_add_quota_conf_to_dict(glusterd_volinfo_t *volinfo, dict_t *load,
         goto out;
 
     fd = open(volinfo->quota_conf_shandle->path, O_RDONLY);
-    if (fd == -1) {
+    if (IS_ERROR(fd)) {
         ret = -1;
         goto out;
     }
@@ -3227,7 +3227,7 @@ glusterd_vol_add_quota_conf_to_dict(glusterd_volinfo_t *volinfo, dict_t *load,
         goto out;
 
     ret = snprintf(key_prefix, sizeof(key_prefix), "%s%d", prefix, vol_idx);
-    if (ret < 0 || ret >= sizeof(key_prefix)) {
+    if (IS_ERROR(ret) || ret >= sizeof(key_prefix)) {
         ret = -1;
         goto out;
     }
@@ -3235,7 +3235,7 @@ glusterd_vol_add_quota_conf_to_dict(glusterd_volinfo_t *volinfo, dict_t *load,
         ret = quota_conf_read_gfid(fd, buf, &type, version);
         if (ret == 0) {
             break;
-        } else if (ret < 0) {
+        } else if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_CRITICAL, 0, GD_MSG_QUOTA_CONF_CORRUPT,
                    "Quota "
                    "configuration store may be corrupt.");
@@ -3880,7 +3880,7 @@ glusterd_import_new_ta_brick(dict_t *peer_data, int32_t vol_count,
     ret = snprintf(key_prefix, sizeof(key_prefix), "%s%d.ta-brick%d", prefix,
                    vol_count, brick_count);
 
-    if (ret < 0 || ret >= sizeof(key_prefix)) {
+    if (IS_ERROR(ret) || ret >= sizeof(key_prefix)) {
         ret = -1;
         snprintf(msg, sizeof(msg), "key_prefix too long");
         goto out;
@@ -3916,13 +3916,13 @@ glusterd_import_new_ta_brick(dict_t *peer_data, int32_t vol_count,
 
     ret = snprintf(new_ta_brickinfo->path, sizeof(new_ta_brickinfo->path), "%s",
                    path);
-    if (ret < 0 || ret >= sizeof(new_ta_brickinfo->path)) {
+    if (IS_ERROR(ret) || ret >= sizeof(new_ta_brickinfo->path)) {
         ret = -1;
         goto out;
     }
     ret = snprintf(new_ta_brickinfo->hostname,
                    sizeof(new_ta_brickinfo->hostname), "%s", hostname);
-    if (ret < 0 || ret >= sizeof(new_ta_brickinfo->hostname)) {
+    if (IS_ERROR(ret) || ret >= sizeof(new_ta_brickinfo->hostname)) {
         ret = -1;
         goto out;
     }
@@ -3977,7 +3977,7 @@ glusterd_import_new_brick(dict_t *peer_data, int32_t vol_count,
 
     ret = snprintf(key_prefix, sizeof(key_prefix), "%s%d.brick%d", prefix,
                    vol_count, brick_count);
-    if (ret < 0 || ret >= sizeof(key_prefix)) {
+    if (IS_ERROR(ret) || ret >= sizeof(key_prefix)) {
         ret = -1;
         snprintf(msg, sizeof(msg), "key_prefix too long");
         goto out;
@@ -4012,13 +4012,13 @@ glusterd_import_new_brick(dict_t *peer_data, int32_t vol_count,
 
     ret = snprintf(new_brickinfo->path, sizeof(new_brickinfo->path), "%s",
                    path);
-    if (ret < 0 || ret >= sizeof(new_brickinfo->path)) {
+    if (IS_ERROR(ret) || ret >= sizeof(new_brickinfo->path)) {
         ret = -1;
         goto out;
     }
     ret = snprintf(new_brickinfo->hostname, sizeof(new_brickinfo->hostname),
                    "%s", hostname);
-    if (ret < 0 || ret >= sizeof(new_brickinfo->hostname)) {
+    if (IS_ERROR(ret) || ret >= sizeof(new_brickinfo->hostname)) {
         ret = -1;
         goto out;
     }
@@ -4139,13 +4139,13 @@ glusterd_import_quota_conf(dict_t *peer_data, int vol_idx,
         goto out;
 
     fd = gf_store_mkstemp(new_volinfo->quota_conf_shandle);
-    if (fd < 0) {
+    if (IS_ERROR(fd)) {
         ret = -1;
         goto out;
     }
 
     ret = snprintf(key_prefix, sizeof(key_prefix), "%s%d", prefix, vol_idx);
-    if (ret < 0 || ret >= sizeof(key_prefix)) {
+    if (IS_ERROR(ret) || ret >= sizeof(key_prefix)) {
         ret = -1;
         gf_msg_debug(this->name, 0, "Failed to set key_prefix for quota conf");
         goto out;
@@ -4185,7 +4185,7 @@ glusterd_import_quota_conf(dict_t *peer_data, int vol_idx,
 
         gf_uuid_parse(gfid_str, gfid);
         ret = glusterd_quota_conf_write_gfid(fd, gfid, (char)gfid_type);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_CRITICAL, errno,
                    GD_MSG_QUOTA_CONF_WRITE_FAIL,
                    "Unable to write "
@@ -4290,7 +4290,7 @@ glusterd_import_volinfo(dict_t *peer_data, int count,
     GF_ASSERT(prefix);
 
     ret = snprintf(key_prefix, sizeof(key_prefix), "%s%d", prefix, count);
-    if (ret < 0 || ret >= sizeof(key_prefix)) {
+    if (IS_ERROR(ret) || ret >= sizeof(key_prefix)) {
         ret = -1;
         snprintf(msg, sizeof(msg), "key_prefix too big");
         goto out;
@@ -4318,7 +4318,7 @@ glusterd_import_volinfo(dict_t *peer_data, int count,
         goto out;
     ret = snprintf(new_volinfo->volname, sizeof(new_volinfo->volname), "%s",
                    volname);
-    if (ret < 0 || ret >= sizeof(new_volinfo->volname)) {
+    if (IS_ERROR(ret) || ret >= sizeof(new_volinfo->volname)) {
         ret = -1;
         goto out;
     }
@@ -4336,7 +4336,7 @@ glusterd_import_volinfo(dict_t *peer_data, int count,
         ret = snprintf(new_volinfo->parent_volname,
                        sizeof(new_volinfo->parent_volname), "%s",
                        parent_volname);
-        if (ret < 0 || ret >= sizeof(new_volinfo->volname)) {
+        if (IS_ERROR(ret) || ret >= sizeof(new_volinfo->volname)) {
             ret = -1;
             goto out;
         }
@@ -4745,7 +4745,7 @@ glusterd_volinfo_stop_stale_bricks(glusterd_volinfo_t *new_volinfo,
          * or if it's part of the new volume and is pending a snap or if it's
          * brick multiplexing enabled, then stop the brick process
          */
-        if (ret || (new_brickinfo->snap_status == -1) ||
+        if (IS_ERROR(ret) || IS_ERROR(new_brickinfo->snap_status) ||
             is_brick_mx_enabled()) {
             /*TODO: may need to switch to 'atomic' flavour of
              * brick_stop, once we make peer rpc program also
@@ -5275,7 +5275,7 @@ glusterd_compare_friend_data(dict_t *peer_data, int32_t *status, char *hostname)
         arg = GF_CALLOC(1, sizeof(*arg), gf_common_mt_char);
         ret = dict_allocate_and_serialize(peer_data, &arg->dict_buf,
                                           &arg->dictlen);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(this->name, GF_LOG_ERROR,
                    "dict_serialize failed while handling "
                    " import friend volume request");
@@ -5769,7 +5769,7 @@ attach_brick_callback(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_getspec_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(frame->this->name, GF_LOG_ERROR, "XDR decoding error");
         ret = -1;
         goto out;
@@ -5914,7 +5914,7 @@ send_attach_req(xlator_t *this, struct rpc_clnt *rpc, char *path,
 
     /* Create the xdr payload */
     ret = xdr_serialize_generic(iov, req, (xdrproc_t)xdr_gd1_mgmt_brick_op_req);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         goto *errlbl;
     }
 
@@ -5979,7 +5979,7 @@ attach_brick(xlator_t *this, glusterd_brickinfo_t *brickinfo,
         len = snprintf(full_id, sizeof(full_id), "%s.%s.%s", volinfo->volname,
                        brickinfo->hostname, unslashed);
     }
-    if ((len < 0) || (len >= sizeof(full_id))) {
+    if (IS_ERROR((len)) || (len >= sizeof(full_id))) {
         goto out;
     }
 
@@ -6369,7 +6369,7 @@ search_brick_path_from_proc(pid_t brick_pid, char *brickpath)
         goto out;
 
     fd = dirfd(dirp);
-    if (fd < 0)
+    if (IS_ERROR(fd))
         goto out;
 
     while ((dp = sys_readdir(dirp, scratch))) {
@@ -6859,7 +6859,7 @@ _local_gsyncd_start(dict_t *this, char *key, data_t *value, void *data)
 
     ret = gsync_status(volinfo->volname, slave, confpath, &ret_status,
                        &is_template_in_use);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this1->name, GF_LOG_INFO, 0, GD_MSG_GSYNC_VALIDATION_FAIL,
                GEOREP " start option validation failed ");
         ret = 0;
@@ -8006,7 +8006,7 @@ glusterd_check_and_set_brick_xattr(char *host, char *path, uuid_t uuid,
 
     /* Check for xattr support in backend fs */
     ret = sys_lsetxattr(path, "trusted.glusterfs.test", "working", 8, 0);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         snprintf(msg, sizeof(msg),
                  "Glusterfs is not"
                  " supported on brick: %s:%s.\nSetting"
@@ -8039,7 +8039,7 @@ glusterd_check_and_set_brick_xattr(char *host, char *path, uuid_t uuid,
         flags = XATTR_CREATE;
 
     ret = sys_lsetxattr(path, GF_XATTR_VOL_ID_KEY, uuid, 16, flags);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         snprintf(msg, sizeof(msg),
                  "Failed to set extended "
                  "attributes %s, reason: %s",
@@ -8443,7 +8443,7 @@ glusterd_start_gsync(glusterd_volinfo_t *master_vol, char *slave,
     synclock_unlock(&priv->big_lock);
     ret = runner_run(&runner);
     synclock_lock(&priv->big_lock);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         errcode = -1;
         goto out;
     }
@@ -8461,7 +8461,7 @@ glusterd_start_gsync(glusterd_volinfo_t *master_vol, char *slave,
     synclock_unlock(&priv->big_lock);
     ret = runner_run(&runner);
     synclock_lock(&priv->big_lock);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_asprintf(op_errstr, GEOREP " start failed for %s %s",
                     master_vol->volname, slave);
         goto out;
@@ -8470,7 +8470,7 @@ glusterd_start_gsync(glusterd_volinfo_t *master_vol, char *slave,
     ret = 0;
 
 out:
-    if ((ret != 0) && errcode == -1) {
+    if (ret != 0 && IS_ERROR(errcode)) {
         if (op_errstr)
             *op_errstr = gf_strdup(
                 "internal error, cannot start "
@@ -8702,7 +8702,7 @@ glusterd_brick_signal(glusterd_volinfo_t *volinfo,
         snprintf(dumpoptions_path, sizeof(dumpoptions_path),
                  DEFAULT_VAR_RUN_DIRECTORY "/glusterdump.%d.options", pid);
         ret = glusterd_set_dump_options(dumpoptions_path, options, option_cnt);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_BRK_STATEDUMP_FAIL,
                    "error while parsing the statedump "
                    "options");
@@ -8800,7 +8800,7 @@ glusterd_nfs_statedump(char *options, int option_cnt, char **op_errstr)
     snprintf(dumpoptions_path, sizeof(dumpoptions_path),
              DEFAULT_VAR_RUN_DIRECTORY "/glusterdump.%d.options", pid);
     ret = glusterd_set_dump_options(dumpoptions_path, options, option_cnt);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_BRK_STATEDUMP_FAIL,
                "error while parsing the statedump "
                "options");
@@ -8930,7 +8930,7 @@ glusterd_quotad_statedump(char *options, int option_cnt, char **op_errstr)
     snprintf(dumpoptions_path, sizeof(dumpoptions_path),
              DEFAULT_VAR_RUN_DIRECTORY "/glusterdump.%d.options", pid);
     ret = glusterd_set_dump_options(dumpoptions_path, options, option_cnt);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_BRK_STATEDUMP_FAIL,
                "error while parsing "
                "statedump options");
@@ -9111,7 +9111,7 @@ glusterd_get_bitd_filepath(char *filepath, glusterd_volinfo_t *volinfo)
 
     len = snprintf(filepath, PATH_MAX, "%s/%s-bitd.vol", path,
                    volinfo->volname);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR((len)) || (len >= PATH_MAX)) {
         ret = -1;
     }
 
@@ -9145,7 +9145,7 @@ glusterd_get_client_filepath(char *filepath, glusterd_volinfo_t *volinfo,
             ret = -1;
             break;
     }
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR((len)) || (len >= PATH_MAX)) {
         ret = -1;
     }
 
@@ -9180,7 +9180,7 @@ glusterd_get_trusted_client_filepath(char *filepath,
             ret = -1;
             break;
     }
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR((len)) || (len >= PATH_MAX)) {
         ret = -1;
     }
 
@@ -10124,7 +10124,7 @@ glusterd_volume_status_add_peer_rsp(dict_t *this, char *key, data_t *value,
     } else {
         len = snprintf(new_key, sizeof(new_key), "%s", key);
     }
-    if (len < 0 || len >= sizeof(new_key))
+    if (IS_ERROR(len) || len >= sizeof(new_key))
         goto out;
 
     ret = dict_setn(rsp_ctx->dict, new_key, len, new_value);
@@ -12527,12 +12527,12 @@ glusterd_clean_up_quota_store(glusterd_volinfo_t *volinfo)
 
     len = snprintf(quota_confpath, sizeof(quota_confpath), "%s/%s", voldir,
                    GLUSTERD_VOLUME_QUOTA_CONFIG);
-    if ((len < 0) || (len >= sizeof(quota_confpath))) {
+    if (IS_ERROR((len)) || (len >= sizeof(quota_confpath))) {
         quota_confpath[0] = 0;
     }
     len = snprintf(cksum_path, sizeof(cksum_path), "%s/%s", voldir,
                    GLUSTERD_VOL_QUOTA_CKSUM_FILE);
-    if ((len < 0) || (len >= sizeof(cksum_path))) {
+    if (IS_ERROR((len)) || (len >= sizeof(cksum_path))) {
         cksum_path[0] = 0;
     }
 
@@ -13345,7 +13345,7 @@ glusterd_get_volopt_content(dict_t *ctx, gf_boolean_t xml_out)
                                "Option: %s\nDefault Value: %s\n"
                                "Description: %s\n\n",
                                vme->key, def_val, descr);
-                if (len < 0) {
+                if (IS_ERROR(len)) {
                     ret = -1;
                     goto cont;
                 }
@@ -13746,7 +13746,7 @@ glusterd_handle_replicate_brick_ops(glusterd_volinfo_t *volinfo,
     dirty[2] = hton32(1);
 
     ret = sys_lsetxattr(brickinfo->path, GF_AFR_DIRTY, dirty, sizeof(dirty), 0);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_SETXATTR_FAIL,
                "Failed to set extended"
                " attribute %s : %s.",
@@ -13762,7 +13762,7 @@ glusterd_handle_replicate_brick_ops(glusterd_volinfo_t *volinfo,
     }
 
     ret = gf_asprintf(&pid, "%d", GF_CLIENT_PID_ADD_REPLICA_MOUNT);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     switch (op) {
@@ -13819,7 +13819,7 @@ glusterd_handle_replicate_brick_ops(glusterd_volinfo_t *volinfo,
         tmpmount,
         (op == GD_OP_REPLACE_BRICK) ? GF_AFR_REPLACE_BRICK : GF_AFR_ADD_BRICK,
         brickinfo->brick_id, sizeof(brickinfo->brick_id), 0);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         gf_msg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_SETXATTR_FAIL,
                "Failed to set extended"
                " attribute %s : %s",
@@ -13961,7 +13961,7 @@ glusterd_brick_op_prerequisites(dict_t *dict, char **op, glusterd_op_t *gd_op,
     }
 
     *gd_op = gd_cli_to_gd_op(*op);
-    if (*gd_op < 0)
+    if (IS_ERROR(*gd_op))
         goto out;
 
     ret = dict_get_strn(dict, "volname", SLEN("volname"), volname);
@@ -14233,10 +14233,10 @@ glusterd_is_profile_on(glusterd_volinfo_t *volinfo)
     GF_ASSERT(volinfo);
 
     ret = glusterd_volinfo_get_boolean(volinfo, VKEY_DIAG_CNT_FOP_HITS);
-    if (ret != -1)
+    if (ret >= 0)
         is_fd_stats_on = ret;
     ret = glusterd_volinfo_get_boolean(volinfo, VKEY_DIAG_LAT_MEASUREMENT);
-    if (ret != -1)
+    if (ret >= 0)
         is_latency_on = ret;
     if ((_gf_true == is_latency_on) && (_gf_true == is_fd_stats_on))
         return _gf_true;

--- a/xlators/mgmt/glusterd/src/glusterd-utils.c
+++ b/xlators/mgmt/glusterd/src/glusterd-utils.c
@@ -3873,7 +3873,7 @@ glusterd_import_new_ta_brick(dict_t *peer_data, int32_t vol_count,
     char *brick_uuid_str = NULL;
 
     GF_ASSERT(peer_data);
-    GF_ASSERT(vol_count >= 0);
+    GF_ASSERT(IS_SUCCESS(vol_count));
     GF_ASSERT(ta_brickinfo);
     GF_ASSERT(prefix);
 
@@ -3971,7 +3971,7 @@ glusterd_import_new_brick(dict_t *peer_data, int32_t vol_count,
     char *brick_uuid_str = NULL;
 
     GF_ASSERT(peer_data);
-    GF_ASSERT(vol_count >= 0);
+    GF_ASSERT(IS_SUCCESS(vol_count));
     GF_ASSERT(brickinfo);
     GF_ASSERT(prefix);
 
@@ -4067,7 +4067,7 @@ glusterd_import_bricks(dict_t *peer_data, int32_t vol_count,
     glusterd_brickinfo_t *new_ta_brickinfo = NULL;
 
     GF_ASSERT(peer_data);
-    GF_ASSERT(vol_count >= 0);
+    GF_ASSERT(IS_SUCCESS(vol_count));
     GF_ASSERT(new_volinfo);
     GF_ASSERT(prefix);
     while (brick_count <= new_volinfo->brick_count) {
@@ -7894,7 +7894,7 @@ glusterd_is_uuid_present(char *path, char *xattr, gf_boolean_t *present)
 
     ret = sys_lgetxattr(path, xattr, &uid, 16);
 
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         *present = _gf_true;
         ret = 0;
         goto out;
@@ -13400,7 +13400,7 @@ glusterd_get_volopt_content(dict_t *ctx, gf_boolean_t xml_out)
     }
 
     ret = dict_set_dynstrn(ctx, "help-str", SLEN("help-str"), output);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         output = NULL;
     }
 out:
@@ -14233,10 +14233,10 @@ glusterd_is_profile_on(glusterd_volinfo_t *volinfo)
     GF_ASSERT(volinfo);
 
     ret = glusterd_volinfo_get_boolean(volinfo, VKEY_DIAG_CNT_FOP_HITS);
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         is_fd_stats_on = ret;
     ret = glusterd_volinfo_get_boolean(volinfo, VKEY_DIAG_LAT_MEASUREMENT);
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         is_latency_on = ret;
     if ((_gf_true == is_latency_on) && (_gf_true == is_fd_stats_on))
         return _gf_true;

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -425,7 +425,7 @@ volopt_trie(char *key, char **hint)
     if (*hint) {
         ret = gf_asprintf(&fullhint, "%s.%s", patt[0], *hint);
         GF_FREE(*hint);
-        if (ret >= 0) {
+        if (IS_SUCCESS(ret)) {
             ret = 0;
             *hint = fullhint;
         }
@@ -1192,7 +1192,7 @@ server_auth_option_handler(volgen_graph_t *graph, struct volopt_map_entry *vme,
         return -1;
     }
     ret = gf_asprintf(&aa, "auth.addr.%s.%s", auth_path, key);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         ret = xlator_set_option(xl, aa, ret, vme->value);
         GF_FREE(aa);
     }
@@ -2640,7 +2640,7 @@ server_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
 
     i = sizeof(server_graph_table) / sizeof(server_graph_table[0]) - 1;
 
-    while (i >= 0) {
+    while (IS_SUCCESS(i)) {
         ret = server_graph_table[i].builder(graph, volinfo, set_dict, param);
         if (ret) {
             gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_BUILD_GRAPH_FAILED,
@@ -4249,7 +4249,7 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     }
 
     ret = dict_get_str_boolean(set_dict, "server.manage-gids", _gf_false);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         ret = dict_set_str_sizen(set_dict, "client.send-gids",
                                  ret ? "false" : "true");
         if (ret)
@@ -5260,7 +5260,7 @@ generate_brick_volfiles(glusterd_volinfo_t *volinfo)
                    "failed to create %s", tstamp_file);
             return -1;
         }
-        if (ret >= 0) {
+        if (IS_SUCCESS(ret)) {
             sys_close(ret);
             /* If snap_volume, retain timestamp for marker.tstamp
              * from parent. Geo-replication depends on mtime of

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -92,7 +92,7 @@ xlator_instantiate_va(const char *type, const char *format, va_list arg)
     int ret = 0;
 
     ret = gf_vasprintf(&volname, format, arg);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         volname = NULL;
 
         goto error;
@@ -130,7 +130,7 @@ volgen_xlator_link(xlator_t *pxl, xlator_t *cxl)
     int ret = 0;
 
     ret = glusterfs_xlator_link(pxl, cxl);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, ENOMEM, GD_MSG_NO_MEMORY,
                "Out of memory, cannot link xlators %s <- %s", pxl->name,
                cxl->name);
@@ -147,7 +147,7 @@ volgen_graph_link(volgen_graph_t *graph, xlator_t *xl)
     /* no need to care about graph->top here */
     if (graph->graph.first)
         ret = volgen_xlator_link(xl, graph->graph.first);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_GRAPH_ENTRY_ADD_FAIL,
                "failed to add graph entry %s", xl->name);
 
@@ -946,7 +946,7 @@ volgen_apply_filters(char *orig_volfile)
                        entry->d_name);
 
         /* Deliberately use stat instead of lstat to allow symlinks. */
-        if (sys_stat(filterpath, &statbuf) == -1)
+        if (IS_ERROR(sys_stat(filterpath, &statbuf)))
             continue;
 
         if (!S_ISREG(statbuf.st_mode))
@@ -978,13 +978,13 @@ volgen_write_volfile(volgen_graph_t *graph, char *filename)
 
     this = THIS;
 
-    if (gf_asprintf(&ftmp, "%s.tmp", filename) == -1) {
+    if (IS_ERROR(gf_asprintf(&ftmp, "%s.tmp", filename))) {
         ftmp = NULL;
         goto error;
     }
 
     fd = sys_creat(ftmp, S_IRUSR | S_IWUSR);
-    if (fd < 0) {
+    if (IS_ERROR(fd)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
                "file creation failed");
         goto error;
@@ -996,7 +996,7 @@ volgen_write_volfile(volgen_graph_t *graph, char *filename)
     if (!f)
         goto error;
 
-    if (glusterfs_graph_print_file(f, &graph->graph) == -1)
+    if (IS_ERROR(glusterfs_graph_print_file(f, &graph->graph)))
         goto error;
 
     if (fclose(f) != 0) {
@@ -1016,7 +1016,7 @@ volgen_write_volfile(volgen_graph_t *graph, char *filename)
 
     f = NULL;
 
-    if (sys_rename(ftmp, filename) == -1)
+    if (IS_ERROR(sys_rename(ftmp, filename)))
         goto error;
 
     GF_FREE(ftmp);
@@ -1192,7 +1192,7 @@ server_auth_option_handler(volgen_graph_t *graph, struct volopt_map_entry *vme,
         return -1;
     }
     ret = gf_asprintf(&aa, "auth.addr.%s.%s", auth_path, key);
-    if (ret != -1) {
+    if (ret >= 0) {
         ret = xlator_set_option(xl, aa, ret, vme->value);
         GF_FREE(aa);
     }
@@ -1260,7 +1260,7 @@ server_check_changelog_off(volgen_graph_t *graph, struct volopt_map_entry *vme,
         goto out;
 
     ret = glusterd_volinfo_get_boolean(volinfo, VKEY_CHANGELOG);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_WARNING, 0, GD_MSG_CHANGELOG_GET_FAIL,
                "failed to get the changelog status");
         ret = -1;
@@ -1309,7 +1309,7 @@ server_check_marker_off(volgen_graph_t *graph, struct volopt_map_entry *vme,
         goto out;
 
     ret = glusterd_volinfo_get_boolean(volinfo, VKEY_MARKER_XTIME);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_WARNING, 0, GD_MSG_MARKER_STATUS_GET_FAIL,
                "failed to get the marker status");
         ret = -1;
@@ -1835,7 +1835,7 @@ brick_graph_add_changelog(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
 
     len = snprintf(changelog_basepath, sizeof(changelog_basepath), "%s/%s",
                    brickinfo->path, ".glusterfs/changelogs");
-    if ((len < 0) || (len >= sizeof(changelog_basepath))) {
+    if (IS_ERROR((len)) || (len >= sizeof(changelog_basepath))) {
         ret = -1;
         goto out;
     }
@@ -1844,7 +1844,7 @@ brick_graph_add_changelog(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
         goto out;
 
     ret = glusterd_is_bitrot_enabled(volinfo);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         goto out;
     } else if (ret) {
         ret = xlator_set_fixed_option(xl, "changelog-notification", "on");
@@ -1975,7 +1975,7 @@ brick_graph_add_namespace(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
         goto out;
 
     ret = dict_get_str_boolean(set_dict, "features.tag-namespaces", 0);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     if (ret) {
@@ -2035,7 +2035,7 @@ brick_graph_add_index(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
 
     len = snprintf(index_basepath, sizeof(index_basepath), "%s/%s",
                    brickinfo->path, ".glusterfs/indices");
-    if ((len < 0) || (len >= sizeof(index_basepath))) {
+    if (IS_ERROR((len)) || (len >= sizeof(index_basepath))) {
         goto out;
     }
 
@@ -2055,7 +2055,7 @@ brick_graph_add_index(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
         if (ret)
             goto out;
         ret = gf_asprintf(&pending_xattr, "trusted.afr.%s-", volinfo->volname);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
         ret = xlator_set_fixed_option(xl, "xattrop-pending-watchlist",
                                       pending_xattr);
@@ -2211,7 +2211,7 @@ brick_graph_add_cdc(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     /* Check for compress volume option, and add it to the graph on
      * server side */
     ret = dict_get_str_boolean(set_dict, "network.compression", 0);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
     if (ret) {
         xl = volgen_graph_add(graph, "features/cdc", volinfo->volname);
@@ -2369,7 +2369,7 @@ brick_graph_add_server(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     if (username) {
         len = snprintf(key, sizeof(key), "auth.login.%s.allow",
                        brickinfo->path);
-        if ((len < 0) || (len >= sizeof(key))) {
+        if (IS_ERROR((len)) || (len >= sizeof(key))) {
             return -1;
         }
 
@@ -2380,7 +2380,7 @@ brick_graph_add_server(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
 
     if (password) {
         len = snprintf(key, sizeof(key), "auth.login.%s.password", username);
-        if ((len < 0) || (len >= sizeof(key))) {
+        if (IS_ERROR((len)) || (len >= sizeof(key))) {
             return -1;
         }
         ret = xlator_set_option(xl, key, len, password);
@@ -2404,7 +2404,7 @@ brick_graph_add_server(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     if (dict_get_str_sizen(volinfo->dict, "auth.ssl-allow", &ssl_user) == 0) {
         len = snprintf(key, sizeof(key), "auth.login.%s.ssl-allow",
                        brickinfo->path);
-        if ((len < 0) || (len >= sizeof(key))) {
+        if (IS_ERROR((len)) || (len >= sizeof(key))) {
             return -1;
         }
 
@@ -2536,7 +2536,8 @@ static volgen_brick_xlator_t server_graph_table[] = {
     {brick_graph_add_posix, "posix"},
 };
 
-static glusterd_server_xlator_t
+#define GD_XLATOR_NONE 0
+static gf_xlator_list_t
 get_server_xlator(char *xlator)
 {
     int i = 0;
@@ -2549,7 +2550,7 @@ get_server_xlator(char *xlator)
             return GF_XLATOR_SERVER;
     }
 
-    return GF_XLATOR_NONE;
+    return GD_XLATOR_NONE;
 }
 
 static glusterd_client_xlator_t
@@ -2578,12 +2579,12 @@ debugxl_option_handler(volgen_graph_t *graph, struct volopt_map_entry *vme,
     if (!strcmp(vme->key, "debug.trace") ||
         !strcmp(vme->key, "debug.error-gen") ||
         !strcmp(vme->key, "debug.delay-gen")) {
-        if (get_server_xlator(vme->value) == GF_XLATOR_NONE &&
+        if (get_server_xlator(vme->value) == GD_XLATOR_NONE &&
             get_client_xlator(vme->value) == GF_CLNT_XLATOR_NONE)
             return 0;
     }
 
-    if (gf_string2boolean(vme->value, &enabled) == -1)
+    if (IS_ERROR(gf_string2boolean(vme->value, &enabled)))
         goto add_graph;
     if (!enabled)
         return 0;
@@ -2707,7 +2708,7 @@ perfxl_option_handler(volgen_graph_t *graph, struct volopt_map_entry *vme,
     if (strcmp(vme->option, "!perf") != 0)
         return 0;
 
-    if (gf_string2boolean(vme->value, &enabled) == -1)
+    if (IS_ERROR(gf_string2boolean(vme->value, &enabled)))
         return -1;
     if (!enabled)
         return 0;
@@ -2784,7 +2785,7 @@ nfsperfxl_option_handler(volgen_graph_t *graph, struct volopt_map_entry *vme,
     if (strcmp(vme->option, "!nfsperf") != 0)
         return 0;
 
-    if (gf_string2boolean(vme->value, &enabled) == -1)
+    if (IS_ERROR(gf_string2boolean(vme->value, &enabled)))
         return -1;
     if (!enabled)
         return 0;
@@ -2803,7 +2804,7 @@ end_sethelp_xml_doc(xmlTextWriterPtr writer)
     int ret = -1;
 
     ret = xmlTextWriterEndElement(writer);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_XML_TEXT_WRITE_FAIL,
                "Could not end an "
                "xmlElement");
@@ -2811,7 +2812,7 @@ end_sethelp_xml_doc(xmlTextWriterPtr writer)
         goto out;
     }
     ret = xmlTextWriterEndDocument(writer);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_XML_TEXT_WRITE_FAIL,
                "Could not end an "
                "xmlDocument");
@@ -2853,7 +2854,7 @@ init_sethelp_xml_doc(xmlTextWriterPtr *writer, xmlBufferPtr *buf)
     }
 
     ret = xmlTextWriterStartDocument(*writer, "1.0", "UTF-8", "yes");
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_XML_DOC_START_FAIL,
                "Error While starting the "
                "xmlDoc");
@@ -2861,7 +2862,7 @@ init_sethelp_xml_doc(xmlTextWriterPtr *writer, xmlBufferPtr *buf)
     }
 
     ret = xmlTextWriterStartElement(*writer, (xmlChar *)"options");
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_XML_ELE_CREATE_FAIL,
                "Could not create an "
                "xmlElement");
@@ -2885,7 +2886,7 @@ xml_add_volset_element(xmlTextWriterPtr writer, const char *name,
     GF_ASSERT(name);
 
     ret = xmlTextWriterStartElement(writer, (xmlChar *)"option");
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_XML_ELE_CREATE_FAIL,
                "Could not create an "
                "xmlElemetnt");
@@ -2895,7 +2896,7 @@ xml_add_volset_element(xmlTextWriterPtr writer, const char *name,
 
     ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"defaultValue",
                                           "%s", def_val);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_XML_ELE_CREATE_FAIL,
                "Could not create an "
                "xmlElemetnt");
@@ -2905,7 +2906,7 @@ xml_add_volset_element(xmlTextWriterPtr writer, const char *name,
 
     ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"description",
                                           "%s", dscrpt);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_XML_ELE_CREATE_FAIL,
                "Could not create an "
                "xmlElemetnt");
@@ -2915,7 +2916,7 @@ xml_add_volset_element(xmlTextWriterPtr writer, const char *name,
 
     ret = xmlTextWriterWriteFormatElement(writer, (xmlChar *)"name", "%s",
                                           name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_XML_ELE_CREATE_FAIL,
                "Could not create an "
                "xmlElemetnt");
@@ -2924,7 +2925,7 @@ xml_add_volset_element(xmlTextWriterPtr writer, const char *name,
     }
 
     ret = xmlTextWriterEndElement(writer);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_XML_ELE_CREATE_FAIL,
                "Could not end an "
                "xmlElemetnt");
@@ -3513,7 +3514,7 @@ volgen_graph_build_dht_cluster(volgen_graph_t *graph,
 
     clusters = volgen_link_bricks_from_list_tail(
         graph, volinfo, voltype, name_fmt, child_count, child_count);
-    if (clusters < 0)
+    if (IS_ERROR(clusters))
         goto out;
 
     dht = first_of(graph);
@@ -3548,7 +3549,7 @@ volgen_graph_build_ec_clusters(volgen_graph_t *graph,
     clusters = volgen_link_bricks_from_list_tail_start(
         graph, volinfo, disperse_args[0], disperse_args[1],
         volinfo->brick_count, volinfo->disperse_count, start_count);
-    if (clusters < 0)
+    if (IS_ERROR(clusters))
         goto out;
 
     sprintf(option, "%d", volinfo->redundancy_count);
@@ -3707,7 +3708,7 @@ volgen_graph_build_afr_clusters(volgen_graph_t *graph,
         volinfo->brick_count + ta_brick_offset,
         volinfo->replica_count + ta_replica_offset);
 
-    if (clusters < 0)
+    if (IS_ERROR(clusters))
         goto out;
 
     ret = set_afr_pending_xattrs_option(graph, volinfo, clusters);
@@ -3776,12 +3777,12 @@ volume_volgen_graph_build_clusters(volgen_graph_t *graph,
     switch (volinfo->type) {
         case GF_CLUSTER_TYPE_REPLICATE:
             clusters = volgen_graph_build_afr_clusters(graph, volinfo);
-            if (clusters < 0)
+            if (IS_ERROR(clusters))
                 goto out;
             break;
         case GF_CLUSTER_TYPE_DISPERSE:
             clusters = volgen_graph_build_ec_clusters(graph, volinfo);
-            if (clusters < 0)
+            if (IS_ERROR(clusters))
                 goto out;
 
             break;
@@ -3799,7 +3800,7 @@ build_distribute:
         goto out;
     }
     clusters = volgen_graph_build_readdir_ahead(graph, volinfo, dist_count);
-    if (clusters < 0)
+    if (IS_ERROR(clusters))
         goto out;
 
     ret = volgen_graph_build_dht_cluster(graph, volinfo, dist_count, is_quotad);
@@ -3844,26 +3845,26 @@ client_graph_set_rda_options(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
      * progress volume set option.
      */
     ret = dict_get_str_sizen(set_dict, VKEY_RDA_CACHE_LIMIT, &rda_cache_s);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = glusterd_volinfo_get(volinfo, VKEY_RDA_CACHE_LIMIT, &rda_cache_s);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
     ret = gf_string2bytesize_uint64(rda_cache_s, &rda_cache_size);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         set_graph_errstr(
             graph, "invalid number format in option " VKEY_RDA_CACHE_LIMIT);
         goto out;
     }
 
     ret = dict_get_str_sizen(set_dict, VKEY_RDA_REQUEST_SIZE, &rda_req_s);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = glusterd_volinfo_get(volinfo, VKEY_RDA_REQUEST_SIZE, &rda_req_s);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
     ret = gf_string2bytesize_uint64(rda_req_s, &rda_req_size);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         set_graph_errstr(
             graph, "invalid number format in option " VKEY_RDA_REQUEST_SIZE);
         goto out;
@@ -3886,7 +3887,7 @@ client_graph_set_rda_options(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
                  rda_req_size, "B");
         ret = dict_set_dynstr_with_alloc(set_dict, VKEY_RDA_REQUEST_SIZE,
                                          new_req_size_str);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 
@@ -3894,7 +3895,7 @@ client_graph_set_rda_options(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
              new_cache_size, "B");
     ret = dict_set_dynstr_with_alloc(set_dict, VKEY_RDA_CACHE_LIMIT,
                                      new_cache_size_str);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
 out:
@@ -3930,7 +3931,7 @@ client_graph_set_perf_options(volgen_graph_t *graph,
      * default for a volume
      */
     ret = client_graph_set_rda_options(graph, volinfo, set_dict);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         return ret;
 
 #ifdef BUILD_GNFS
@@ -4041,7 +4042,7 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     GF_ASSERT(conf);
 
     ret = dict_get_str_boolean(set_dict, "gfproxy-client", 0);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     volname = volinfo->volname;
@@ -4053,7 +4054,7 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
         else
             ret = volume_volgen_graph_build_clusters(graph, volinfo, _gf_false);
 
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto out;
     } else {
         gfproxy_clnt = _gf_true;
@@ -4069,7 +4070,7 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     }
 
     ret = dict_get_str_boolean(set_dict, "features.cloudsync", _gf_false);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     if (ret) {
@@ -4081,7 +4082,7 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     }
 
     ret = dict_get_str_boolean(set_dict, "features.shard", _gf_false);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     if (ret) {
@@ -4129,7 +4130,7 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     /* Check for compress volume option, and add it to the graph on client side
      */
     ret = dict_get_str_boolean(set_dict, "network.compression", 0);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
     if (ret) {
         xl = volgen_graph_add(graph, "features/cdc", volname);
@@ -4153,7 +4154,7 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
 
     if (conf->op_version == GD_OP_VERSION_MIN) {
         ret = glusterd_volinfo_get_boolean(volinfo, VKEY_FEATURES_QUOTA);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto out;
         if (ret) {
             xl = volgen_graph_add(graph, "features/quota", volname);
@@ -4248,7 +4249,7 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     }
 
     ret = dict_get_str_boolean(set_dict, "server.manage-gids", _gf_false);
-    if (ret != -1) {
+    if (ret >= 0) {
         ret = dict_set_str_sizen(set_dict, "client.send-gids",
                                  ret ? "false" : "true");
         if (ret)
@@ -4262,12 +4263,12 @@ client_graph_builder(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
         goto out;
 
     uss_enabled = dict_get_str_boolean(set_dict, "features.uss", _gf_false);
-    if (uss_enabled == -1)
+    if (IS_ERROR(uss_enabled))
         goto out;
     if (uss_enabled && !volinfo->is_snap_volume) {
         ret = volgen_graph_build_snapview_client(graph, volinfo, volname,
                                                  set_dict);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto out;
     }
 
@@ -4431,7 +4432,7 @@ nfs_option_handler(volgen_graph_t *graph, struct volopt_map_entry *vme,
         if (!strcmp(vme->option, opt->pattern)) {
             keylen = gf_asprintf(&aa, opt->printf_pattern, volinfo->volname);
 
-            if (keylen == -1) {
+            if (IS_ERROR(keylen)) {
                 return -1;
             }
 
@@ -4448,7 +4449,7 @@ nfs_option_handler(volgen_graph_t *graph, struct volopt_map_entry *vme,
     if (!strcmp(vme->option, "!nfs3.*.export-dir")) {
         keylen = gf_asprintf(&aa, "nfs3.%s.export-dir", volinfo->volname);
 
-        if (keylen == -1) {
+        if (IS_ERROR(keylen)) {
             return -1;
         }
 
@@ -4705,7 +4706,7 @@ build_shd_volume_graph(xlator_t *this, volgen_graph_t *graph,
         goto out;
 
     clusters = build_shd_clusters(&cgraph, volinfo, set_dict);
-    if (clusters < 0) {
+    if (IS_ERROR(clusters)) {
         ret = -1;
         goto out;
     }
@@ -4840,7 +4841,7 @@ build_nfs_graph(volgen_graph_t *graph, dict_t *mod_dict)
             continue;
 
         ret = gf_asprintf(&skey, "rpc-auth.addr.%s.allow", voliter->volname);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, ENOMEM, GD_MSG_NO_MEMORY,
                    "Out of memory");
             goto out;
@@ -4851,7 +4852,7 @@ build_nfs_graph(volgen_graph_t *graph, dict_t *mod_dict)
             goto out;
 
         ret = gf_asprintf(&skey, "nfs3.%s.volume-id", voliter->volname);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, 0, GD_MSG_NO_MEMORY,
                    "Out of memory");
             goto out;
@@ -4988,7 +4989,7 @@ get_brick_filepath(char *filename, glusterd_volinfo_t *volinfo,
     else
         len = snprintf(filename, PATH_MAX, "%s/%s.%s.%s.vol", path,
                        volinfo->volname, brickinfo->hostname, brick);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR((len)) || (len >= PATH_MAX)) {
         filename[0] = 0;
     }
 }
@@ -5148,7 +5149,7 @@ build_quotad_graph(volgen_graph_t *graph, dict_t *mod_dict)
             dict_copy(mod_dict, set_dict);
 
         ret = gf_asprintf(&skey, "%s.volume-id", voliter->volname);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, ENOMEM, GD_MSG_NO_MEMORY,
                    "Out of memory");
             goto out;
@@ -5220,7 +5221,7 @@ get_parent_vol_tstamp_file(char *filename, glusterd_volinfo_t *volinfo)
 
     len = snprintf(filename, PATH_MAX, "%s/vols/%s/marker.tstamp",
                    priv->workdir, volinfo->parent_volname);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR((len)) || (len >= PATH_MAX)) {
         filename[0] = 0;
     }
 }
@@ -5241,7 +5242,7 @@ generate_brick_volfiles(glusterd_volinfo_t *volinfo)
     GF_ASSERT(this);
 
     ret = glusterd_volinfo_get_boolean(volinfo, VKEY_MARKER_XTIME);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         return -1;
 
     assign_brick_groups(volinfo);
@@ -5249,15 +5250,14 @@ generate_brick_volfiles(glusterd_volinfo_t *volinfo)
 
     if (ret) {
         ret = open(tstamp_file, O_WRONLY | O_CREAT | O_EXCL, 0600);
+        /* ret can be checked for -1 here, as we use 'open()' */
         if (ret == -1 && errno == EEXIST) {
             gf_msg_debug(this->name, 0, "timestamp file exist");
             ret = -2;
         }
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
-                   "failed to create "
-                   "%s",
-                   tstamp_file);
+                   "failed to create %s", tstamp_file);
             return -1;
         }
         if (ret >= 0) {
@@ -5281,13 +5281,11 @@ generate_brick_volfiles(glusterd_volinfo_t *volinfo)
         }
     } else {
         ret = sys_unlink(tstamp_file);
-        if (ret == -1 && errno == ENOENT)
+        if (IS_ERROR(ret) && errno == ENOENT)
             ret = 0;
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_FILE_OP_FAILED,
-                   "failed to unlink "
-                   "%s",
-                   tstamp_file);
+                   "failed to unlink %s", tstamp_file);
             return -1;
         }
     }
@@ -5372,7 +5370,7 @@ glusterd_generate_client_per_brick_volfile(glusterd_volinfo_t *volinfo)
 
         get_brick_filepath(filepath, volinfo, brick, "client");
         ret = volgen_write_volfile(&graph, filepath);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         volgen_graph_free(&graph);
@@ -5688,7 +5686,7 @@ build_bitd_clusters(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     xl = first_of(graph);
 
     ret = gf_asprintf(&brick_hint, "%d", numbricks);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = xlator_set_fixed_option(xl, "brick-count", brick_hint);
@@ -5762,7 +5760,7 @@ build_bitd_volume_graph(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
 
     clusters = build_bitd_clusters(&cgraph, volinfo, set_dict, brick_count,
                                    numbricks);
-    if (clusters < 0) {
+    if (IS_ERROR(clusters)) {
         ret = -1;
         goto out;
     }
@@ -5920,7 +5918,7 @@ build_scrub_volume_graph(volgen_graph_t *graph, glusterd_volinfo_t *volinfo,
     }
 
     clusters = build_scrub_clusters(&cgraph, volinfo, set_dict, brick_count);
-    if (clusters < 0) {
+    if (IS_ERROR(clusters)) {
         ret = -1;
         goto out;
     }

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.h
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.h
@@ -115,21 +115,6 @@ typedef enum gd_volopt_flags_ {
     VOLOPT_FLAG_NEVER_RESET = 0x08, /* option which should not be reset */
 } gd_volopt_flags_t;
 
-typedef enum {
-    GF_XLATOR_POSIX = 0,
-    GF_XLATOR_ACL,
-    GF_XLATOR_LOCKS,
-    GF_XLATOR_LEASES,
-    GF_XLATOR_UPCALL,
-    GF_XLATOR_IOT,
-    GF_XLATOR_INDEX,
-    GF_XLATOR_MARKER,
-    GF_XLATOR_IO_STATS,
-    GF_XLATOR_BD,
-    GF_XLATOR_SERVER,
-    GF_XLATOR_NONE,
-} glusterd_server_xlator_t;
-
 /* As of now debug xlators can be loaded only below fuse in the client
  * graph via cli. More xlators can be added below when the cli option
  * for adding debug xlators anywhere in the client graph has to be made

--- a/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-ops.c
@@ -319,7 +319,7 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
 
     ret = -1;
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         snprintf(err_str, sizeof(err_str),
                  "Failed to decode request "
@@ -337,7 +337,7 @@ __glusterd_handle_create_volume(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -552,7 +552,7 @@ __glusterd_handle_cli_start_volume(rpcsvc_request_t *req)
     conf = this->private;
     GF_ASSERT(conf);
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(errstr, sizeof(errstr),
                  "Failed to decode message "
                  "received from cli");
@@ -568,7 +568,7 @@ __glusterd_handle_cli_start_volume(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -644,7 +644,7 @@ __glusterd_handle_cli_stop_volume(rpcsvc_request_t *req)
     GF_ASSERT(conf);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to decode message "
                  "received from cli");
@@ -659,7 +659,7 @@ __glusterd_handle_cli_stop_volume(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -739,7 +739,7 @@ __glusterd_handle_cli_delete_volume(rpcsvc_request_t *req)
     GF_ASSERT(req);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(err_str, sizeof(err_str),
                  "Failed to decode request "
                  "received from cli");
@@ -755,7 +755,7 @@ __glusterd_handle_cli_delete_volume(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -891,7 +891,7 @@ __glusterd_handle_cli_heal_volume(rpcsvc_request_t *req)
     GF_ASSERT(req);
 
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         goto out;
@@ -906,7 +906,7 @@ __glusterd_handle_cli_heal_volume(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -1011,7 +1011,7 @@ __glusterd_handle_cli_statedump_volume(rpcsvc_request_t *req)
 
     ret = -1;
     ret = xdr_to_generic(req->msg[0], &cli_req, (xdrproc_t)xdr_gf_cli_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         req->rpc_err = GARBAGE_ARGS;
         goto out;
     }
@@ -1021,7 +1021,7 @@ __glusterd_handle_cli_statedump_volume(rpcsvc_request_t *req)
 
         ret = dict_unserialize(cli_req.dict.dict_val, cli_req.dict.dict_len,
                                &dict);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_DICT_UNSERIALIZE_FAIL,
                    "failed to "
                    "unserialize req-buffer to dictionary");
@@ -1469,7 +1469,7 @@ glusterd_op_stage_start_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
         }
 
         if ((gf_uuid_compare(brickinfo->uuid, MY_UUID)) ||
-            (brickinfo->snap_status == -1))
+            (IS_ERROR(brickinfo->snap_status)))
             continue;
 
         ret = gf_lstat_dir(brickinfo->path, NULL);
@@ -1481,36 +1481,36 @@ glusterd_op_stage_start_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                            "brick directory %s for volume %s. "
                            "Reason : %s",
                            brickinfo->path, volname, strerror(errno));
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(msg, "<error>");
             }
             goto out;
         }
         ret = sys_lgetxattr(brickinfo->path, GF_XATTR_VOL_ID_KEY, volume_id,
                             16);
-        if (ret < 0 && (!(flags & GF_CLI_FLAG_OP_FORCE))) {
+        if (IS_ERROR(ret) && (!(flags & GF_CLI_FLAG_OP_FORCE))) {
             len = snprintf(msg, sizeof(msg),
                            "Failed to get "
                            "extended attribute %s for brick dir "
                            "%s. Reason : %s",
                            GF_XATTR_VOL_ID_KEY, brickinfo->path,
                            strerror(errno));
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(msg, "<error>");
             }
             ret = -1;
             goto out;
-        } else if (ret < 0) {
+        } else if (IS_ERROR(ret)) {
             ret = sys_lsetxattr(brickinfo->path, GF_XATTR_VOL_ID_KEY,
                                 volinfo->volume_id, 16, XATTR_CREATE);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 len = snprintf(msg, sizeof(msg),
                                "Failed to "
                                "set extended attribute %s on "
                                "%s. Reason: %s",
                                GF_XATTR_VOL_ID_KEY, brickinfo->path,
                                strerror(errno));
-                if (len < 0) {
+                if (IS_ERROR(len)) {
                     strcpy(msg, "<error>");
                 }
                 goto out;
@@ -1526,7 +1526,7 @@ glusterd_op_stage_start_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                            brickinfo->hostname, brickinfo->path,
                            uuid_utoa_r(volinfo->volume_id, volid),
                            uuid_utoa_r(volume_id, xattr_volid));
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 strcpy(msg, "<error>");
             }
             ret = -1;
@@ -2340,7 +2340,7 @@ glusterd_op_create_volume(dict_t *dict, char **op_errstr)
         brick = strtok_r(brick_list + 1, " \n", &saveptr);
 
     brickid = glusterd_get_next_available_brickid(volinfo);
-    if (brickid < 0)
+    if (IS_ERROR(brickid))
         goto out;
     while (i <= count) {
         ret = glusterd_brickinfo_new_from_brick(brick, &brickinfo, _gf_true,
@@ -2837,7 +2837,7 @@ glusterd_clearlocks_send_cmd(glusterd_volinfo_t *volinfo, char *cmd, char *path,
 
     snprintf(abspath, sizeof(abspath), "%s/%s", mntpt, path);
     ret = sys_lgetxattr(abspath, cmd, result, PATH_MAX);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         snprintf(errstr, err_len,
                  "clear-locks getxattr command "
                  "failed. Reason: %s",
@@ -3009,7 +3009,7 @@ glusterd_clearlocks_get_local_client_ports(glusterd_volinfo_t *volinfo,
                            brickinfo->path);
         } else
             len = snprintf(brickname, sizeof(brickname), "%s", brickinfo->path);
-        if ((len < 0) || (len >= sizeof(brickname))) {
+        if (IS_ERROR((len)) || (len >= sizeof(brickname))) {
             ret = -1;
             goto out;
         }
@@ -3027,7 +3027,7 @@ glusterd_clearlocks_get_local_client_ports(glusterd_volinfo_t *volinfo,
 
         ret = gf_asprintf(&xl_opts[i], "%s-client-%d.remote-port=%d",
                           volinfo->volname, index, port);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             xl_opts[i] = NULL;
             goto out;
         }
@@ -3104,7 +3104,7 @@ glusterd_op_clearlocks_volume(dict_t *dict, char **op_errstr, dict_t *rsp_dict)
                           kind, opts);
     else
         ret = gf_asprintf(&cmd_str, GF_XATTR_CLRLK_CMD ".t%s.k%s", type, kind);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = glusterd_volinfo_find(volname, &volinfo);

--- a/xlators/mgmt/glusterd/src/glusterd-volume-set.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volume-set.c
@@ -137,7 +137,7 @@ validate_quota(glusterd_volinfo_t *volinfo, dict_t *dict, char *key,
     GF_ASSERT(priv);
 
     ret = glusterd_volinfo_get_boolean(volinfo, VKEY_FEATURES_QUOTA);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_QUOTA_GET_STAT_FAIL,
                "failed to get the quota status");
         goto out;
@@ -277,7 +277,7 @@ validate_server_options(glusterd_volinfo_t *volinfo, dict_t *dict, char *key,
         goto out;
     }
 
-    if (origin_val < 0) {
+    if (IS_ERROR(origin_val)) {
         snprintf(errstr, sizeof(errstr),
                  "%s is not a "
                  "compatible value. %s expects a positive"
@@ -716,7 +716,7 @@ validate_rda_cache_limit(glusterd_volinfo_t *volinfo, dict_t *dict, char *key,
     uint64_t rda_cache_size = 0;
 
     ret = gf_string2bytesize_uint64(value, &rda_cache_size);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (rda_cache_size <= (1 * GF_UNIT_GB))

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -945,7 +945,7 @@ check_prepare_mountbroker_root(char *mountbroker_root)
     int ret = 0;
 
     ret = open(mountbroker_root, O_RDONLY);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         dfd = ret;
         ret = sys_fstat(dfd, &st);
     }
@@ -974,7 +974,7 @@ check_prepare_mountbroker_root(char *mountbroker_root)
 
     for (;;) {
         ret = sys_openat(dfd, "..", O_RDONLY, 0);
-        if (ret >= 0) {
+        if (IS_SUCCESS(ret)) {
             dfd2 = ret;
             ret = sys_fstat(dfd2, &st2);
         }
@@ -1011,7 +1011,7 @@ check_prepare_mountbroker_root(char *mountbroker_root)
     ret = sys_mkdirat(dfd0, MB_HIVE, 0711);
     if (IS_ERROR(ret) && errno == EEXIST)
         ret = 0;
-    if (ret >= 0)
+    if (IS_SUCCESS(ret))
         ret = sys_fstatat(dfd0, MB_HIVE, &st, AT_SYMLINK_NOFOLLOW);
     if (IS_ERROR(ret) || st.st_mode != (S_IFDIR | 0711)) {
         gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_CREATE_DIR_FAILED,
@@ -1150,7 +1150,7 @@ glusterd_init_uds_listener(xlator_t *this)
         ret = glusterd_program_register(this, rpc, gd_uds_programs[i]);
         if (ret) {
             i--;
-            for (; i >= 0; i--)
+            for (IS_SUCCESS(; i); i--)
                 rpcsvc_program_unregister(rpc, gd_uds_programs[i]);
 
             goto out;
@@ -1813,7 +1813,7 @@ init(xlator_t *this)
         ret = glusterd_program_register(this, rpc, gd_inet_programs[i]);
         if (ret) {
             i--;
-            for (; i >= 0; i--)
+            for (IS_SUCCESS(; i); i--)
                 rpcsvc_program_unregister(rpc, gd_inet_programs[i]);
 
             goto out;

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -1150,7 +1150,7 @@ glusterd_init_uds_listener(xlator_t *this)
         ret = glusterd_program_register(this, rpc, gd_uds_programs[i]);
         if (ret) {
             i--;
-            for (IS_SUCCESS(; i); i--)
+            for (; i >= 0; i--)
                 rpcsvc_program_unregister(rpc, gd_uds_programs[i]);
 
             goto out;
@@ -1813,7 +1813,7 @@ init(xlator_t *this)
         ret = glusterd_program_register(this, rpc, gd_inet_programs[i]);
         if (ret) {
             i--;
-            for (IS_SUCCESS(; i); i--)
+            for (; i >= 0; i--)
                 rpcsvc_program_unregister(rpc, gd_inet_programs[i]);
 
             goto out;

--- a/xlators/mgmt/glusterd/src/glusterd.c
+++ b/xlators/mgmt/glusterd/src/glusterd.c
@@ -480,7 +480,7 @@ glusterd_check_gsync_present(int *valid_state)
     runner_add_args(&runner, GSYNCD_PREFIX "/gsyncd", "--version", NULL);
     runner_redir(&runner, STDOUT_FILENO, RUN_PIPE);
     ret = runner_start(&runner);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         if (errno == ENOENT) {
             gf_msg("glusterd", GF_LOG_INFO, errno, GD_MSG_MODULE_NOT_INSTALLED,
                    GEOREP " module not installed in the system");
@@ -532,18 +532,18 @@ group_write_allow(char *path, gid_t gid)
     int ret = 0;
 
     ret = sys_stat(path, &st);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
     GF_ASSERT(S_ISDIR(st.st_mode));
 
     ret = sys_chown(path, -1, gid);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     ret = sys_chmod(path, (st.st_mode & ~S_IFMT) | S_IWGRP | S_IXGRP | S_ISVTX);
 
 out:
-    if (ret == -1)
+    if (IS_ERROR(ret))
         gf_msg("glusterd", GF_LOG_CRITICAL, errno,
                GD_MSG_WRITE_ACCESS_GRANT_FAIL,
                "failed to set up write access to %s for group %d (%s)", path,
@@ -573,12 +573,12 @@ glusterd_crt_georep_folders(char *georepdir, glusterd_conf_t *conf)
     }
 
     len = snprintf(georepdir, PATH_MAX, "%s/" GEOREP, conf->workdir);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         ret = -1;
         goto out;
     }
     ret = mkdir_p(georepdir, 0755, _gf_true);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create " GEOREP " directory %s", georepdir);
         goto out;
@@ -603,12 +603,12 @@ glusterd_crt_georep_folders(char *georepdir, glusterd_conf_t *conf)
         goto out;
     }
     len = snprintf(logdir, PATH_MAX, "%s/" GEOREP, conf->logdir);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         ret = -1;
         goto out;
     }
     ret = mkdir_p(logdir, 0755, _gf_true);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create " GEOREP " log directory");
         goto out;
@@ -627,12 +627,12 @@ glusterd_crt_georep_folders(char *georepdir, glusterd_conf_t *conf)
         goto out;
     }
     len = snprintf(logdir, PATH_MAX, "%s/" GEOREP "-slaves", conf->logdir);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         ret = -1;
         goto out;
     }
     ret = mkdir_p(logdir, 0755, _gf_true);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create " GEOREP " slave log directory");
         goto out;
@@ -653,13 +653,13 @@ glusterd_crt_georep_folders(char *georepdir, glusterd_conf_t *conf)
     }
 
     len = snprintf(logdir, PATH_MAX, "%s/" GEOREP "-slaves/mbr", conf->logdir);
-    if ((len < 0) || (len >= PATH_MAX)) {
+    if (IS_ERROR(len) || (len >= PATH_MAX)) {
         ret = -1;
         goto out;
     }
 
     ret = mkdir_p(logdir, 0755, _gf_true);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         gf_msg("glusterd", GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create " GEOREP " mountbroker slave log directory");
         goto out;
@@ -688,7 +688,7 @@ configure_syncdaemon(glusterd_conf_t *conf)
 #define RUN_GSYNCD_CMD                                                         \
     do {                                                                       \
         ret = runner_run_reuse(&runner);                                       \
-        if (ret == -1) {                                                       \
+        if (IS_ERROR(ret)) {                                                   \
             runner_log(&runner, "glusterd", GF_LOG_ERROR, "command failed");   \
             runner_end(&runner);                                               \
             goto out;                                                          \
@@ -706,13 +706,13 @@ configure_syncdaemon(glusterd_conf_t *conf)
     int valid_state = 0;
 
     ret = setenv("_GLUSTERD_CALLED_", "1", 1);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = 0;
         goto out;
     }
     valid_state = -1;
     ret = glusterd_check_gsync_present(&valid_state);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         ret = valid_state;
         goto out;
     }
@@ -945,11 +945,11 @@ check_prepare_mountbroker_root(char *mountbroker_root)
     int ret = 0;
 
     ret = open(mountbroker_root, O_RDONLY);
-    if (ret != -1) {
+    if (ret >= 0) {
         dfd = ret;
         ret = sys_fstat(dfd, &st);
     }
-    if (ret == -1 || !S_ISDIR(st.st_mode)) {
+    if (IS_ERROR(ret) || !S_ISDIR(st.st_mode)) {
         gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DIR_OP_FAILED,
                "cannot access mountbroker-root directory %s", mountbroker_root);
         ret = -1;
@@ -974,11 +974,11 @@ check_prepare_mountbroker_root(char *mountbroker_root)
 
     for (;;) {
         ret = sys_openat(dfd, "..", O_RDONLY, 0);
-        if (ret != -1) {
+        if (ret >= 0) {
             dfd2 = ret;
             ret = sys_fstat(dfd2, &st2);
         }
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_DIR_OP_FAILED,
                    "error while checking mountbroker-root ancestors "
                    "%d (%s)",
@@ -1009,11 +1009,11 @@ check_prepare_mountbroker_root(char *mountbroker_root)
     }
 
     ret = sys_mkdirat(dfd0, MB_HIVE, 0711);
-    if (ret == -1 && errno == EEXIST)
+    if (IS_ERROR(ret) && errno == EEXIST)
         ret = 0;
-    if (ret != -1)
+    if (ret >= 0)
         ret = sys_fstatat(dfd0, MB_HIVE, &st, AT_SYMLINK_NOFOLLOW);
-    if (ret == -1 || st.st_mode != (S_IFDIR | 0711)) {
+    if (IS_ERROR(ret) || st.st_mode != (S_IFDIR | 0711)) {
         gf_msg("glusterd", GF_LOG_ERROR, errno, GD_MSG_CREATE_DIR_FAILED,
                "failed to set up mountbroker-root directory %s",
                mountbroker_root);
@@ -1306,11 +1306,11 @@ glusterd_init_var_run_dirs(xlator_t *this, char *var_run_dir,
         goto out;
     }
 
-    if ((-1 == ret) && (ENOENT == errno)) {
+    if ((IS_ERROR(ret) && (ENOENT == errno))) {
         /* Create missing dirs */
         ret = mkdir_p(abs_path, 0755, _gf_true);
 
-        if (-1 == ret) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                    "Unable to create directory %s"
                    " ,errno = %d",
@@ -1423,7 +1423,7 @@ init(xlator_t *this)
         lim.rlim_cur = 65536;
         lim.rlim_max = 65536;
 
-        if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
+        if (IS_ERROR(setrlimit(RLIMIT_NOFILE, &lim))) {
             gf_msg(this->name, GF_LOG_ERROR, errno, GD_MSG_SETXATTR_FAIL,
                    "Failed to set 'ulimit -n "
                    " 65536'");
@@ -1443,7 +1443,7 @@ init(xlator_t *this)
     } else {
         len = snprintf(rundir, PATH_MAX, "%s", dir_data->data);
     }
-    if (len < 0 || len >= PATH_MAX)
+    if (IS_ERROR(len) || len >= PATH_MAX)
         exit(2);
 
     dir_data = dict_get(this->options, "cluster-test-mode");
@@ -1456,11 +1456,11 @@ init(xlator_t *this)
         gf_msg(this->name, GF_LOG_INFO, 0, GD_MSG_CLUSTER_RC_ENABLE,
                "cluster-test-mode is enabled logdir is %s", dir_data->data);
     }
-    if (len < 0 || len >= PATH_MAX)
+    if (IS_ERROR(len) || len >= PATH_MAX)
         exit(2);
 
     ret = mkdir_p(logdir, 0777, _gf_true);
-    if ((ret == -1) && (EEXIST != errno)) {
+    if (IS_ERROR(ret) && (EEXIST != errno)) {
         gf_msg(THIS->name, GF_LOG_ERROR, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create log dir %s", logdir);
         exit(1);
@@ -1474,7 +1474,7 @@ init(xlator_t *this)
     } else {
         len = snprintf(workdir, PATH_MAX, "%s", dir_data->data);
     }
-    if (len < 0 || len >= PATH_MAX)
+    if (IS_ERROR(len) || len >= PATH_MAX)
         exit(2);
 
     ret = sys_stat(workdir, &buf);
@@ -1492,10 +1492,10 @@ init(xlator_t *this)
         exit(1);
     }
 
-    if ((-1 == ret) && (ENOENT == errno)) {
+    if (IS_ERROR(ret) && (ENOENT == errno)) {
         ret = mkdir_p(workdir, 0755, _gf_true);
 
-        if (-1 == ret) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                    "Unable to create directory %s"
                    " ,errno = %d",
@@ -1534,7 +1534,7 @@ init(xlator_t *this)
 
     len = snprintf(snap_mount_dir, sizeof(snap_mount_dir), "%s%s", var_run_dir,
                    GLUSTERD_DEFAULT_SNAPS_BRICK_DIR);
-    if ((len < 0) || (len >= sizeof(snap_mount_dir))) {
+    if (IS_ERROR(len) || (len >= sizeof(snap_mount_dir))) {
         gf_msg(this->name, GF_LOG_CRITICAL, 0, GD_MSG_DIR_OP_FAILED,
                "Snap mount dir too long");
         exit(1);
@@ -1585,20 +1585,20 @@ init(xlator_t *this)
     snprintf(cmd_log_filename, PATH_MAX, "%s/cmd_history.log", logdir);
     ret = gf_cmd_log_init(cmd_log_filename);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg("this->name", GF_LOG_CRITICAL, errno, GD_MSG_FILE_OP_FAILED,
                "Unable to create cmd log file %s", cmd_log_filename);
         exit(1);
     }
 
     len = snprintf(storedir, sizeof(storedir), "%s/vols", workdir);
-    if ((len < 0) || (len >= sizeof(storedir))) {
+    if (IS_ERROR(len) || (len >= sizeof(storedir))) {
         exit(1);
     }
 
     ret = sys_mkdir(storedir, 0755);
 
-    if ((-1 == ret) && (errno != EEXIST)) {
+    if ((IS_ERROR(ret) && (errno != EEXIST))) {
         gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create volume directory %s"
                " ,errno = %d",
@@ -1608,13 +1608,13 @@ init(xlator_t *this)
 
     /*keeping individual volume pid file information in /var/run/gluster* */
     len = snprintf(storedir, sizeof(storedir), "%s/vols", rundir);
-    if ((len < 0) || (len >= sizeof(storedir))) {
+    if (IS_ERROR(len) || (len >= sizeof(storedir))) {
         exit(1);
     }
 
     ret = sys_mkdir(storedir, 0755);
 
-    if ((-1 == ret) && (errno != EEXIST)) {
+    if (IS_ERROR(ret) && (errno != EEXIST)) {
         gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create volume directory %s"
                " ,errno = %d",
@@ -1623,13 +1623,13 @@ init(xlator_t *this)
     }
 
     len = snprintf(storedir, sizeof(storedir), "%s/snaps", workdir);
-    if ((len < 0) || (len >= sizeof(storedir))) {
+    if (IS_ERROR(len) || (len >= sizeof(storedir))) {
         exit(1);
     }
 
     ret = sys_mkdir(storedir, 0755);
 
-    if ((-1 == ret) && (errno != EEXIST)) {
+    if (IS_ERROR(ret) && (errno != EEXIST)) {
         gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create snaps directory %s"
                " ,errno = %d",
@@ -1638,13 +1638,13 @@ init(xlator_t *this)
     }
 
     len = snprintf(storedir, sizeof(storedir), "%s/peers", workdir);
-    if ((len < 0) || (len >= sizeof(storedir))) {
+    if (IS_ERROR(len) || (len >= sizeof(storedir))) {
         exit(1);
     }
 
     ret = sys_mkdir(storedir, 0755);
 
-    if ((-1 == ret) && (errno != EEXIST)) {
+    if (IS_ERROR(ret) && (errno != EEXIST)) {
         gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create peers directory %s"
                " ,errno = %d",
@@ -1653,12 +1653,12 @@ init(xlator_t *this)
     }
 
     len = snprintf(storedir, sizeof(storedir), "%s/bricks", logdir);
-    if ((len < 0) || (len >= sizeof(storedir))) {
+    if (IS_ERROR(len) || (len >= sizeof(storedir))) {
         exit(1);
     }
 
     ret = sys_mkdir(storedir, 0755);
-    if ((-1 == ret) && (errno != EEXIST)) {
+    if (IS_ERROR(ret) && (errno != EEXIST)) {
         gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create logs directory %s"
                " ,errno = %d",
@@ -1668,11 +1668,11 @@ init(xlator_t *this)
 
 #ifdef BUILD_GNFS
     len = snprintf(storedir, sizeof(storedir), "%s/nfs", workdir);
-    if ((len < 0) || (len >= sizeof(storedir))) {
+    if (IS_ERROR(len) || (len >= sizeof(storedir))) {
         exit(1);
     }
     ret = sys_mkdir(storedir, 0755);
-    if ((-1 == ret) && (errno != EEXIST)) {
+    if (IS_ERROR(ret) && (errno != EEXIST)) {
         gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create nfs directory %s"
                " ,errno = %d",
@@ -1681,33 +1681,33 @@ init(xlator_t *this)
     }
 #endif
     len = snprintf(storedir, sizeof(storedir), "%s/bitd", workdir);
-    if ((len < 0) || (len >= sizeof(storedir))) {
+    if (IS_ERROR(len) || (len >= sizeof(storedir))) {
         exit(1);
     }
     ret = sys_mkdir(storedir, 0755);
-    if ((-1 == ret) && (errno != EEXIST)) {
+    if (IS_ERROR(ret) && (errno != EEXIST)) {
         gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create bitrot directory %s", storedir);
         exit(1);
     }
 
     len = snprintf(storedir, sizeof(storedir), "%s/scrub", workdir);
-    if ((len < 0) || (len >= sizeof(storedir))) {
+    if (IS_ERROR(len) || (len >= sizeof(storedir))) {
         exit(1);
     }
     ret = sys_mkdir(storedir, 0755);
-    if ((-1 == ret) && (errno != EEXIST)) {
+    if (IS_ERROR(ret) && (errno != EEXIST)) {
         gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create scrub directory %s", storedir);
         exit(1);
     }
 
     len = snprintf(storedir, sizeof(storedir), "%s/glustershd", workdir);
-    if ((len < 0) || (len >= sizeof(storedir))) {
+    if (IS_ERROR(len) || (len >= sizeof(storedir))) {
         exit(1);
     }
     ret = sys_mkdir(storedir, 0755);
-    if ((-1 == ret) && (errno != EEXIST)) {
+    if (IS_ERROR(ret) && (errno != EEXIST)) {
         gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create glustershd directory %s"
                " ,errno = %d",
@@ -1716,11 +1716,11 @@ init(xlator_t *this)
     }
 
     len = snprintf(storedir, sizeof(storedir), "%s/quotad", workdir);
-    if ((len < 0) || (len >= sizeof(storedir))) {
+    if (IS_ERROR(len) || (len >= sizeof(storedir))) {
         exit(1);
     }
     ret = sys_mkdir(storedir, 0755);
-    if ((-1 == ret) && (errno != EEXIST)) {
+    if (IS_ERROR(ret) && (errno != EEXIST)) {
         gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create quotad directory %s"
                " ,errno = %d",
@@ -1729,11 +1729,11 @@ init(xlator_t *this)
     }
 
     len = snprintf(storedir, sizeof(storedir), "%s/groups", workdir);
-    if ((len < 0) || (len >= sizeof(storedir))) {
+    if (IS_ERROR(len) || (len >= sizeof(storedir))) {
         exit(1);
     }
     ret = sys_mkdir(storedir, 0755);
-    if ((-1 == ret) && (errno != EEXIST)) {
+    if (IS_ERROR(ret) && (errno != EEXIST)) {
         gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_CREATE_DIR_FAILED,
                "Unable to create glustershd directory %s"
                " ,errno = %d",
@@ -1906,7 +1906,7 @@ init(xlator_t *this)
     /* Set option to run bricks on valgrind if enabled in glusterd.vol */
     this->ctx->cmd_args.valgrind = valgrind;
     ret = dict_get_str(this->options, "run-with-valgrind", &valgrind_str);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, 0, "cannot get run-with-valgrind value");
     }
     if (valgrind_str) {
@@ -1939,7 +1939,7 @@ init(xlator_t *this)
      * tree.
      */
     ret = glusterd_hooks_create_hooks_directory(conf->workdir);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_CRITICAL, errno, GD_MSG_DIR_OP_FAILED,
                "Unable to create hooks directory ");
         exit(1);
@@ -1989,7 +1989,7 @@ init(xlator_t *this)
     }
 
     ret = glusterd_restore();
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (dict_get_str(conf->opts, GLUSTERD_LOCALTIME_LOGGING_KEY,
@@ -2055,7 +2055,7 @@ init(xlator_t *this)
 
     ret = 0;
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (this->private != NULL) {
             GF_FREE(this->private);
             this->private = NULL;

--- a/xlators/mgmt/glusterd/src/glusterd.h
+++ b/xlators/mgmt/glusterd/src/glusterd.h
@@ -656,7 +656,7 @@ typedef ssize_t (*gd_serialize_t)(struct iovec outmsg, void *args);
             _vol_dir_len = snprintf(path, PATH_MAX, "%s/vols/%s",              \
                                     priv->workdir, volinfo->volname);          \
         }                                                                      \
-        if ((_vol_dir_len < 0) || (_vol_dir_len >= PATH_MAX)) {                \
+        if (IS_ERROR((_vol_dir_len)) || (_vol_dir_len >= PATH_MAX)) {          \
             path[0] = 0;                                                       \
         }                                                                      \
     } while (0)
@@ -668,7 +668,7 @@ typedef ssize_t (*gd_serialize_t)(struct iovec outmsg, void *args);
         GLUSTERD_GET_VOLUME_DIR(vol_path, volinfo, priv);                      \
         _defrag_dir_len = snprintf(path, PATH_MAX, "%s/%s", vol_path,          \
                                    "rebalance");                               \
-        if ((_defrag_dir_len < 0) || (_defrag_dir_len >= PATH_MAX)) {          \
+        if (IS_ERROR((_defrag_dir_len)) || (_defrag_dir_len >= PATH_MAX)) {    \
             path[0] = 0;                                                       \
         }                                                                      \
     } while (0)
@@ -680,7 +680,8 @@ typedef ssize_t (*gd_serialize_t)(struct iovec outmsg, void *args);
         GLUSTERD_GET_DEFRAG_DIR(defrag_path, volinfo, priv);                   \
         _defrag_pidfile_len = snprintf(path, PATH_MAX, "%s/%s.pid",            \
                                        defrag_path, uuid_utoa(MY_UUID));       \
-        if ((_defrag_pidfile_len < 0) || (_defrag_pidfile_len >= PATH_MAX)) {  \
+        if (IS_ERROR((_defrag_pidfile_len)) ||                                 \
+            (_defrag_pidfile_len >= PATH_MAX)) {                               \
             path[0] = 0;                                                       \
         }                                                                      \
     } while (0)
@@ -690,7 +691,7 @@ typedef ssize_t (*gd_serialize_t)(struct iovec outmsg, void *args);
         int32_t _shd_dir_len;                                                  \
         _shd_dir_len = snprintf(path, PATH_MAX, "%s/shd/%s", priv->rundir,     \
                                 volinfo->volname);                             \
-        if ((_shd_dir_len < 0) || (_shd_dir_len >= PATH_MAX)) {                \
+        if (IS_ERROR((_shd_dir_len)) || (_shd_dir_len >= PATH_MAX)) {          \
             path[0] = 0;                                                       \
         }                                                                      \
     } while (0)
@@ -706,7 +707,7 @@ typedef ssize_t (*gd_serialize_t)(struct iovec outmsg, void *args);
             _vol_pid_len = snprintf(path, PATH_MAX, "%s/vols/%s",              \
                                     priv->rundir, volinfo->volname);           \
         }                                                                      \
-        if ((_vol_pid_len < 0) || (_vol_pid_len >= PATH_MAX)) {                \
+        if (IS_ERROR((_vol_pid_len)) || (_vol_pid_len >= PATH_MAX)) {          \
             path[0] = 0;                                                       \
         }                                                                      \
     } while (0)
@@ -716,7 +717,7 @@ typedef ssize_t (*gd_serialize_t)(struct iovec outmsg, void *args);
         int32_t _snap_geo_len;                                                 \
         _snap_geo_len = snprintf(path, PATH_MAX, "%s/snaps/%s/%s",             \
                                  priv->workdir, snap->snapname, GEOREP);       \
-        if ((_snap_geo_len < 0) || (_snap_geo_len >= PATH_MAX)) {              \
+        if (IS_ERROR((_snap_geo_len)) || (_snap_geo_len >= PATH_MAX)) {        \
             path[0] = 0;                                                       \
         }                                                                      \
     } while (0)
@@ -751,7 +752,7 @@ typedef ssize_t (*gd_serialize_t)(struct iovec outmsg, void *args);
         GLUSTERD_REMOVE_SLASH_FROM_PATH(brickinfo->path, exp_path);            \
         _brick_pid_len = snprintf(pidfile, PATH_MAX, "%s/%s-%s.pid", volpath,  \
                                   brickinfo->hostname, exp_path);              \
-        if ((_brick_pid_len < 0) || (_brick_pid_len >= PATH_MAX)) {            \
+        if (IS_ERROR((_brick_pid_len)) || (_brick_pid_len >= PATH_MAX)) {      \
             pidfile[0] = 0;                                                    \
         }                                                                      \
     } while (0)

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -1099,7 +1099,7 @@ fuse_fop_resume(fuse_state_t *state)
     /*
      * Fail fd resolution failures right away.
      */
-    if (IS_ERROR(state->resolve.fd && state->resolve.op_ret)) {
+    if (state->resolve.fd && IS_ERROR(state->resolve.op_ret)) {
         send_fuse_err(state->this, state->finh, state->resolve.op_errno);
         free_fuse_state(state);
         return;

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -90,7 +90,7 @@ __fuse_fd_ctx_check_n_create(xlator_t *this, fd_t *fd)
             goto out;
         }
         ret = __fd_ctx_set(fd, this, (uint64_t)(unsigned long)fd_ctx);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log("glusterfs-fuse", GF_LOG_DEBUG, "fd-ctx-set failed");
             GF_FREE(fd_ctx);
             fd_ctx = NULL;
@@ -149,7 +149,7 @@ fuse_fd_ctx_get(xlator_t *this, fd_t *fd)
     int ret = 0;
 
     ret = fd_ctx_get(fd, this, &value);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -222,7 +222,7 @@ check_and_dump_fuse_W(fuse_private_t *priv, struct iovec *iov_out, int count,
     };
     struct fuse_out_header *fouh = NULL;
 
-    if (res == -1) {
+    if (IS_ERROR(res)) {
         const char *errdesc = NULL;
         gf_loglevel_t loglevel = GF_LOG_ERROR;
 
@@ -288,7 +288,7 @@ check_and_dump_fuse_W(fuse_private_t *priv, struct iovec *iov_out, int count,
         return EINVAL;
     }
 
-    if (priv->fuse_dump_fd == -1)
+    if (IS_ERROR(priv->fuse_dump_fd))
         return 0;
 
     fusedump_setup_meta(diov, &w, &fusedump_item_count, &fts, &fsig);
@@ -299,7 +299,7 @@ check_and_dump_fuse_W(fuse_private_t *priv, struct iovec *iov_out, int count,
         res = sys_writev(priv->fuse_dump_fd, iov_out, count);
     pthread_mutex_unlock(&priv->fuse_dump_mutex);
 
-    if (res == -1)
+    if (IS_ERROR(res))
         gf_log("glusterfs-fuse", GF_LOG_ERROR,
                "failed to dump fuse message (W): %s", strerror(errno));
 
@@ -1067,7 +1067,7 @@ fuse_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     state = frame->root->state;
     prev = cookie;
 
-    if (op_ret == -1 && state->is_revalidate == 1) {
+    if (IS_ERROR(op_ret) && state->is_revalidate == 1) {
         itable = state->itable;
         /*
          * A stale mapping might exist for a dentry/inode that has been
@@ -1099,7 +1099,7 @@ fuse_fop_resume(fuse_state_t *state)
     /*
      * Fail fd resolution failures right away.
      */
-    if (state->resolve.fd && state->resolve.op_ret < 0) {
+    if (IS_ERROR(state->resolve.fd && state->resolve.op_ret)) {
         send_fuse_err(state->this, state->finh, state->resolve.op_errno);
         free_fuse_state(state);
         return;
@@ -1123,7 +1123,8 @@ fuse_lookup_resume(fuse_state_t *state)
     /* parent was resolved, entry could not, may be a missing gfid?
      * Hence try to do a regular lookup
      */
-    if ((state->resolve.op_ret == -1) && (state->resolve.op_errno == ENODATA)) {
+    if (IS_ERROR(state->resolve.op_ret) &&
+        (state->resolve.op_errno == ENODATA)) {
         state->resolve.op_ret = 0;
     }
 
@@ -1327,7 +1328,7 @@ fuse_attr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
             state->gfid[15] = 1;
 
             ret = fuse_loc_fill(&state->loc, state, finh->nodeid, 0, NULL);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_log("glusterfs-fuse", GF_LOG_WARNING,
                        "%" PRIu64 ": loc_fill() on / failed", finh->unique);
                 send_fuse_err(this, finh, ENOENT);
@@ -1436,7 +1437,7 @@ fuse_getattr(xlator_t *this, fuse_in_header_t *finh, void *msg,
         state->gfid[15] = 1;
 
         ret = fuse_loc_fill(&state->loc, state, finh->nodeid, 0, NULL);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log("glusterfs-fuse", GF_LOG_WARNING,
                    "%" PRIu64 ": GETATTR on / (fuse_loc_fill() failed)",
                    finh->unique);
@@ -1562,7 +1563,7 @@ fuse_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
                state->loc.path, fd);
 
         ret = fuse_fd_inherit_directio(this, fd, &foo);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             op_errno = -ret;
             gf_log("glusterfs-fuse", GF_LOG_WARNING,
                    "cannot inherit direct-io values for fd "
@@ -1960,7 +1961,7 @@ static int
 fuse_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
 {
-    if (op_ret == -1 && op_errno == ENOTSUP)
+    if (IS_ERROR(op_ret) && op_errno == ENOTSUP)
         GF_LOG_OCCASIONALLY(gf_fuse_xattr_enotsup_log, "glusterfs-fuse",
                             GF_LOG_CRITICAL,
                             "extended attribute not supported "
@@ -2694,8 +2695,9 @@ fuse_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         if (op_errno == ENOENT)
             op_errno = ESTALE;
 
-        gf_log("glusterfs-fuse", GF_LOG_WARNING, "%" PRIu64 ": %s => -1 (%s)",
-               finh->unique, state->loc.path, strerror(op_errno));
+        gf_log("glusterfs-fuse", GF_LOG_WARNING, "%" PRIu64 ": %s => %s (%s)",
+               finh->unique, state->loc.path, gf_strerror(op_ret),
+               strerror(op_errno));
 
         send_fuse_err(this, finh, op_errno);
         gf_fd_put(priv->fdtable, state->fd_no);
@@ -3549,7 +3551,7 @@ fuse_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_WARNING,
                "%" PRIu64 ": READDIR => -1 (%s)", frame->root->unique,
                strerror(op_errno));
@@ -3664,7 +3666,7 @@ fuse_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     finh = state->finh;
     priv = this->private;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_WARNING,
                "%" PRIu64 ": READDIRP => -1 (%s)", frame->root->unique,
                strerror(op_errno));
@@ -4155,7 +4157,7 @@ fuse_setxattr(xlator_t *this, fuse_in_header_t *finh, void *msg,
         dict_value[fsi->size] = '\0';
     }
     ret = dict_set_dynptr(state->xattr, newkey, dict_value, fsi->size);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         GF_FREE(dict_value);
         GF_FREE(newkey);
@@ -4256,7 +4258,7 @@ fuse_xattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
              * while counting size and then while filling buffer
              */
             len = dict_keys_join(NULL, 0, dict, fuse_filter_xattr);
-            if (len < 0)
+            if (IS_ERROR(len))
                 goto out;
 
             value = alloca(len + 1);
@@ -4756,7 +4758,7 @@ fuse_setlk_interrupt_handler_cbk(call_frame_t *frame, void *cookie,
     int ret = 0;
 
     ret = dict_get_bin(xdata, "fuse-interrupt-record", (void **)&fir);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log("glusterfs-fuse", GF_LOG_ERROR, "interrupt record not found");
 
         goto out;
@@ -4796,7 +4798,7 @@ fuse_setlk_interrupt_handler(xlator_t *this, fuse_interrupt_record_t *fir)
     ret = gf_asprintf(
         &xattr_name, GF_XATTR_CLRLK_CMD ".tposix.kblocked.%hd,%jd-%jd",
         state->lk_lock.l_whence, state->lk_lock.l_start, state->lk_lock.l_len);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         xattr_name = NULL;
         goto err;
     }
@@ -5017,7 +5019,8 @@ timed_response_loop(void *data)
                               next);
             list_for_each_entry(tmp, &priv->timed_list, next)
             {
-                if (timespec_cmp(&tmp->scheduled_ts, &dmsg->scheduled_ts) < 0) {
+                if (IS_ERROR(timespec_cmp(&tmp->scheduled_ts,
+                                          &dmsg->scheduled_ts))) {
                     dmsg = tmp;
                 }
             }
@@ -5027,7 +5030,7 @@ timed_response_loop(void *data)
         pthread_mutex_unlock(&priv->timed_mutex);
 
         timespec_now(&now);
-        if (timespec_cmp(&now, &dmsg->scheduled_ts) < 0) {
+        if (IS_ERROR(timespec_cmp(&now, &dmsg->scheduled_ts))) {
             timespec_sub(&now, &dmsg->scheduled_ts, &delta);
             nanosleep(&delta, NULL);
         }
@@ -5328,7 +5331,7 @@ fuse_first_lookup(xlator_t *this)
 
     ret = syncop_lookup(xl, &loc, &iatt, NULL, dict, NULL);
     DECODE_SYNCOP_ERR(ret);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_ERROR, "first lookup on root failed (%s)",
                strerror(errno));
         /* NOTE: Treat it as an error case. */
@@ -5377,7 +5380,7 @@ fuse_nameless_lookup(xlator_t *this, xlator_t *xl, uuid_t gfid, loc_t *loc)
     }
 
     ret = syncop_lookup(xl, loc, &iatt, NULL, xattr_req, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     linked_inode = inode_link(loc->inode, NULL, NULL, &iatt);
@@ -5409,7 +5412,7 @@ fuse_migrate_fd_open(xlator_t *this, fd_t *basefd, fd_t *oldfd,
     int ret = 0, flags = 0;
 
     ret = inode_path(basefd->inode, NULL, (char **)&loc.path);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log("glusterfs-fuse", GF_LOG_WARNING,
                "cannot construct path of gfid (%s) failed"
                "(old-subvolume:%s-%d new-subvolume:%s-%d)",
@@ -5424,7 +5427,7 @@ fuse_migrate_fd_open(xlator_t *this, fd_t *basefd, fd_t *oldfd,
 
     if (loc.inode == NULL) {
         ret = fuse_nameless_lookup(this, new_subvol, basefd->inode->gfid, &loc);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log("glusterfs-fuse", GF_LOG_WARNING,
                    "name-less lookup of gfid (%s) failed (%s)"
                    "(old-subvolume:%s-%d new-subvolume:%s-%d)",
@@ -5467,7 +5470,7 @@ fuse_migrate_fd_open(xlator_t *this, fd_t *basefd, fd_t *oldfd,
         ret = syncop_open(new_subvol, &loc, flags, newfd, NULL, NULL);
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log("glusterfs-fuse", GF_LOG_WARNING,
                "open on basefd (ptr:%p inode-gfid:%s) failed (%s)"
                "(old-subvolume:%s-%d new-subvolume:%s-%d)",
@@ -5532,7 +5535,7 @@ fuse_migrate_locks(xlator_t *this, fd_t *basefd, fd_t *oldfd,
 
     ret = syncop_fgetxattr(old_subvol, oldfd, &lockinfo, GF_XATTR_LOCKINFO_KEY,
                            NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_WARNING,
                "getting lockinfo failed while migrating locks"
                "(oldfd:%p newfd:%p inode-gfid:%s)"
@@ -5557,7 +5560,7 @@ fuse_migrate_locks(xlator_t *this, fd_t *basefd, fd_t *oldfd,
     }
 
     ret = syncop_fsetxattr(new_subvol, newfd, lockinfo, 0, NULL, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_WARNING,
                "migrating locks failed (oldfd:%p newfd:%p "
                "inode-gfid:%s) (old-subvol:%s-%d new-subvol:%s-%d)",
@@ -5627,7 +5630,7 @@ fuse_migrate_fd(xlator_t *this, fd_t *basefd, xlator_t *old_subvol,
         else
             ret = syncop_fsync(old_subvol, oldfd, 0, NULL, NULL, NULL, NULL);
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log("glusterfs-fuse", GF_LOG_WARNING,
                    "syncop_fsync(dir) failed (%s) on fd (%p)"
                    "(basefd:%p basefd-inode.gfid:%s) "
@@ -5647,7 +5650,7 @@ fuse_migrate_fd(xlator_t *this, fd_t *basefd, xlator_t *old_subvol,
     }
 
     ret = fuse_migrate_fd_open(this, basefd, oldfd, old_subvol, new_subvol);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_WARNING,
                "open corresponding to "
                "basefd (ptr:%p inode-gfid:%s) in new graph failed "
@@ -5658,7 +5661,7 @@ fuse_migrate_fd(xlator_t *this, fd_t *basefd, xlator_t *old_subvol,
     }
 
     ret = fuse_migrate_locks(this, basefd, oldfd, old_subvol, new_subvol);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_WARNING,
                "migrating locks from old-subvolume (%s-%d) to "
                "new-subvolume (%s-%d) failed (inode-gfid:%s oldfd:%p "
@@ -5668,7 +5671,7 @@ fuse_migrate_fd(xlator_t *this, fd_t *basefd, xlator_t *old_subvol,
                basefd);
     }
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_WARNING,
                "migration of basefd "
                "(ptr:%p inode-gfid:%s) failed"
@@ -5713,7 +5716,7 @@ fuse_handle_opened_fds(xlator_t *this, xlator_t *old_subvol,
             if (fdctx) {
                 LOCK(&fd->lock);
                 {
-                    if (ret < 0) {
+                    if (IS_ERROR(ret)) {
                         fdctx->migration_failed = 1;
                     } else {
                         fdctx->migration_failed = 0;
@@ -5813,7 +5816,7 @@ fuse_handle_graph_switch(xlator_t *this, xlator_t *old_subvol,
 
     ret = synctask_new(this->ctx->env, fuse_graph_switch_task, NULL, frame,
                        args);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_WARNING,
                "starting sync-task to "
                "handle graph switch failed");
@@ -5909,7 +5912,8 @@ fuse_get_mount_status(xlator_t *this)
     int kid_status = -1;
     fuse_private_t *priv = this->private;
 
-    if (sys_read(priv->status_pipe[0], &kid_status, sizeof(kid_status)) < 0) {
+    if (IS_ERROR(
+            sys_read(priv->status_pipe[0], &kid_status, sizeof(kid_status)))) {
         gf_log(this->name, GF_LOG_ERROR, "could not get mount status");
         kid_status = -1;
     }
@@ -5985,7 +5989,7 @@ fuse_thread_proc(void *data)
                 pfd[0].events = POLLIN | POLLHUP | POLLERR;
                 pfd[1].fd = priv->fd;
                 pfd[1].events = POLLIN | POLLHUP | POLLERR;
-                if (poll(pfd, 2, -1) < 0) {
+                if (IS_ERROR(poll(pfd, 2, -1))) {
                     gf_log(this->name, GF_LOG_ERROR, "poll error %s",
                            strerror(errno));
                     pthread_mutex_unlock(&priv->sync_mutex);
@@ -6054,7 +6058,7 @@ fuse_thread_proc(void *data)
 
         res = sys_readv(priv->fd, iov_in, 2);
 
-        if (res == -1) {
+        if (IS_ERROR(res)) {
             if (errno == ENODEV || errno == EBADF) {
                 gf_log("glusterfs-fuse", GF_LOG_DEBUG,
                        "terminating upon getting %s when "
@@ -6448,7 +6452,7 @@ notify(xlator_t *this, int32_t event, void *data, ...)
                 if (!private->mount_finished) {
                     pfd.fd = private->status_pipe[0];
                     pfd.events = POLLIN | POLLHUP | POLLERR;
-                    if (poll(&pfd, 1, -1) < 0) {
+                    if (IS_ERROR(poll(&pfd, 1, -1))) {
                         gf_log(this->name, GF_LOG_ERROR, "poll error %s",
                                strerror(errno));
                         goto auth_fail_unlock;
@@ -6600,7 +6604,7 @@ fuse_dumper(xlator_t *this, fuse_in_header_t *finh, void *msg,
     pthread_mutex_lock(&priv->fuse_dump_mutex);
     ret = sys_writev(priv->fuse_dump_fd, diov, sizeof(diov) / sizeof(diov[0]));
     pthread_mutex_unlock(&priv->fuse_dump_mutex);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         gf_log("glusterfs-fuse", GF_LOG_ERROR,
                "failed to dump fuse message (R): %s", strerror(errno));
 
@@ -6673,7 +6677,7 @@ init(xlator_t *this_xl)
 
     /* get options from option dictionary */
     ret = dict_get_str(options, ZR_MOUNTPOINT_OPT, &value_string);
-    if (ret == -1 || value_string == NULL) {
+    if (IS_ERROR(ret) || value_string == NULL) {
         gf_log("fuse", GF_LOG_ERROR,
                "Mandatory option 'mountpoint' is not specified.");
         goto cleanup_exit;
@@ -6759,7 +6763,7 @@ init(xlator_t *this_xl)
     ret = dict_get_str(options, "dump-fuse", &value_string);
     if (ret == 0) {
         ret = sys_unlink(value_string);
-        if (ret == -1 && errno != ENOENT) {
+        if (IS_ERROR(ret) && errno != ENOENT) {
             gf_log("glusterfs-fuse", GF_LOG_ERROR,
                    "failed to remove old fuse dump file %s: %s", value_string,
                    strerror(errno));
@@ -6767,7 +6771,7 @@ init(xlator_t *this_xl)
             goto cleanup_exit;
         }
         ret = open(value_string, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_log("glusterfs-fuse", GF_LOG_ERROR,
                    "failed to open fuse dump file %s: %s", value_string,
                    strerror(errno));
@@ -6795,7 +6799,7 @@ init(xlator_t *this_xl)
 
     GF_OPTION_INIT("fuse-mountopts", priv->fuse_mountopts, str, cleanup_exit);
 
-    if (gid_cache_init(&priv->gid_cache, priv->gid_cache_timeout) < 0) {
+    if (IS_ERROR(gid_cache_init(&priv->gid_cache, priv->gid_cache_timeout))) {
         gf_log("glusterfs-fuse", GF_LOG_ERROR,
                "Failed to initialize "
                "group cache.");
@@ -6922,7 +6926,7 @@ init(xlator_t *this_xl)
         }
     }
 
-    if (pipe(priv->status_pipe) < 0) {
+    if (IS_ERROR(pipe(priv->status_pipe))) {
         gf_log(this_xl->name, GF_LOG_ERROR,
                "could not create pipe to separate mount process");
         goto cleanup_exit;
@@ -6931,11 +6935,11 @@ init(xlator_t *this_xl)
     priv->fd = gf_fuse_mount(priv->mount_point, fsname, mnt_args,
                              sync_to_mount ? &ctx->mnt_pid : NULL,
                              priv->status_pipe[1]);
-    if (priv->fd == -1)
+    if (IS_ERROR(priv->fd))
         goto cleanup_exit;
     if (priv->auto_unmount) {
         ret = gf_fuse_unmount_daemon(priv->mount_point, priv->fd);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             goto cleanup_exit;
     }
 

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -1524,7 +1524,7 @@ fuse_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         foo.fh = (uintptr_t)fd;
         foo.open_flags = 0;
 
@@ -2627,7 +2627,7 @@ fuse_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         foo.fh = (uintptr_t)fd;
 
         if (((priv->direct_io_mode == 2) &&
@@ -2906,7 +2906,7 @@ fuse_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE,
                "%" PRIu64 ": READ => %d/%" GF_PRI_SIZET ",%" PRId64 "/%" PRIu64,
                frame->root->unique, op_ret, state->size, state->off,
@@ -3001,7 +3001,7 @@ fuse_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE,
                "%" PRIu64 ": WRITE => %d/%" GF_PRI_SIZET ",%" PRId64
                "/%" PRIu64,
@@ -3135,7 +3135,7 @@ fuse_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE,
                "%" PRIu64 ": WRITE => %d/%" GF_PRI_SIZET ",%" PRIu64
                " , %" PRIu64 " ,%" PRIu64 ",%" PRIu64,
@@ -3233,7 +3233,7 @@ fuse_lseek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         flo.offset = offset;
         send_fuse_obj(this, finh, &flo);
     } else {
@@ -4098,7 +4098,7 @@ fuse_setxattr(xlator_t *this, fuse_in_header_t *finh, void *msg,
     /* Check if the command is for changing the log
        level of process or specific xlator */
     ret = is_gf_log_command(this, name, value, fsi->size);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         op_errno = ret;
         goto done;
     }
@@ -4234,7 +4234,7 @@ fuse_xattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE, "%" PRIu64 ": %s() %s => %d",
                frame->root->unique, gf_fop_list[frame->root->op],
                state->loc.path, op_ret);

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -346,7 +346,7 @@ typedef struct fuse_graph_switch_args fuse_graph_switch_args_t;
                sake of backward compatibility with old (3.3.[01])              \
                releases till then. */                                          \
             ret = dict_set_int16(state->xdata, "umask", fci->umask);           \
-            if (ret < 0) {                                                     \
+            if (IS_ERROR(ret)) {                                               \
                 gf_log("glusterfs-fuse", GF_LOG_WARNING,                       \
                        "%s Failed adding umask"                                \
                        " to request",                                          \
@@ -356,7 +356,7 @@ typedef struct fuse_graph_switch_args fuse_graph_switch_args_t;
                 return;                                                        \
             }                                                                  \
             ret = dict_set_int16(state->xdata, "mode", fci->mode);             \
-            if (ret < 0) {                                                     \
+            if (IS_ERROR(ret)) {                                               \
                 gf_log("glusterfs-fuse", GF_LOG_WARNING,                       \
                        "%s Failed adding mode "                                \
                        "to request",                                           \

--- a/xlators/mount/fuse/src/fuse-helpers.c
+++ b/xlators/mount/fuse/src/fuse-helpers.c
@@ -181,7 +181,7 @@ frame_fill_groups(call_frame_t *frame)
         }
 
         ngroups = gf_getgrouplist(result->pw_name, frame->root->gid, &mygroups);
-        if (ngroups == -1) {
+        if (IS_ERROR(ngroups)) {
             gf_log(this->name, GF_LOG_ERROR,
                    "could not map %s to "
                    "group list (ngroups %d, max %d)",
@@ -301,7 +301,7 @@ get_groups(fuse_private_t *priv, call_frame_t *frame)
         return;
     }
 
-    if (-1 == priv->gid_cache_timeout) {
+    if (IS_ERROR(priv->gid_cache_timeout)) {
         frame->root->ngrps = 0;
         return;
     }

--- a/xlators/mount/fuse/src/fuse-resolve.c
+++ b/xlators/mount/fuse/src/fuse-resolve.c
@@ -55,11 +55,11 @@ fuse_resolve_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     STACK_DESTROY(frame->root);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, (op_errno == ENOENT) ? GF_LOG_DEBUG : GF_LOG_WARNING,
                "%s/%s: failed to resolve (%s)", uuid_utoa(resolve_loc->pargfid),
                resolve_loc->name, strerror(op_errno));
-        resolve->op_ret = -1;
+        resolve->op_ret = op_ret;
         resolve->op_errno = op_errno;
         goto out;
     }
@@ -121,7 +121,7 @@ fuse_resolve_gfid_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     STACK_DESTROY(frame->root);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, (op_errno == ENOENT) ? GF_LOG_DEBUG : GF_LOG_WARNING,
                "%s: failed to resolve (%s)",
                uuid_utoa(resolve->resolve_loc.gfid), strerror(op_errno));
@@ -298,7 +298,7 @@ fuse_resolve_parent(fuse_state_t *state)
         return 0;
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         fuse_resolve_entry(state);
         return 0;
     }
@@ -388,7 +388,7 @@ fuse_migrate_fd_task(void *data)
 
     LOCK(&basefd->lock);
     {
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             basefd_ctx->migration_failed = 1;
         } else {
             basefd_ctx->migration_failed = 0;
@@ -481,9 +481,9 @@ fuse_resolve_fd(fuse_state_t *state)
         FUSE_FD_GET_ACTIVE_FD(activefd, basefd);
         active_subvol = activefd->inode->table->xl;
 
-        if ((ret == -1) || fd_migration_error ||
+        if (IS_ERROR(ret) || fd_migration_error ||
             (state->active_subvol != active_subvol)) {
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 gf_log(state->this->name, GF_LOG_WARNING,
                        "starting sync-task to migrate "
                        "basefd (ptr:%p inode-gfid:%s) failed "
@@ -518,7 +518,7 @@ fuse_resolve_fd(fuse_state_t *state)
         }
     }
 
-    if ((resolve->op_ret == -1) && (resolve->op_errno == EBADF)) {
+    if (IS_ERROR(resolve->op_ret) && (resolve->op_errno == EBADF)) {
         gf_log("fuse-resolve", GF_LOG_WARNING,
                "migration of basefd (ptr:%p inode-gfid:%s) "
                "did not complete, failing fop with EBADF "

--- a/xlators/nfs/server/src/acl3.c
+++ b/xlators/nfs/server/src/acl3.c
@@ -113,7 +113,7 @@ nfs3_fh_to_xlator(struct nfs3_state *nfs3, struct nfs3_fh *fh);
         xlator_t *xlatorp = NULL;                                              \
         char buf[256], gfid[GF_UUID_BUF_SIZE];                                 \
         rpc_transport_t *trans = NULL;                                         \
-        if ((cst)->resolve_ret < 0) {                                          \
+        if (IS_ERROR((cst)->resolve_ret)) {                                    \
             trans = rpcsvc_request_transport(cst->req);                        \
             xlatorp = nfs3_fh_to_xlator(cst->nfs3state, &cst->resolvefh);      \
             gf_uuid_unparse(cst->resolvefh.gfid, gfid);                        \
@@ -180,7 +180,7 @@ acl3svc_submit_reply(rpcsvc_request_t *req, void *arg, acl3_serializer sfunc)
      * to XDR format which will be written into the buffer in outmsg.
      */
     msglen = sfunc(outmsg, arg);
-    if (msglen < 0) {
+    if (IS_ERROR(msglen)) {
         gf_msg(GF_ACL, GF_LOG_ERROR, errno, NFS_MSG_ENCODE_MSG_FAIL,
                "Failed to encode message");
         goto ret;
@@ -203,7 +203,7 @@ acl3svc_submit_reply(rpcsvc_request_t *req, void *arg, acl3_serializer sfunc)
 
     /* Then, submit the message for transmission. */
     ret = rpcsvc_submit_message(req, &outmsg, 1, NULL, 0, iobref);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_ACL, GF_LOG_ERROR, errno, NFS_MSG_REP_SUBMIT_FAIL,
                "Reply submission failed");
         goto ret;
@@ -273,7 +273,7 @@ acl3_getacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
     cs = frame->local;
     getaclreply = &cs->args.getaclreply;
-    if ((op_ret < 0) && (op_errno != ENODATA && op_errno != ENOATTR)) {
+    if (IS_ERROR((op_ret)) && (op_errno != ENODATA && op_errno != ENOATTR)) {
         stat = nfs3_cbk_errno_status(op_ret, op_errno);
         goto err;
     } else if (!dict) {
@@ -289,7 +289,7 @@ acl3_getacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (data && data->data) {
         aclcount = acl3_nfs_acl_from_xattr(cs->aclentry, data->data, data->len,
                                            !defacl);
-        if (aclcount < 0) {
+        if (IS_ERROR(aclcount)) {
             gf_msg(GF_ACL, GF_LOG_ERROR, aclcount, NFS_MSG_GET_USER_ACL_FAIL,
                    "Failed to get USER ACL");
             stat = nfs3_errno_to_nfsstat3(-aclcount);
@@ -342,7 +342,7 @@ acl3_default_getacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
     cs = frame->local;
     getaclreply = &cs->args.getaclreply;
-    if ((op_ret < 0) && (op_errno != ENODATA && op_errno != ENOATTR)) {
+    if (IS_ERROR((op_ret)) && (op_errno != ENODATA && op_errno != ENOATTR)) {
         stat = nfs3_cbk_errno_status(op_ret, op_errno);
         goto err;
     } else if (!dict) {
@@ -358,7 +358,7 @@ acl3_default_getacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (data && data->data) {
         aclcount = acl3_nfs_acl_from_xattr(cs->daclentry, data->data, data->len,
                                            defacl);
-        if (aclcount < 0) {
+        if (IS_ERROR(aclcount)) {
             gf_msg(GF_ACL, GF_LOG_ERROR, aclcount, NFS_MSG_GET_DEF_ACL_FAIL,
                    "Failed to get DEFAULT ACL");
             stat = nfs3_errno_to_nfsstat3(-aclcount);
@@ -373,7 +373,7 @@ acl3_default_getacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     nfs_request_user_init(&nfu, cs->req);
     ret = nfs_getxattr(cs->nfsx, cs->vol, &nfu, &cs->resolvedloc,
                        POSIX_ACL_ACCESS_XATTR, NULL, acl3_getacl_cbk, cs);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         stat = nfs3_errno_to_nfsstat3(-ret);
         goto err;
     }
@@ -410,7 +410,7 @@ acl3_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     cs = frame->local;
     getaclreply = &cs->args.getaclreply;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         stat = nfs3_cbk_errno_status(op_ret, op_errno);
         goto err;
     }
@@ -431,7 +431,7 @@ acl3_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
                            POSIX_ACL_ACCESS_XATTR, NULL, acl3_getacl_cbk, cs);
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         stat = nfs3_errno_to_nfsstat3(-ret);
         goto err;
     }
@@ -465,7 +465,7 @@ acl3_getacl_resume(void *carg)
                    cs);
     stat = -ret;
 acl3err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_ACL, GF_LOG_ERROR, stat, NFS_MSG_OPEN_FAIL,
                "unable to open_and_resume");
         cs->args.getaclreply.status = nfs3_errno_to_nfsstat3(stat);
@@ -523,7 +523,7 @@ acl3svc_getacl(rpcsvc_request_t *req)
     stat = nfs3_errno_to_nfsstat3(-ret);
 
 acl3err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_ACL, GF_LOG_ERROR, -ret, NFS_MSG_RESOLVE_ERROR,
                "unable to resolve and resume");
         getaclreply.status = stat;
@@ -542,7 +542,7 @@ acl3_setacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 {
     nfs3_call_state_t *cs = NULL;
     cs = frame->local;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         nfsstat3 status = nfs3_cbk_errno_status(op_ret, op_errno);
         cs->args.setaclreply.status = status;
     }
@@ -583,7 +583,7 @@ acl3_setacl_resume(void *carg)
     dict_unref(xattr);
 
 acl3err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         stat = -ret;
         gf_msg(GF_ACL, GF_LOG_ERROR, stat, NFS_MSG_OPEN_FAIL,
                "unable to open_and_resume");
@@ -659,7 +659,7 @@ acl3svc_setacl(rpcsvc_request_t *req)
     /* setfacl: NFS USER ACL */
     aclerrno = acl3_nfs_acl_to_xattr(aclentry, cs->aclxattr, cs->aclcount,
                                      !defacl);
-    if (aclerrno < 0) {
+    if (IS_ERROR(aclerrno)) {
         gf_msg(GF_ACL, GF_LOG_ERROR, -aclerrno, NFS_MSG_SET_USER_ACL_FAIL,
                "Failed to set USER ACL");
         stat = nfs3_errno_to_nfsstat3(-aclerrno);
@@ -669,7 +669,7 @@ acl3svc_setacl(rpcsvc_request_t *req)
     /* setfacl: NFS DEFAULT ACL */
     aclerrno = acl3_nfs_acl_to_xattr(daclentry, cs->daclxattr, cs->daclcount,
                                      defacl);
-    if (aclerrno < 0) {
+    if (IS_ERROR(aclerrno)) {
         gf_msg(GF_ACL, GF_LOG_ERROR, -aclerrno, NFS_MSG_SET_DEF_ACL_FAIL,
                "Failed to set DEFAULT ACL");
         stat = nfs3_errno_to_nfsstat3(-aclerrno);
@@ -680,7 +680,7 @@ acl3svc_setacl(rpcsvc_request_t *req)
     stat = nfs3_errno_to_nfsstat3(-ret);
 
 acl3err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_ACL, GF_LOG_ERROR, -ret, NFS_MSG_RESOLVE_ERROR,
                "unable to resolve and resume");
         setaclreply.status = stat;
@@ -692,7 +692,7 @@ acl3err:
     }
 
 rpcerr:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs3_call_state_wipe(cs);
     if (aclentry)
         GF_FREE(aclentry);
@@ -744,14 +744,14 @@ acl3svc_init(xlator_t *nfsx)
     options = dict_new();
 
     ret = gf_asprintf(&portstr, "%d", GF_ACL3_PORT);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 
     ret = dict_set_dynstr(options, "transport.socket.listen-port", portstr);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
     ret = dict_set_str(options, "transport-type", "socket");
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_ACL, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                "dict_set_str error");
         goto err;
@@ -759,13 +759,13 @@ acl3svc_init(xlator_t *nfsx)
 
     if (nfs->allow_insecure) {
         ret = dict_set_str(options, "rpc-auth-allow-insecure", "on");
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_ACL, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                    "dict_set_str error");
             goto err;
         }
         ret = dict_set_str(options, "rpc-auth.ports.insecure", "on");
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_ACL, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                    "dict_set_str error");
             goto err;
@@ -773,14 +773,14 @@ acl3svc_init(xlator_t *nfsx)
     }
 
     ret = dict_set_str(options, "transport.address-family", "inet");
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_ACL, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                "dict_set_str error");
         goto err;
     }
 
     ret = rpcsvc_create_listeners(nfs->rpcsvc, options, "ACL");
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_ACL, GF_LOG_ERROR, errno, NFS_MSG_LISTENERS_CREATE_FAIL,
                "Unable to create listeners");
         dict_unref(options);
@@ -815,7 +815,7 @@ acl3_nfs_acl_to_xattr(aclentry *ace,  /* ACL entries to be read */
     if (!aclcount)
         return (0);
 
-    if ((aclcount < 0) || (aclcount > NFS_ACL_MAX_ENTRIES))
+    if (IS_ERROR((aclcount)) || (aclcount > NFS_ACL_MAX_ENTRIES))
         return (-EINVAL);
 
     xheader = (posix_acl_xattr_header *)(xattrbuf);
@@ -883,7 +883,7 @@ acl3_nfs_acl_from_xattr(aclentry *ace,  /* ACL entries to be filled */
         return (-EINVAL);
 
     aclcount = posix_acl_xattr_count(bufsize);
-    if ((aclcount < 0) || (aclcount > NFS_ACL_MAX_ENTRIES))
+    if (IS_ERROR((aclcount)) || (aclcount > NFS_ACL_MAX_ENTRIES))
         return (-EINVAL);
 
     xheader = (posix_acl_xattr_header *)(xattrbuf);

--- a/xlators/nfs/server/src/exports.c
+++ b/xlators/nfs/server/src/exports.c
@@ -635,7 +635,7 @@ __exp_line_opt_parse(const char *opt_str, struct export_options **exp_opts)
     char *equals = NULL;
 
     ret = parser_set_string(options_parser, opt_str);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     while ((strmatch = parser_get_next_match(options_parser))) {
@@ -668,7 +668,7 @@ __exp_line_opt_parse(const char *opt_str, struct export_options **exp_opts)
             opts->nosuid = _gf_true;
         else if (equals) {
             ret = __exp_line_opt_key_value_parse(strmatch, opts);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 /* This means invalid key value options were
                  * specified, or memory allocation failed.
                  * The ret value gets bubbled up to the caller.
@@ -843,7 +843,7 @@ __exp_line_ng_parse(const char *line, dict_t **ng_dict)
      * and the regex used to parse it.
      */
     ret = parser_set_string(netgroup_parser, line);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -942,7 +942,7 @@ __exp_line_host_parse(const char *line, dict_t **host_dict)
      * parse it.
      */
     ret = parser_set_string(hostname_parser, line);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -1158,7 +1158,7 @@ _exp_line_parse(const char *line, struct export_dir **dir,
 
     /* Get the directory string from the line */
     ret = __exp_line_dir_parse(line, &dirstr, ms);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_EXP, GF_LOG_ERROR, 0, NFS_MSG_PARSE_DIR_FAIL,
                "Parsing directory failed: %s", strerror(-ret));
         /* If parsing the directory failed,
@@ -1174,7 +1174,7 @@ _exp_line_parse(const char *line, struct export_dir **dir,
 
     /* Parse the netgroup part of the string */
     ret = __exp_line_ng_parse(line, &netgroups);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_EXP, GF_LOG_ERROR, -ret, NFS_MSG_PARSE_FAIL,
                "Critical error: %s", strerror(-ret));
         /* Return values less than 0
@@ -1199,7 +1199,7 @@ _exp_line_parse(const char *line, struct export_dir **dir,
 
     /* Parse the host part of the string */
     ret = __exp_line_host_parse(line, &hosts);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_EXP, GF_LOG_ERROR, -ret, NFS_MSG_PARSE_FAIL,
                "Critical error: %s", strerror(-ret));
         goto free_and_out;
@@ -1385,7 +1385,7 @@ exp_file_parse(const char *filepath, struct exports_file **expfile,
     }
 
     ret = _exp_init_parsers();
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto parse_done;
 
     /* Process the file line by line, with each line being parsed into
@@ -1428,7 +1428,7 @@ exp_file_parse(const char *filepath, struct exports_file **expfile,
             goto free_and_done;
         }
 
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_EXP, GF_LOG_ERROR, -ret, NFS_MSG_PARSE_FAIL,
                    "Failed to parse line #%lu", line_number);
             continue; /* Skip entering this line and continue */

--- a/xlators/nfs/server/src/mount3-auth.c
+++ b/xlators/nfs/server/src/mount3-auth.c
@@ -120,7 +120,7 @@ mnt3_auth_set_exports_auth(struct mnt3_auth_params *auth_params,
 
     /* Parse the exports file and set the auth parameter */
     ret = exp_file_parse(filename, &expfile, auth_params->ms);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT_AUTH, GF_LOG_ERROR, 0, NFS_MSG_LOAD_PARSE_ERROR,
                "Failed to load & parse file"
                " %s, see logs for more information",

--- a/xlators/nfs/server/src/mount3.c
+++ b/xlators/nfs/server/src/mount3.c
@@ -114,7 +114,7 @@ mnt3svc_submit_reply(rpcsvc_request_t *req, void *arg, mnt3_serializer sfunc)
      * to XDR format which will be written into the buffer in outmsg.
      */
     msglen = sfunc(outmsg, arg);
-    if (msglen < 0) {
+    if (IS_ERROR(msglen)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, 0, NFS_MSG_ENCODE_MSG_FAIL,
                "Failed to encode message");
         goto ret;
@@ -137,7 +137,7 @@ mnt3svc_submit_reply(rpcsvc_request_t *req, void *arg, mnt3_serializer sfunc)
 
     /* Then, submit the message for transmission. */
     ret = rpcsvc_submit_message(req, &outmsg, 1, NULL, 0, iobref);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, errno, NFS_MSG_REP_SUBMIT_FAIL,
                "Reply submission failed");
         goto ret;
@@ -392,7 +392,7 @@ __mount_rewrite_rmtab(struct mount3_state *ms, gf_store_handle_t *sh)
     }
 
     fd = gf_store_mkstemp(sh);
-    if (fd == -1) {
+    if (IS_ERROR(fd)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, EINVAL, NFS_MSG_INVALID_ENTRY,
                "Failed to open %s", sh->path);
         return;
@@ -612,7 +612,7 @@ mnt3svc_update_mountlist(struct mount3_state *ms, rpcsvc_request_t *req,
      * can map it into the mount entry.
      */
     ret = rpcsvc_transport_peername(req->trans, me->hostname, MNTPATHLEN);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto free_err;
 
     colon = strrchr(me->hostname, ':');
@@ -657,7 +657,7 @@ free_err:
     if (update_rmtab)
         gf_store_handle_destroy(sh);
 
-    if (ret == -1)
+    if (IS_ERROR(ret))
         GF_FREE(me);
 
     return ret;
@@ -780,7 +780,7 @@ mnt3svc_lookup_mount_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         op_errno = EINVAL;
     }
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, op_errno, NFS_MSG_LOOKUP_MNT_ERROR,
                "error=%s", strerror(op_errno));
         status = mnt3svc_errno_to_mnterr(op_errno);
@@ -888,7 +888,7 @@ mnt3svc_mount_inode(rpcsvc_request_t *req, struct mount3_state *ms,
         return ret;
 
     ret = nfs_inode_loc_fill(exportinode, &exportloc, NFS_RESOLVE_EXIST);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_INODE_LOC_FILL_ERROR,
                "Loc fill failed for export inode"
                ": gfid %s, volume: %s",
@@ -1063,7 +1063,7 @@ __mnt3_resolve_export_subdir_comp(mnt3_resolve_t *mres)
     ret = nfs_entry_loc_fill(mres->mstate->nfsx, mres->exp->vol->itable, gfid,
                              nextcomp, &mres->resolveloc, NFS_RESOLVE_CREATE,
                              NULL);
-    if ((ret < 0) && (ret != -2)) {
+    if (IS_ERROR(ret) && (ret != -2)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, EFAULT, NFS_MSG_RESOLVE_INODE_FAIL,
                "Failed to resolve and "
                "create inode: parent gfid %s, entry %s",
@@ -1135,11 +1135,11 @@ mnt3_resolve_subdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     mres = frame->local;
     ms = mres->mstate;
     mntxl = (xlator_t *)cookie;
-    if (op_ret == -1 && op_errno == ESTALE) {
+    if (IS_ERROR(op_ret) && (op_errno == ESTALE)) {
         /* Nuke inode from cache and try the LOOKUP
          * request again. */
         return __mnt3_fresh_lookup(mres);
-    } else if (op_ret == -1) {
+    } else if (IS_ERROR(op_ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, op_errno, NFS_MSG_RESOLVE_SUBDIR_FAIL,
                "path=%s (%s)", mres->resolveloc.path, strerror(op_errno));
         mntstat = mnt3svc_errno_to_mnterr(op_errno);
@@ -1202,11 +1202,11 @@ mnt3_resolve_subdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     } else {
         mres->parentfh = fh;
         op_ret = __mnt3_resolve_export_subdir_comp(mres);
-        if (op_ret < 0)
+        if (IS_ERROR(op_ret))
             mntstat = mnt3svc_errno_to_mnterr(-op_ret);
     }
 err:
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg_debug(GF_MNT, 0, "Mount reply status: %d", mntstat);
         svc = rpcsvc_request_service(mres->req);
         autharrlen = rpcsvc_auth_array(svc, mntxl->name, autharr, 10);
@@ -1264,7 +1264,7 @@ mnt3_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_ASSERT(frame);
 
     mres = frame->local;
-    if (!mres || !path || (path[0] == '/') || (op_ret < 0))
+    if (!mres || !path || (path[0] == '/') || IS_ERROR(op_ret))
         goto mnterr;
 
     /* Finding current location of symlink */
@@ -1283,7 +1283,7 @@ mnt3_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
     /* Resolving into absolute path */
     ret = gf_build_absolute_path(parent_path, relative_path, &absolute_path);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_RESOLVE_SYMLINK_ERROR,
                "Cannot resolve symlink, path is out of boundary "
                "from current location %s and with relative path "
@@ -1383,7 +1383,7 @@ __mnt3_resolve_subdir(mnt3_resolve_t *mres)
     ret = nfs_entry_loc_fill(mres->mstate->nfsx, mres->exp->vol->itable,
                              rootgfid, firstcomp, &mres->resolveloc,
                              NFS_RESOLVE_CREATE, NULL);
-    if ((ret < 0) && (ret != -2)) {
+    if (IS_ERROR(ret) && (ret != -2)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, EFAULT, NFS_MSG_RESOLVE_INODE_FAIL,
                "Failed to resolve and "
                "create inode for volume root: %s",
@@ -1569,7 +1569,7 @@ mnt3_resolve_subdir(rpcsvc_request_t *req, struct mount3_state *ms,
 
     mres->parentfh = pfh;
     ret = __mnt3_resolve_subdir(mres);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_RESOLVE_SUBDIR_FAIL,
                "Failed to resolve export dir: %s", mres->exp->expname);
         GF_FREE(mres);
@@ -1592,7 +1592,7 @@ mnt3_resolve_export_subdir(rpcsvc_request_t *req, struct mount3_state *ms,
     volume_subdir = mnt3_get_volume_subdir(exp->expname, NULL);
 
     ret = mnt3_resolve_subdir(req, ms, exp, volume_subdir, _gf_true);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_RESOLVE_SUBDIR_FAIL,
                "Failed to resolve export dir: %s", exp->expname);
         goto err;
@@ -1834,7 +1834,7 @@ mnt3_parse_dir_exports(rpcsvc_request_t *req, struct mount3_state *ms,
     }
 
     ret = mnt3_resolve_subdir(req, ms, exp, subdir, send_reply);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_RESOLVE_SUBDIR_FAIL,
                "Failed to resolve export dir: %s", subdir);
         goto err;
@@ -2189,7 +2189,7 @@ mnt3svc_mnt(rpcsvc_request_t *req)
     pvec.iov_base = path;
     pvec.iov_len = MNTPATHLEN;
     ret = xdr_to_mountpath(pvec, req->msg[0]);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, 0, NFS_MSG_ARGS_DECODE_ERROR,
                "Failed to decode args");
         rpcsvc_request_seterr(req, GARBAGE_ARGS);
@@ -2208,7 +2208,7 @@ mnt3svc_mnt(rpcsvc_request_t *req)
     nfs = (struct nfs_state *)ms->nfsx->private;
     gf_msg_debug(GF_MNT, 0, "dirpath: %s", path);
     ret = mnt3_find_export(req, path, &exp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         mntstat = mnt3svc_errno_to_mnterr(-ret);
         goto mnterr;
     } else if (!exp) {
@@ -2256,10 +2256,10 @@ mnt3svc_mnt(rpcsvc_request_t *req)
 
     ret = mnt3svc_mount(req, ms, exp);
 
-    if (ret < 0)
+    if (IS_ERROR(ret))
         mntstat = mnt3svc_errno_to_mnterr(-ret);
 mnterr:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         mnt3svc_mnt_error_reply(req, mntstat);
         ret = 0;
     }
@@ -2347,7 +2347,7 @@ __build_mountlist(struct mount3_state *ms, int *count)
     ret = 0;
 
 free_list:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         xdr_free_mountlist(first);
         first = NULL;
     }
@@ -2457,7 +2457,7 @@ mnt3svc_umount(struct mount3_state *ms, char *dirpath, char *hostname)
          * might still be pointing to the last entry, which may not be
          * the one we're looking for.
          */
-        if (ret == -1) { /* Not found in list. */
+        if (IS_ERROR(ret)) { /* Not found in list. */
             gf_msg_trace(GF_MNT, 0, "Export not found");
             goto out_unlock;
         }
@@ -2507,7 +2507,7 @@ mnt3svc_umnt(rpcsvc_request_t *req)
     pvec.iov_base = dirpath;
     pvec.iov_len = MNTPATHLEN;
     ret = xdr_to_mountpath(pvec, req->msg[0]);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, 0, NFS_MSG_ARGS_DECODE_ERROR,
                "Failed decode args");
         rpcsvc_request_seterr(req, GARBAGE_ARGS);
@@ -2538,7 +2538,7 @@ mnt3svc_umnt(rpcsvc_request_t *req)
     gf_msg_debug(GF_MNT, 0, "dirpath: %s, hostname: %s", dirpath, hostname);
     ret = mnt3svc_umount(ms, dirpath, hostname);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         ret = 0;
         mstat = MNT3ERR_NOENT;
     }
@@ -2744,7 +2744,7 @@ mnt3_xlchildren_to_exports(rpcsvc_t *svc, struct mount3_state *ms)
 
 free_list:
     UNLOCK(&ms->mountlock);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         xdr_free_exports_list(first);
         first = NULL;
     }
@@ -3154,7 +3154,7 @@ mnt3_export_fill_hostspec(struct host_auth_spec *hostspec, const char *hostip)
     token = strtok_r(NULL, "/", &savptr);
     if (token != NULL) {
         prefixlen = strtol(token, &endptr, 10);
-        if ((errno != 0) || (*endptr != '\0') || (prefixlen < 0) ||
+        if ((errno != 0) || (*endptr != '\0') || IS_ERROR(prefixlen) ||
             (prefixlen > IPv4_ADDR_SIZE)) {
             gf_msg(THIS->name, GF_LOG_WARNING, EINVAL, NFS_MSG_INVALID_ENTRY,
                    "Invalid IPv4 subnetwork mask");
@@ -3327,7 +3327,7 @@ mnt3_init_export_ent(struct mount3_state *ms, xlator_t *xl, char *exportpath,
         exp->exptype = MNT3_EXPTYPE_VOLUME;
         ret = snprintf(exp->expname, alloclen, "/%s", xl->name);
     }
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(xl->name, GF_LOG_ERROR, ret, NFS_MSG_SET_EXP_FAIL,
                "Failed to set the export name");
         goto err;
@@ -3406,7 +3406,7 @@ __mnt3_init_volume(struct mount3_state *ms, dict_t *opts, xlator_t *xlator)
         goto no_dvm;
 
     ret = snprintf(searchstr, 1024, "nfs3.%s.volume-id", xlator->name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_SNPRINTF_FAIL,
                "snprintf failed");
         ret = -1;
@@ -3415,7 +3415,7 @@ __mnt3_init_volume(struct mount3_state *ms, dict_t *opts, xlator_t *xlator)
 
     if (dict_get(opts, searchstr)) {
         ret = dict_get_str(opts, searchstr, &optstr);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_DICT_GET_FAILED,
                    "Failed to read "
                    "option: %s",
@@ -3434,7 +3434,7 @@ __mnt3_init_volume(struct mount3_state *ms, dict_t *opts, xlator_t *xlator)
 
     if (optstr) {
         ret = gf_uuid_parse(optstr, volumeid);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_PARSE_VOL_UUID_FAIL,
                    "Failed to parse "
                    "volume UUID");
@@ -3445,7 +3445,7 @@ __mnt3_init_volume(struct mount3_state *ms, dict_t *opts, xlator_t *xlator)
 
 no_dvm:
     ret = snprintf(searchstr, 1024, "nfs3.%s.export-dir", xlator->name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_SNPRINTF_FAIL,
                "snprintf failed");
         ret = -1;
@@ -3454,7 +3454,7 @@ no_dvm:
 
     if (dict_get(opts, searchstr)) {
         ret = dict_get_str(opts, searchstr, &optstr);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_DICT_GET_FAILED,
                    "Failed to read "
                    "option: %s",
@@ -3464,7 +3464,7 @@ no_dvm:
         }
 
         ret = __mnt3_init_volume_direxports(ms, xlator, optstr, volumeid);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_MNT, GF_LOG_ERROR, 0, NFS_MSG_DIR_EXP_SETUP_FAIL,
                    "Dir export "
                    "setup failed for volume: %s",
@@ -3505,7 +3505,7 @@ __mnt3_init_volume_export(struct mount3_state *ms, dict_t *opts)
     }
 
     ret = dict_get_str(opts, "nfs3.export-volumes", &optstr);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_DICT_GET_FAILED,
                "Failed to read option: nfs3.export-volumes");
         ret = -1;
@@ -3513,7 +3513,7 @@ __mnt3_init_volume_export(struct mount3_state *ms, dict_t *opts)
     }
 
     ret = gf_string2boolean(optstr, &boolt);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_STR2BOOL_FAIL,
                "Failed to convert string to boolean");
     }
@@ -3547,7 +3547,7 @@ __mnt3_init_dir_export(struct mount3_state *ms, dict_t *opts)
     }
 
     ret = dict_get_str(opts, "nfs3.export-dirs", &optstr);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_DICT_GET_FAILED,
                "Failed to read option: nfs3.export-dirs");
         ret = -1;
@@ -3555,7 +3555,7 @@ __mnt3_init_dir_export(struct mount3_state *ms, dict_t *opts)
     }
 
     ret = gf_string2boolean(optstr, &boolt);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_STR2BOOL_FAIL,
                "Failed to convert string to boolean");
     }
@@ -3588,7 +3588,7 @@ mnt3_init_options(struct mount3_state *ms, dict_t *options)
         gf_msg_trace(GF_MNT, 0, "Initing options for: %s",
                      volentry->xlator->name);
         ret = __mnt3_init_volume(ms, options, volentry->xlator);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_VOL_INIT_FAIL,
                    "Volume init failed");
             goto err;
@@ -3622,7 +3622,7 @@ mnt3_init_state(xlator_t *nfsx)
     ms->nfsx = nfsx;
     INIT_LIST_HEAD(&ms->exportlist);
     ret = mnt3_init_options(ms, nfsx->options);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_OPT_INIT_FAIL,
                "Options init failed");
         return NULL;
@@ -3812,7 +3812,7 @@ _mnt3_has_file_changed(const char *path, time_t *oldmtime)
     GF_VALIDATE_OR_GOTO(GF_MNT, oldmtime, out);
 
     ret = get_file_mtime(path, &mtime);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     if (mtime != *oldmtime) {
@@ -3946,7 +3946,7 @@ _mnt3_init_auth_params(struct mount3_state *mstate)
     snprintf(exp_file_path, nbytes, "%s", exports_file_path);
 
     ret = mnt3_auth_set_exports_auth(mstate->auth_params, exp_file_path);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_SET_EXP_AUTH_PARAM_FAIL,
                "Failed to set export auth params.");
         goto out;
@@ -3957,7 +3957,7 @@ _mnt3_init_auth_params(struct mount3_state *mstate)
     snprintf(ng_file_path, nbytes, "%s", netgroups_file_path);
 
     ret = mnt3_auth_set_netgroups_auth(mstate->auth_params, ng_file_path);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_SET_EXP_AUTH_PARAM_FAIL,
                "Failed to set netgroup auth params.");
         goto out;
@@ -4039,7 +4039,7 @@ mnt3svc_init(xlator_t *nfsx)
 
     if (nfs->exports_auth) {
         ret = _mnt3_init_auth_params(mstate);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto err;
 
         mstate->authcache = auth_cache_init(nfs->auth_cache_ttl_sec);
@@ -4064,15 +4064,15 @@ mnt3svc_init(xlator_t *nfsx)
     options = dict_new();
 
     ret = gf_asprintf(&portstr, "%d", GF_MOUNTV3_PORT);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 
     ret = dict_set_dynstr(options, "transport.socket.listen-port", portstr);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 
     ret = dict_set_str(options, "transport-type", "socket");
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                "dict_set_str error");
         goto err;
@@ -4080,13 +4080,13 @@ mnt3svc_init(xlator_t *nfsx)
 
     if (nfs->allow_insecure) {
         ret = dict_set_str(options, "rpc-auth-allow-insecure", "on");
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                    "dict_set_str error");
             goto err;
         }
         ret = dict_set_str(options, "rpc-auth.ports.insecure", "on");
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                    "dict_set_str error");
             goto err;
@@ -4094,7 +4094,7 @@ mnt3svc_init(xlator_t *nfsx)
     }
 
     ret = rpcsvc_create_listeners(nfs->rpcsvc, options, nfsx->name);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_LISTENERS_CREATE_FAIL,
                "Unable to create listeners");
         dict_unref(options);
@@ -4164,14 +4164,14 @@ mnt1svc_init(xlator_t *nfsx)
     options = dict_new();
 
     ret = gf_asprintf(&portstr, "%d", GF_MOUNTV1_PORT);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 
     ret = dict_set_dynstr(options, "transport.socket.listen-port", portstr);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
     ret = dict_set_str(options, "transport-type", "socket");
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                "dict_set_str error");
         goto err;
@@ -4179,13 +4179,13 @@ mnt1svc_init(xlator_t *nfsx)
 
     if (nfs->allow_insecure) {
         ret = dict_set_str(options, "rpc-auth-allow-insecure", "on");
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                    "dict_set_str error");
             goto err;
         }
         ret = dict_set_str(options, "rpc-auth.ports.insecure", "on");
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                    "dict_set_str error");
             goto err;
@@ -4194,7 +4194,7 @@ mnt1svc_init(xlator_t *nfsx)
 
 #ifdef IPV6_DEFAULT
     ret = dict_set_str(options, "transport.address-family", "inet6");
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_NFS, GF_LOG_ERROR,
                "dict_set_str error when trying to enable ipv6");
         goto err;
@@ -4202,7 +4202,7 @@ mnt1svc_init(xlator_t *nfsx)
 #endif
 
     ret = rpcsvc_create_listeners(nfs->rpcsvc, options, nfsx->name);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_LISTENERS_CREATE_FAIL,
                "Unable to create listeners");
         dict_unref(options);
@@ -4248,7 +4248,7 @@ mount_reconfigure_state(xlator_t *nfsx, dict_t *options)
     ret = mnt3_init_options(ms, options);
     UNLOCK(&ms->mountlock);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_MNT, GF_LOG_ERROR, ret, NFS_MSG_RECONF_FAIL,
                "Options reconfigure failed");
         return (-1);

--- a/xlators/nfs/server/src/netgroups.c
+++ b/xlators/nfs/server/src/netgroups.c
@@ -736,7 +736,7 @@ _parse_ng_host(char *ng_str, struct netgroup_host **ngh)
     }
 
     ret = parser_set_string(ng_host_parser, ng_str);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     gf_msg_trace(GF_NG, 0, "parsing host string: %s", ng_str);
@@ -813,7 +813,7 @@ _ng_handle_host_part(char *match, struct netgroup_entry *ngp)
 
     /* Parse the host string and get a struct for it */
     ret = _parse_ng_host(match, &ngh);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NG, GF_LOG_CRITICAL, -ret, NFS_MSG_PARSE_FAIL,
                "Critical error : %s", strerror(-ret));
         goto out;
@@ -969,7 +969,7 @@ _parse_ng_line(char *ng_str, struct netgroups_file *file,
     }
 
     ret = parser_set_string(ng_file_parser, ng_str);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     /* This is the first name in the line, and should be the
@@ -992,7 +992,7 @@ _parse_ng_line(char *ng_str, struct netgroups_file *file,
     ngp = _nge_dict_get(file->ng_file_dict, match);
     if (!ngp) {
         ret = _ng_setup_netgroup_entry(match, file, &ngp);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             /* Bubble up error to caller. We don't need to free ngp
              * here because this can only fail if allocating the
              * struct fails.
@@ -1030,7 +1030,7 @@ _parse_ng_line(char *ng_str, struct netgroups_file *file,
             nge = _nge_dict_get(file->ng_file_dict, match);
             if (!nge) {
                 ret = _ng_setup_netgroup_entry(match, file, &nge);
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     /* Bubble up error to caller. We don't
                      * need to free nge here because this
                      * can only fail if allocating the
@@ -1114,7 +1114,7 @@ ng_file_parse(const char *filepath)
     }
 
     ret = _ng_init_parsers();
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto err;
 
     /* Read the file line-by-line and parse it */

--- a/xlators/nfs/server/src/nfs-common.c
+++ b/xlators/nfs/server/src/nfs-common.c
@@ -160,7 +160,7 @@ nfs_loc_fill(loc_t *loc, inode_t *inode, inode_t *parent, char *path)
 
     ret = 0;
 loc_wipe:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs_loc_wipe(loc);
 
     return ret;
@@ -182,7 +182,7 @@ nfs_inode_loc_fill(inode_t *inode, loc_t *loc, int how)
      */
     if (!gf_uuid_is_null(inode->gfid)) {
         ret = inode_path(inode, NULL, &resolvedpath);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_PATH_RESOLVE_FAIL,
                    "path resolution "
                    "failed %s",
@@ -202,7 +202,7 @@ nfs_inode_loc_fill(inode_t *inode, loc_t *loc, int how)
     }
 
     ret = nfs_loc_fill(loc, inode, parent, resolvedpath);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_LOC_FILL_RESOLVE_FAIL,
                "loc fill resolution failed %s", resolvedpath);
         goto err;
@@ -257,7 +257,7 @@ nfs_gfid_loc_fill(inode_table_t *itable, uuid_t gfid, loc_t *loc, int how)
     gf_uuid_copy(loc->gfid, gfid);
 
     ret = nfs_inode_loc_fill(inode, loc, how);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_INODE_LOC_FILL_ERROR,
                "Inode loc filling failed.: %s", strerror(-ret));
         goto err;
@@ -288,7 +288,7 @@ nfs_parent_inode_loc_fill(inode_t *parent, inode_t *entryinode, char *entry,
         return ret;
 
     ret = inode_path(parent, entry, &path);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_PATH_RESOLVE_FAIL,
                "path resolution failed %s", path);
         goto err;
@@ -350,14 +350,14 @@ nfs_entry_loc_fill(xlator_t *this, inode_table_t *itable, uuid_t pargfid,
              * through ret, otherwise, we still need to force a
              * lookup by returning -2.
              */
-            if (pret < 0)
+            if (IS_ERROR(pret))
                 ret = -3;
         }
         goto err;
     }
 
     ret = inode_path(parent, entry, &resolvedpath);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_PATH_RESOLVE_FAIL,
                "path resolution failed %s", resolvedpath);
         ret = -3;
@@ -365,7 +365,7 @@ nfs_entry_loc_fill(xlator_t *this, inode_table_t *itable, uuid_t pargfid,
     }
 
     ret = nfs_loc_fill(loc, entryinode, parent, resolvedpath);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_INODE_LOC_FILL_ERROR,
                "loc_fill failed %s", resolvedpath);
         ret = -3;

--- a/xlators/nfs/server/src/nfs-fops.c
+++ b/xlators/nfs/server/src/nfs-fops.c
@@ -81,7 +81,7 @@ nfs_fix_groups(xlator_t *this, call_stack_t *root)
     gf_msg_trace(this->name, 0, "mapped %u => %s", root->uid, result->pw_name);
 
     ngroups = gf_getgrouplist(result->pw_name, root->gid, &mygroups);
-    if (ngroups == -1) {
+    if (IS_ERROR(ngroups)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, NFS_MSG_MAP_GRP_LIST_FAIL,
                "could not map %s to group list", result->pw_name);
         return;
@@ -265,7 +265,7 @@ err:
 #define nfs_fop_restore_root_ino(locl, fopret, preattr, postattr, prepar,      \
                                  postpar)                                      \
     do {                                                                       \
-        if (fopret == -1)                                                      \
+        if (IS_ERROR(fopret))                                                  \
             break;                                                             \
         if ((locl)->rootinode) {                                               \
             if ((preattr)) {                                                   \
@@ -302,7 +302,7 @@ err:
 #define nfs_fop_newloc_restore_root_ino(locl, fopret, preattr, postattr,       \
                                         prepar, postpar)                       \
     do {                                                                       \
-        if (fopret == -1)                                                      \
+        if (IS_ERROR(fopret))                                                  \
             break;                                                             \
                                                                                \
         if ((locl)->newrootinode) {                                            \
@@ -349,7 +349,7 @@ nfs_gfid_dict(inode_t *inode)
     }
 
     ret = dict_set_gfuuid(dictgfid, "gfid-req", dyngfid, false);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         GF_FREE(dyngfid);
         dict_unref(dictgfid);
         return (NULL);
@@ -439,7 +439,7 @@ nfs_fop_lookup(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *loc,
 
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -484,7 +484,7 @@ nfs_fop_access(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *loc,
                       accessbits, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -529,7 +529,7 @@ nfs_fop_stat(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *loc,
                       NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -575,7 +575,7 @@ nfs_fop_fstat(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, fd_t *fd,
 
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -617,7 +617,7 @@ nfs_fop_opendir(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
     ret = 0;
 
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -658,7 +658,7 @@ nfs_fop_flush(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, fd_t *fd,
                       NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -704,7 +704,7 @@ nfs_fop_readdirp(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, fd_t *dirfd,
 
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -747,7 +747,7 @@ nfs_fop_statfs(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
                       pathloc, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -801,7 +801,7 @@ nfs_fop_create(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
 
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -846,7 +846,7 @@ nfs_fop_setattr(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
                       pathloc, buf, valid, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -897,7 +897,7 @@ nfs_fop_mkdir(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
                       pathloc, mode, 0, nfl->dictgfid);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -948,7 +948,7 @@ nfs_fop_symlink(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, char *target,
                       target, pathloc, 0, nfl->dictgfid);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -992,7 +992,7 @@ nfs_fop_readlink(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
                       pathloc, size, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -1043,7 +1043,7 @@ nfs_fop_mknod(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
                       pathloc, mode, dev, 0, nfl->dictgfid);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -1088,7 +1088,7 @@ nfs_fop_rmdir(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
                       pathloc, 0, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -1133,7 +1133,7 @@ nfs_fop_unlink(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
                       pathloc, 0, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -1184,7 +1184,7 @@ nfs_fop_link(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *oldloc,
                       newloc, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -1239,7 +1239,7 @@ nfs_fop_rename(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *oldloc,
                       oldloc, newloc, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -1281,7 +1281,7 @@ nfs_fop_open(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *loc,
                       flags, fd, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -1350,7 +1350,7 @@ nfs_fop_write(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, fd_t *fd,
                       vector, count, offset, flags, srciobref, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -1394,7 +1394,7 @@ nfs_fop_fsync(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, fd_t *fd,
                       datasync, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -1440,7 +1440,7 @@ nfs_fop_read(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, fd_t *fd,
                       size, offset, 0, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -1492,7 +1492,7 @@ nfs_fop_lk(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, fd_t *fd, int cmd,
                       flock, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -1535,7 +1535,7 @@ nfs_fop_getxattr(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *loc,
                       loc, name, NULL);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -1578,7 +1578,7 @@ nfs_fop_setxattr(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *loc,
                       loc, dict, flags, xdata);
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }
@@ -1623,7 +1623,7 @@ nfs_fop_truncate(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *loc,
 
     ret = 0;
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (frame)
             nfs_stack_destroy(nfl, frame);
     }

--- a/xlators/nfs/server/src/nfs-inodes.c
+++ b/xlators/nfs/server/src/nfs-inodes.c
@@ -60,7 +60,7 @@ nfs_inode_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop_create_cbk_t progcbk = NULL;
     inode_t *linked_inode = NULL;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     linked_inode = inode_link(inode, nfl->parent, nfl->path, buf);
@@ -113,7 +113,7 @@ nfs_inode_create(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
     ret = nfs_fop_create(nfsx, xl, nfu, pathloc, flags, mode, newfd,
                          nfs_inode_create_cbk, nfl);
 wipe_nfl:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs_fop_local_wipe(xl, nfl);
 
 err:
@@ -130,7 +130,7 @@ nfs_inode_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop_mkdir_cbk_t progcbk = NULL;
     inode_t *linked_inode = NULL;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     linked_inode = inode_link(inode, nfl->parent, nfl->path, buf);
@@ -163,7 +163,7 @@ nfs_inode_mkdir(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
     nfl_inodes_init(nfl, pathloc->inode, pathloc->parent, NULL, pathloc->name,
                     NULL);
     ret = nfs_fop_mkdir(nfsx, xl, nfu, pathloc, mode, nfs_inode_mkdir_cbk, nfl);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs_fop_local_wipe(nfsx, nfl);
 
 err:
@@ -177,7 +177,7 @@ nfs_inode_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     struct nfs_fop_local *nfl = NULL;
     fop_open_cbk_t progcbk = NULL;
 
-    if ((op_ret == -1) && (fd))
+    if (IS_ERROR((op_ret)) && (fd))
         fd_unref(fd);
     /* Not needed here since the fd is cached in higher layers and the bind
      * must happen atomically when the fd gets added to the fd LRU.
@@ -214,11 +214,11 @@ nfs_inode_open(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *loc,
     ret = nfs_fop_open(nfsx, xl, nfu, loc, flags, newfd, nfs_inode_open_cbk,
                        nfl);
 
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs_fop_local_wipe(xl, nfl);
 
 fd_err:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         if (newfd)
             fd_unref(newfd);
 
@@ -238,7 +238,7 @@ nfs_inode_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop_rename_cbk_t progcbk = NULL;
 
     nfl = frame->local;
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     inode_rename(this->itable, nfl->parent, nfl->path, nfl->newparent,
@@ -269,7 +269,7 @@ nfs_inode_rename(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *oldloc,
                          nfl);
 
 err:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs_fop_local_wipe(xl, nfl);
 
     return ret;
@@ -285,7 +285,7 @@ nfs_inode_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop_link_cbk_t progcbk = NULL;
     inode_t *linked_inode = NULL;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     nfl = frame->local;
@@ -320,7 +320,7 @@ nfs_inode_link(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *oldloc,
     ret = nfs_fop_link(nfsx, xl, nfu, oldloc, newloc, nfs_inode_link_cbk, nfl);
 
 err:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs_fop_local_wipe(xl, nfl);
 
     return ret;
@@ -336,7 +336,7 @@ nfs_inode_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     nfl = frame->local;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_unlink;
 
     inode_unlink(nfl->inode, nfl->parent, nfl->path);
@@ -366,7 +366,7 @@ nfs_inode_unlink(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
     ret = nfs_fop_unlink(nfsx, xl, nfu, pathloc, nfs_inode_unlink_cbk, nfl);
 
 err:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs_fop_local_wipe(xl, nfl);
 
     return ret;
@@ -382,7 +382,7 @@ nfs_inode_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     nfl = frame->local;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_unlink;
 
     inode_unlink(nfl->inode, nfl->parent, nfl->path);
@@ -414,7 +414,7 @@ nfs_inode_rmdir(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
     ret = nfs_fop_rmdir(nfsx, xl, nfu, pathloc, nfs_inode_rmdir_cbk, nfl);
 
 err:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs_fop_local_wipe(xl, nfl);
     return ret;
 }
@@ -431,7 +431,7 @@ nfs_inode_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     nfl = frame->local;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     linked_inode = inode_link(inode, nfl->parent, nfl->path, buf);
@@ -468,7 +468,7 @@ nfs_inode_mknod(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *pathloc,
                         nfl);
 
 err:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs_fop_local_wipe(xl, nfl);
 
     return ret;
@@ -485,7 +485,7 @@ nfs_inode_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     inode_t *linked_inode = NULL;
 
     nfl = frame->local;
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     linked_inode = inode_link(inode, nfl->parent, nfl->path, buf);
@@ -521,7 +521,7 @@ nfs_inode_symlink(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, char *target,
                           nfl);
 
 err:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs_fop_local_wipe(xl, nfl);
 
     return ret;
@@ -534,7 +534,7 @@ nfs_inode_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     struct nfs_fop_local *nfl = NULL;
     fop_open_cbk_t progcbk = NULL;
 
-    if (op_ret != -1)
+    if (op_ret >= 0)
         fd_bind(fd);
 
     inodes_nfl_to_prog_data(nfl, progcbk, frame);
@@ -569,7 +569,7 @@ nfs_inode_opendir(xlator_t *nfsx, xlator_t *xl, nfs_user_t *nfu, loc_t *loc,
                           nfl);
 
 err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (newfd)
             fd_unref(newfd);
         nfs_fop_local_wipe(xl, nfl);

--- a/xlators/nfs/server/src/nfs-inodes.c
+++ b/xlators/nfs/server/src/nfs-inodes.c
@@ -534,7 +534,7 @@ nfs_inode_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     struct nfs_fop_local *nfl = NULL;
     fop_open_cbk_t progcbk = NULL;
 
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         fd_bind(fd);
 
     inodes_nfl_to_prog_data(nfl, progcbk, frame);

--- a/xlators/nfs/server/src/nfs.c
+++ b/xlators/nfs/server/src/nfs.c
@@ -64,7 +64,7 @@ nfs_init_version(xlator_t *this, nfs_version_initer_t init,
     nfs = (struct nfs_state *)this->private;
 
     ret = nfs_add_initer(&nfs->versions, init, required);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_PROT_INIT_ADD_FAIL,
                "Failed to add protocol initializer");
         goto err;
@@ -100,7 +100,7 @@ nfs_init_version(xlator_t *this, nfs_version_initer_t init,
     gf_msg_debug(GF_NFS, 0, "Starting program: %s", prog->progname);
 
     ret = rpcsvc_program_register(nfs->rpcsvc, prog, _gf_false);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_PGM_INIT_FAIL,
                "Program: %s init failed", prog->progname);
         goto err;
@@ -111,7 +111,7 @@ nfs_init_version(xlator_t *this, nfs_version_initer_t init,
         goto err;
 
     ret = rpcsvc_program_register_portmap(prog, prog->progport);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_PGM_REG_FAIL,
                "Program  %s registration failed", prog->progname);
         goto err;
@@ -327,14 +327,14 @@ nfs_init_versions(struct nfs_state *nfs, xlator_t *this)
         gf_msg_debug(GF_NFS, 0, "Starting program: %s", prog->progname);
 
         ret = rpcsvc_program_register(nfs->rpcsvc, prog, _gf_false);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_PGM_INIT_FAIL,
                    "Program: %s init failed", prog->progname);
             goto err;
         }
         if (nfs->register_portmap) {
             ret = rpcsvc_program_register_portmap(prog, prog->progport);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_PGM_REG_FAIL,
                        "%s program  %s registration failed",
                        version->required ? "Required" : "Optional",
@@ -346,7 +346,7 @@ nfs_init_versions(struct nfs_state *nfs, xlator_t *this)
             }
 #ifdef IPV6_DEFAULT
             ret = rpcsvc_program_register_rpcbind6(prog, prog->progport);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_PGM_REG_FAIL,
                        "Program (ipv6) %s registration failed", prog->progname);
                 goto err;
@@ -367,21 +367,21 @@ nfs_add_all_initiators(struct nfs_state *nfs)
 
     /* Add the initializers for all versions. */
     ret = nfs_add_initer(&nfs->versions, mnt3svc_init, _gf_true);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_PROT_INIT_ADD_FAIL,
                "Failed to add MOUNT3 protocol initializer");
         goto ret;
     }
 
     ret = nfs_add_initer(&nfs->versions, mnt1svc_init, _gf_true);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_PROT_INIT_ADD_FAIL,
                "Failed to add MOUNT1 protocol initializer");
         goto ret;
     }
 
     ret = nfs_add_initer(&nfs->versions, nfs3svc_init, _gf_true);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_PROT_INIT_ADD_FAIL,
                "Failed to add NFS3 protocol initializer");
         goto ret;
@@ -389,7 +389,7 @@ nfs_add_all_initiators(struct nfs_state *nfs)
 
     if (nfs->enable_nlm == _gf_true) {
         ret = nfs_add_initer(&nfs->versions, nlm4svc_init, _gf_false);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_PROT_INIT_ADD_FAIL,
                    "Failed to add protocol initializer");
             goto ret;
@@ -398,7 +398,7 @@ nfs_add_all_initiators(struct nfs_state *nfs)
 
     if (nfs->enable_acl == _gf_true) {
         ret = nfs_add_initer(&nfs->versions, acl3svc_init, _gf_false);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_PROT_INIT_ADD_FAIL,
                    "Failed to add ACL protocol initializer");
             goto ret;
@@ -473,7 +473,7 @@ nfs_start_subvol_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                             struct iatt *buf, dict_t *xattr,
                             struct iatt *postparent)
 {
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(GF_NFS, GF_LOG_CRITICAL, op_errno, NFS_MSG_LOOKUP_ROOT_FAIL,
                "Failed to lookup root: %s", strerror(op_errno));
         goto err;
@@ -506,7 +506,7 @@ nfs_startup_subvolume(xlator_t *nfsx, xlator_t *xl)
     }
 
     ret = nfs_root_loc_fill(xl->itable, &rootloc);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_CRITICAL, 0, NFS_MSG_ROOT_LOC_INIT_FAIL,
                "Failed to init root loc");
         goto err;
@@ -515,7 +515,7 @@ nfs_startup_subvolume(xlator_t *nfsx, xlator_t *xl)
     nfs_user_root_create(&nfu);
     ret = nfs_fop_lookup(nfsx, xl, &nfu, &rootloc, nfs_start_subvol_lookup_cbk,
                          (void *)nfsx->private);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_CRITICAL, -ret, NFS_MSG_LOOKUP_ROOT_FAIL,
                "Failed to lookup root: %s", strerror(-ret));
         goto err;
@@ -542,7 +542,7 @@ nfs_startup_subvolumes(xlator_t *nfsx)
     while (cl) {
         gf_msg_debug(GF_NFS, 0, "Starting subvolume: %s", cl->xlator->name);
         ret = nfs_startup_subvolume(nfsx, cl->xlator);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_CRITICAL, 0, NFS_MSG_STARTUP_FAIL,
                    "Failed to start-up xlator: %s", cl->xlator->name);
             goto err;
@@ -593,7 +593,7 @@ nfs_init_subvolumes(struct nfs_state *nfs, xlator_list_t *cl)
     while (cl) {
         gf_msg_debug(GF_NFS, 0, "Initing subvolume: %s", cl->xlator->name);
         ret = nfs_init_subvolume(nfs, cl->xlator);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_CRITICAL, 0, NFS_MSG_XLATOR_INIT_FAIL,
                    "Failed to init "
                    "xlator: %s",
@@ -751,14 +751,14 @@ nfs_init_state(xlator_t *this)
     nfs->memfactor = GF_NFS_DEFAULT_MEMFACTOR;
     if (dict_get(this->options, "nfs.mem-factor")) {
         ret = dict_get_str(this->options, "nfs.mem-factor", &optstr);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_DICT_GET_FAILED,
                    "Failed to parse dict");
             goto free_rpcsvc;
         }
 
         ret = gf_string2uint(optstr, &nfs->memfactor);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_PARSE_FAIL,
                    "Failed to parse uint string");
             goto free_rpcsvc;
@@ -777,14 +777,14 @@ nfs_init_state(xlator_t *this)
     nfs->dynamicvolumes = GF_NFS_DVM_OFF;
     if (dict_get(this->options, "nfs.dynamic-volumes")) {
         ret = dict_get_str(this->options, "nfs.dynamic-volumes", &optstr);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_DICT_GET_FAILED,
                    "Failed to parse dict");
             goto free_foppool;
         }
 
         ret = gf_string2boolean(optstr, &boolt);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_PARSE_FAIL,
                    "Failed to parse bool string");
             goto free_foppool;
@@ -813,14 +813,14 @@ nfs_init_state(xlator_t *this)
     nfs->enable_ino32 = 0;
     if (dict_get(this->options, "nfs.enable-ino32")) {
         ret = dict_get_str(this->options, "nfs.enable-ino32", &optstr);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_PARSE_FAIL,
                    "Failed to parse dict");
             goto free_foppool;
         }
 
         ret = gf_string2boolean(optstr, &boolt);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_PARSE_FAIL,
                    "Failed to parse bool string");
             goto free_foppool;
@@ -832,14 +832,14 @@ nfs_init_state(xlator_t *this)
 
     if (dict_get(this->options, "nfs.port")) {
         ret = dict_get_str(this->options, "nfs.port", &optstr);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_PARSE_FAIL,
                    "Failed to parse dict");
             goto free_foppool;
         }
 
         ret = gf_string2uint(optstr, &nfs->override_portnum);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_PARSE_FAIL,
                    "Failed to parse uint string");
             goto free_foppool;
@@ -849,7 +849,7 @@ nfs_init_state(xlator_t *this)
     if (dict_get(this->options, "transport.socket.bind-address")) {
         ret = dict_get_str(this->options, "transport.socket.bind-address",
                            &optstr);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_log(GF_NFS, GF_LOG_ERROR,
                    "Failed to parse "
                    "transport.socket.bind-address string");
@@ -868,14 +868,14 @@ nfs_init_state(xlator_t *this)
             ret = gf_asprintf(&optstr, "%d", nfs->override_portnum);
         else
             ret = gf_asprintf(&optstr, "%d", GF_NFS3_PORT);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, ENOMEM, NFS_MSG_NO_MEMORY,
                    "failed mem-allocation");
             goto free_foppool;
         }
         ret = dict_set_dynstr(this->options, "transport.socket.listen-port",
                               optstr);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_DICT_SET_FAILED,
                    "dict_set_dynstr error");
             goto free_foppool;
@@ -884,7 +884,7 @@ nfs_init_state(xlator_t *this)
 
 #ifdef IPV6_DEFAULT
     ret = dict_set_str(this->options, "transport.address-family", "inet6");
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_NFS, GF_LOG_ERROR, "dict_set_str error");
         goto free_foppool;
     }
@@ -894,7 +894,7 @@ nfs_init_state(xlator_t *this)
      * gluster nfs, so we can set default value as socket
      */
     ret = dict_set_str(this->options, "transport-type", "socket");
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_DICT_SET_FAILED,
                "dict_set_str error");
         goto free_foppool;
@@ -903,14 +903,14 @@ nfs_init_state(xlator_t *this)
     nfs->mount_udp = 0;
     if (dict_get(this->options, "nfs.mount-udp")) {
         ret = dict_get_str(this->options, "nfs.mount-udp", &optstr);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_PARSE_FAIL,
                    "Failed to parse dict");
             goto free_foppool;
         }
 
         ret = gf_string2boolean(optstr, &boolt);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_PARSE_FAIL,
                    "Failed to parse bool "
                    "string");
@@ -924,14 +924,14 @@ nfs_init_state(xlator_t *this)
     nfs->exports_auth = GF_NFS_DEFAULT_EXPORT_AUTH;
     if (dict_get(this->options, "nfs.exports-auth-enable")) {
         ret = dict_get_str(this->options, "nfs.exports-auth-enable", &optstr);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_PARSE_FAIL,
                    "Failed to parse dict");
             goto free_foppool;
         }
 
         ret = gf_string2boolean(optstr, &boolt);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_PARSE_FAIL,
                    "Failed to parse bool string");
             goto free_foppool;
@@ -945,14 +945,14 @@ nfs_init_state(xlator_t *this)
     if (dict_get(this->options, "nfs.auth-refresh-interval-sec")) {
         ret = dict_get_str(this->options, "nfs.auth-refresh-interval-sec",
                            &optstr);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_PARSE_FAIL,
                    "Failed to parse dict");
             goto free_foppool;
         }
 
         ret = gf_string2uint(optstr, &nfs->auth_refresh_time_secs);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_PARSE_FAIL,
                    "Failed to parse uint string");
             goto free_foppool;
@@ -962,14 +962,14 @@ nfs_init_state(xlator_t *this)
     nfs->auth_cache_ttl_sec = GF_NFS_DEFAULT_AUTH_CACHE_TTL_SEC;
     if (dict_get(this->options, "nfs.auth-cache-ttl-sec")) {
         ret = dict_get_str(this->options, "nfs.auth-cache-ttl-sec", &optstr);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_PARSE_FAIL,
                    "Failed to parse dict");
             goto free_foppool;
         }
 
         ret = gf_string2uint(optstr, &nfs->auth_cache_ttl_sec);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_PARSE_FAIL,
                    "Failed to parse uint string");
             goto free_foppool;
@@ -983,7 +983,7 @@ nfs_init_state(xlator_t *this)
     nfs->rmtab = gf_strdup(NFS_DATADIR "/rmtab");
     if (dict_get(this->options, "nfs.mount-rmtab")) {
         ret = dict_get_str(this->options, "nfs.mount-rmtab", &nfs->rmtab);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_PARSE_FAIL,
                    "Failed to parse dict");
             goto free_foppool;
@@ -1002,14 +1002,14 @@ nfs_init_state(xlator_t *this)
     nfs->allow_insecure = 1;
     if (dict_get(this->options, "rpc-auth.ports.insecure")) {
         ret = dict_get_str(this->options, "rpc-auth.ports.insecure", &optstr);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_PARSE_FAIL,
                    "Failed to parse dict");
             goto free_foppool;
         }
 
         ret = gf_string2boolean(optstr, &boolt);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_PARSE_FAIL,
                    "Failed to parse bool "
                    "string");
@@ -1022,14 +1022,14 @@ nfs_init_state(xlator_t *this)
 
     if (dict_get(this->options, "rpc-auth-allow-insecure")) {
         ret = dict_get_str(this->options, "rpc-auth-allow-insecure", &optstr);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, -ret, NFS_MSG_PARSE_FAIL,
                    "Failed to parse dict");
             goto free_foppool;
         }
 
         ret = gf_string2boolean(optstr, &boolt);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, errno, NFS_MSG_PARSE_FAIL,
                    "Failed to parse bool string");
             goto free_foppool;
@@ -1042,13 +1042,13 @@ nfs_init_state(xlator_t *this)
     if (nfs->allow_insecure) {
         /* blindly set both the options */
         ret = dict_set_str(this->options, "rpc-auth-allow-insecure", "on");
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_DICT_SET_FAILED,
                    "dict_set_str error");
             goto free_foppool;
         }
         ret = dict_set_str(this->options, "rpc-auth.ports.insecure", "on");
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_DICT_SET_FAILED,
                    "dict_set_str error");
             goto free_foppool;
@@ -1067,7 +1067,8 @@ nfs_init_state(xlator_t *this)
     GF_OPTION_INIT(OPT_SERVER_GID_CACHE_TIMEOUT, nfs->server_aux_gids_max_age,
                    uint32, free_foppool);
 
-    if (gid_cache_init(&nfs->gid_cache, nfs->server_aux_gids_max_age) < 0) {
+    if (IS_ERROR(
+            gid_cache_init(&nfs->gid_cache, nfs->server_aux_gids_max_age))) {
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_INIT_GRP_CACHE_FAIL,
                "Failed to initialize group cache.");
         goto free_foppool;
@@ -1105,7 +1106,7 @@ nfs_init_state(xlator_t *this)
 
     ret = rpcsvc_set_outstanding_rpc_limit(
         nfs->rpcsvc, this->options, RPCSVC_DEF_NFS_OUTSTANDING_RPC_LIMIT);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_RPC_CONFIG_FAIL,
                "Failed to configure outstanding-rpc-limit");
         goto free_foppool;
@@ -1124,13 +1125,13 @@ nfs_init_state(xlator_t *this)
     ret = 0;
 
 free_foppool:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         mem_pool_destroy(nfs->foppool);
 
 free_rpcsvc:
     /*
      * rpcsvc_deinit */
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         GF_FREE(nfs);
         nfs = NULL;
     }
@@ -1208,7 +1209,7 @@ nfs_reconfigure_state(xlator_t *this, dict_t *options)
     rpc_statd = GF_RPC_STATD_PROG;
     if (dict_get(options, OPT_SERVER_RPC_STATD_PIDFILE)) {
         ret = dict_get_str(options, "nfs.rpc-statd", &rpc_statd);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_READ_FAIL,
                    "Failed to read reconfigured option: "
                    "nfs.rpc-statd");
@@ -1226,7 +1227,7 @@ nfs_reconfigure_state(xlator_t *this, dict_t *options)
     rmtab = NFS_DATADIR "/rmtab";
     if (dict_get(options, "nfs.mount-rmtab")) {
         ret = dict_get_str(options, "nfs.mount-rmtab", &rmtab);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_READ_FAIL,
                    "Failed to read reconfigured option:"
                    " nfs.mount-rmtab");
@@ -1290,7 +1291,7 @@ nfs_reconfigure_state(xlator_t *this, dict_t *options)
     optbool = _gf_false;
     if (dict_get(options, "nfs.enable-ino32")) {
         ret = dict_get_str_boolean(options, "nfs.enable-ino32", _gf_false);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_READ_FAIL,
                    "Failed to read reconfigured option: "
                    "nfs.enable-ino32");
@@ -1306,7 +1307,7 @@ nfs_reconfigure_state(xlator_t *this, dict_t *options)
 
     /* nfs.nlm is enabled by default */
     ret = dict_get_str_boolean(options, "nfs.nlm", _gf_true);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         optbool = _gf_true;
     } else {
         optbool = ret;
@@ -1322,7 +1323,7 @@ nfs_reconfigure_state(xlator_t *this, dict_t *options)
 
     /* nfs.acl is enabled by default */
     ret = dict_get_str_boolean(options, "nfs.acl", _gf_true);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         optbool = _gf_true;
     } else {
         optbool = ret;
@@ -1395,7 +1396,7 @@ reconfigure(xlator_t *this, dict_t *options)
     /* Reconfigure rpc.outstanding-rpc-limit */
     ret = rpcsvc_set_outstanding_rpc_limit(
         nfs->rpcsvc, options, RPCSVC_DEF_NFS_OUTSTANDING_RPC_LIMIT);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS, GF_LOG_ERROR, 0, NFS_MSG_RECONFIG_FAIL,
                "Failed to reconfigure outstanding-rpc-limit");
         return (-1);

--- a/xlators/nfs/server/src/nfs3-helpers.c
+++ b/xlators/nfs/server/src/nfs3-helpers.c
@@ -253,7 +253,7 @@ nfs3_errno_to_nfsstat3(int errnum)
 nfsstat3
 nfs3_cbk_errno_status(int32_t op_ret, int32_t op_errno)
 {
-    if ((op_ret == -1) && (op_errno == 0)) {
+    if (IS_ERROR((op_ret)) && (op_errno == 0)) {
         return NFS3ERR_SERVERFAULT;
     }
 
@@ -1706,7 +1706,7 @@ nfs3_log_rw_call(uint32_t xid, char *op, struct nfs3_fh *fh, offset3 offt,
     if (THIS->ctx->log.loglevel < GF_LOG_DEBUG)
         return;
     nfs3_fh_to_str(fh, fhstr, sizeof(fhstr));
-    if (stablewrite == -1)
+    if (IS_ERROR(stablewrite))
         gf_msg_debug(GF_NFS3, 0,
                      "XID: %x, %s: args: %s, offset:"
                      " %" PRIu64 ",  count: %" PRIu32,
@@ -3508,7 +3508,7 @@ nfs3_fh_resolve_inode_done(nfs3_call_state_t *cs, inode_t *inode)
 
     gf_msg_trace(GF_NFS3, 0, "FH inode resolved");
     ret = nfs_inode_loc_fill(inode, &cs->resolvedloc, NFS_RESOLVE_EXIST);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS3, GF_LOG_ERROR, -ret, NFS_MSG_INODE_LOC_FILL_ERROR,
                "inode loc fill failed");
         goto err;
@@ -3534,7 +3534,7 @@ nfs3_fh_resolve_entry_lookup_cbk(call_frame_t *frame, void *cookie,
     cs->resolve_ret = op_ret;
     cs->resolve_errno = op_errno;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ENOENT) {
             gf_msg_trace(GF_NFS3, 0, "Lookup failed: %s: %s",
                          cs->resolvedloc.path, strerror(op_errno));
@@ -3582,7 +3582,7 @@ nfs3_fh_resolve_inode_lookup_cbk(call_frame_t *frame, void *cookie,
     cs->resolve_ret = op_ret;
     cs->resolve_errno = op_errno;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ENOENT) {
             gf_msg_trace(GF_NFS3, 0, "Lookup failed: %s: %s",
                          cs->resolvedloc.path, strerror(op_errno));
@@ -3639,7 +3639,7 @@ nfs3_fh_resolve_inode_hard(nfs3_call_state_t *cs)
     nfs_loc_wipe(&cs->resolvedloc);
     ret = nfs_gfid_loc_fill(cs->vol->itable, cs->resolvefh.gfid,
                             &cs->resolvedloc, NFS_RESOLVE_CREATE);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS3, GF_LOG_ERROR, -ret, NFS_MSG_INODE_LOC_FILL_ERROR,
                "Failed to fill loc using gfid: "
                "%s",
@@ -3700,7 +3700,7 @@ nfs3_fh_resolve_entry_hard(nfs3_call_state_t *cs)
                        nfs3_fh_resolve_entry_lookup_cbk, cs);
         }
         ret = 0;
-    } else if (ret == -1) {
+    } else if (IS_ERROR(ret)) {
         gf_msg_trace(GF_NFS3, 0, "Entry needs parent lookup: %s",
                      cs->resolvedloc.path);
         ret = nfs3_fh_resolve_inode_hard(cs);
@@ -3757,7 +3757,7 @@ nfs3_fh_resolve_resume(nfs3_call_state_t *cs)
     if (!cs)
         return ret;
 
-    if (cs->resolve_ret < 0)
+    if (IS_ERROR(cs->resolve_ret))
         goto err_resume_call;
 
     if (!cs->resolventry)
@@ -3766,7 +3766,7 @@ nfs3_fh_resolve_resume(nfs3_call_state_t *cs)
         ret = nfs3_fh_resolve_entry(cs);
 
 err_resume_call:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         cs->resolve_ret = -1;
         cs->resolve_errno = EFAULT;
         nfs3_call_resume(cs);
@@ -3789,7 +3789,7 @@ nfs3_fh_resolve_root_lookup_cbk(call_frame_t *frame, void *cookie,
     cs->resolve_ret = op_ret;
     cs->resolve_errno = op_errno;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(GF_NFS3, GF_LOG_ERROR, op_errno, NFS_MSG_LOOKUP_ROOT_FAIL,
                "Root lookup failed: %s", strerror(op_errno));
         goto err;
@@ -3821,7 +3821,7 @@ nfs3_fh_resolve_root(nfs3_call_state_t *cs)
     nfs_user_root_create(&nfu);
     gf_msg_trace(GF_NFS3, 0, "Root needs lookup");
     ret = nfs_root_loc_fill(cs->vol->itable, &cs->resolvedloc);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NFS3, GF_LOG_ERROR, -ret, NFS_MSG_LOOKUP_ROOT_FAIL,
                "Failed to lookup root from itable: %s", strerror(-ret));
         goto out;

--- a/xlators/nfs/server/src/nfs3.c
+++ b/xlators/nfs/server/src/nfs3.c
@@ -4252,7 +4252,7 @@ nfs3svc_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 err:
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         goto ret;
 
     if (cs->maxcount == 0) {

--- a/xlators/nfs/server/src/nlm4.c
+++ b/xlators/nfs/server/src/nlm4.c
@@ -137,7 +137,7 @@ nfs3_fh_to_xlator(struct nfs3_state *nfs3, struct nfs3_fh *fh);
         xlator_t *xlatorp = NULL;                                              \
         char buf[256], gfid[GF_UUID_BUF_SIZE];                                 \
         rpc_transport_t *trans = NULL;                                         \
-        if ((cst)->resolve_ret < 0) {                                          \
+        if (IS_ERROR((cst)->resolve_ret)) {                                    \
             trans = rpcsvc_request_transport(cst->req);                        \
             xlatorp = nfs3_fh_to_xlator(cst->nfs3state, &cst->resolvefh);      \
             gf_uuid_unparse(cst->resolvefh.gfid, gfid);                        \
@@ -290,7 +290,7 @@ nlm_monitor(char *caller_name)
     }
     UNLOCK(&nlm_client_list_lk);
 
-    if (monitor == -1)
+    if (IS_ERROR(monitor))
         gf_msg(GF_NLM, GF_LOG_ERROR, 0, NFS_MSG_CALLER_NOT_FOUND,
                "%s was not found in the nlmclnt list", caller_name);
 
@@ -480,7 +480,7 @@ nlm4svc_submit_reply(rpcsvc_request_t *req, void *arg, nlm4_serializer sfunc)
      * to XDR format which will be written into the buffer in outmsg.
      */
     msglen = sfunc(outmsg, arg);
-    if (msglen < 0) {
+    if (IS_ERROR(msglen)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_ENCODE_MSG_FAIL,
                "Failed to encode message");
         goto ret;
@@ -503,7 +503,7 @@ nlm4svc_submit_reply(rpcsvc_request_t *req, void *arg, nlm4_serializer sfunc)
 
     /* Then, submit the message for transmission. */
     ret = rpcsvc_submit_message(req, &outmsg, 1, NULL, 0, iobref);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_REP_SUBMIT_FAIL,
                "Reply submission failed");
         goto ret;
@@ -786,7 +786,7 @@ nlm4svc_test_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     nfs3_call_state_t *cs = NULL;
 
     cs = frame->local;
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         stat = nlm4_errno_to_nlm4stat(op_errno);
         goto err;
     } else if (flock->l_type == F_UNLCK)
@@ -846,7 +846,7 @@ nlm4_test_resume(void *carg)
     ret = nlm4_test_fd_resume(cs);
 
 nlm4err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, -ret, NFS_MSG_OPEN_FAIL,
                "unable to open_and_resume");
         stat = nlm4_errno_to_nlm4stat(-ret);
@@ -906,7 +906,7 @@ nlm4svc_test(rpcsvc_request_t *req)
     ret = nfs3_fh_resolve_and_resume(cs, &fh, NULL, nlm4_test_resume);
 
 nlm4err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, -ret, NFS_MSG_RESOLVE_ERROR,
                "unable to resolve and resume");
         nlm4_test_reply(cs, stat, NULL);
@@ -915,7 +915,7 @@ nlm4err:
     }
 
 rpcerr:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs3_call_state_wipe(cs);
 
     return ret;
@@ -1055,25 +1055,25 @@ nlm4_establish_callback(nfs3_call_state_t *cs, call_frame_t *cbk_frame)
 
     options = dict_new();
     ret = dict_set_str(options, "transport-type", "socket");
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                "dict_set_str error");
         goto err;
     }
 
     ret = dict_set_dynstr(options, "remote-host", gf_strdup(peerip));
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                "dict_set_str error");
         goto err;
     }
 
     ret = gf_asprintf(&portstr, "%d", port);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 
     ret = dict_set_dynstr(options, "remote-port", portstr);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                "dict_set_dynstr error");
         goto err;
@@ -1082,11 +1082,11 @@ nlm4_establish_callback(nfs3_call_state_t *cs, call_frame_t *cbk_frame)
     /* needed in case virtual IP is used */
     ret = dict_set_dynstr(options, "transport.socket.source-addr",
                           gf_strdup(myip));
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 
     ret = dict_set_str(options, "auth-null", "on");
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                "dict_set_dynstr error");
         goto err;
@@ -1110,7 +1110,7 @@ nlm4_establish_callback(nfs3_call_state_t *cs, call_frame_t *cbk_frame)
     }
 
     ret = rpc_clnt_register_notify(rpc_clnt, nlm_rpcclnt_notify, ncf);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_RPC_CLNT_ERROR,
                "rpc_clnt_register_connect error");
         goto err;
@@ -1119,13 +1119,13 @@ nlm4_establish_callback(nfs3_call_state_t *cs, call_frame_t *cbk_frame)
     /* After this connect succeeds, granted msg is sent in notify */
     ret = rpc_transport_connect(rpc_clnt->conn.trans, port);
 
-    if (ret == -1 && EINPROGRESS == errno)
+    if (IS_ERROR(ret) && EINPROGRESS == errno)
         ret = 0;
 
 err:
     if (options)
         dict_unref(options);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         if (rpc_clnt)
             rpc_clnt_unref(rpc_clnt);
         if (ncf)
@@ -1208,7 +1208,7 @@ nlm4svc_send_granted(struct nlm4_notify_args *ncf)
                           nlm4svc_send_granted_cbk, &outmsg, 1, NULL, 0, iobref,
                           ncf->frame, NULL, 0, NULL, 0, NULL);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, -ret, NFS_MSG_RPC_CLNT_ERROR,
                "rpc_clnt_submit error");
         goto ret;
@@ -1398,7 +1398,7 @@ nlm4svc_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     caller_name = cs->args.nlm4_lockargs.alock.caller_name;
     transit_cnt = nlm_dec_transit_count(cs->fd, caller_name);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (transit_cnt == 0)
             nlm_search_and_delete(cs->fd, &cs->args.nlm4_lockargs.alock);
         stat = nlm4_errno_to_nlm4stat(op_errno);
@@ -1465,7 +1465,7 @@ nlm4_lock_fd_resume(void *carg)
                      nlm4svc_lock_cbk, cs);
 
 nlm4err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         stat = nlm4_errno_to_nlm4stat(-ret);
         gf_msg(GF_NLM, GF_LOG_ERROR, stat, NFS_MSG_LOCK_FAIL,
                "unable to call lk()");
@@ -1493,7 +1493,7 @@ nlm4_lock_resume(void *carg)
     ret = nlm4_file_open_and_resume(cs, nlm4_lock_fd_resume);
 
 nlm4err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, -ret, NFS_MSG_OPEN_FAIL,
                "unable to open and resume");
         stat = nlm4_errno_to_nlm4stat(-ret);
@@ -1558,7 +1558,7 @@ nlm4svc_lock_common(rpcsvc_request_t *req, int mon)
     ret = nfs3_fh_resolve_and_resume(cs, &fh, NULL, nlm4_lock_resume);
 
 nlm4err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, -ret, NFS_MSG_RESOLVE_ERROR,
                "unable to resolve and resume");
         nlm4_generic_reply(cs->req, cs->args.nlm4_lockargs.cookie, stat);
@@ -1567,7 +1567,7 @@ nlm4err:
     }
 
 rpcerr:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         nfs3_call_state_wipe(cs);
     }
 
@@ -1595,7 +1595,7 @@ nlm4svc_cancel_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     nfs3_call_state_t *cs = NULL;
 
     cs = frame->local;
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         stat = nlm4_errno_to_nlm4stat(op_errno);
         goto err;
     } else {
@@ -1668,7 +1668,7 @@ nlm4_cancel_resume(void *carg)
     ret = nlm4_cancel_fd_resume(cs);
 
 nlm4err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_WARNING, -ret, NFS_MSG_LOCK_FAIL,
                "unable to unlock_fd_resume()");
         stat = nlm4_errno_to_nlm4stat(-ret);
@@ -1730,7 +1730,7 @@ nlm4svc_cancel(rpcsvc_request_t *req)
     ret = nfs3_fh_resolve_and_resume(cs, &fh, NULL, nlm4_cancel_resume);
 
 nlm4err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, -ret, NFS_MSG_RESOLVE_ERROR,
                "unable to resolve and resume");
         nlm4_generic_reply(cs->req, cs->args.nlm4_cancargs.cookie, stat);
@@ -1739,7 +1739,7 @@ nlm4err:
     }
 
 rpcerr:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         nfs3_call_state_wipe(cs);
     }
     return ret;
@@ -1754,7 +1754,7 @@ nlm4svc_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     nfs3_call_state_t *cs = NULL;
 
     cs = GF_REF_GET((nfs3_call_state_t *)frame->local);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         stat = nlm4_errno_to_nlm4stat(op_errno);
         goto err;
     } else {
@@ -1830,7 +1830,7 @@ nlm4_unlock_resume(void *carg)
     ret = nlm4_unlock_fd_resume(cs);
 
 nlm4err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_WARNING, -ret, NFS_MSG_LOCK_FAIL,
                "unable to unlock_fd_resume");
         stat = nlm4_errno_to_nlm4stat(-ret);
@@ -1894,7 +1894,7 @@ nlm4svc_unlock(rpcsvc_request_t *req)
     ret = nfs3_fh_resolve_and_resume(cs, &fh, NULL, nlm4_unlock_resume);
 
 nlm4err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, -ret, NFS_MSG_RESOLVE_ERROR,
                "unable to resolve and resume");
         nlm4_generic_reply(req, cs->args.nlm4_unlockargs.cookie, stat);
@@ -1903,7 +1903,7 @@ nlm4err:
     }
 
 rpcerr:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         nfs3_call_state_wipe(cs);
     }
     return ret;
@@ -1957,7 +1957,7 @@ nlm4_add_share_to_inode(nlm_share_t *share)
     inode = share->inode;
     ret = inode_ctx_get(inode, this, &ctx);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         ictx = GF_CALLOC(1, sizeof(struct nfs_inode_ctx), gf_nfs_mt_inode_ctx);
         if (!ictx) {
             gf_msg(this->name, GF_LOG_ERROR, ENOMEM, NFS_MSG_NO_MEMORY,
@@ -2172,7 +2172,7 @@ nlm4svc_share(rpcsvc_request_t *req)
     ret = nfs3_fh_resolve_and_resume(cs, &fh, NULL, nlm4_share_resume);
 
 nlm4err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, -ret, NFS_MSG_SHARE_CALL_FAIL,
                "SHARE call failed");
         nlm4_share_reply(cs, stat);
@@ -2181,7 +2181,7 @@ nlm4err:
     }
 
 rpcerr:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs3_call_state_wipe(cs);
 
     return ret;
@@ -2335,7 +2335,7 @@ nlm4svc_unshare(rpcsvc_request_t *req)
     ret = nfs3_fh_resolve_and_resume(cs, &fh, NULL, nlm4_unshare_resume);
 
 nlm4err:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, -ret, NFS_MSG_UNSHARE_CALL_FAIL,
                "UNSHARE call failed");
         nlm4_share_reply(cs, stat);
@@ -2344,7 +2344,7 @@ nlm4err:
     }
 
 rpcerr:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         nfs3_call_state_wipe(cs);
 
     return ret;
@@ -2468,7 +2468,7 @@ nlm_handle_connect(struct rpc_clnt *rpc_clnt, struct nlm4_notify_args *ncf)
             caller_name = alock->caller_name;
 
             ret = nlm_set_rpc_clnt(rpc_clnt, caller_name);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 gf_msg(GF_NLM, GF_LOG_ERROR, 0, NFS_MSG_RPC_CLNT_ERROR,
                        "Failed to set "
                        "rpc clnt");
@@ -2594,14 +2594,14 @@ nlm4svc_init(xlator_t *nfsx)
     options = dict_new();
 
     ret = gf_asprintf(&portstr, "%d", GF_NLM4_PORT);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
 
     ret = dict_set_dynstr(options, "transport.socket.listen-port", portstr);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto err;
     ret = dict_set_str(options, "transport-type", "socket");
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                "dict_set_str error");
         goto err;
@@ -2609,13 +2609,13 @@ nlm4svc_init(xlator_t *nfsx)
 
     if (nfs->allow_insecure) {
         ret = dict_set_str(options, "rpc-auth-allow-insecure", "on");
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                    "dict_set_str error");
             goto err;
         }
         ret = dict_set_str(options, "rpc-auth.ports.insecure", "on");
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                    "dict_set_str error");
             goto err;
@@ -2623,14 +2623,14 @@ nlm4svc_init(xlator_t *nfsx)
     }
 
     ret = dict_set_str(options, "transport.address-family", "inet");
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_DICT_SET_FAILED,
                "dict_set_str error");
         goto err;
     }
 
     ret = rpcsvc_create_listeners(nfs->rpcsvc, options, "NLM");
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_LISTENERS_CREATE_FAIL,
                "Unable to create listeners");
         dict_unref(options);
@@ -2654,7 +2654,7 @@ nlm4svc_init(xlator_t *nfsx)
        out. Until then NLM support is non-existent on OSX.
     */
     ret = sys_unlink(GF_SM_NOTIFY_PIDFILE);
-    if (ret == -1 && errno != ENOENT) {
+    if (IS_ERROR(ret) && errno != ENOENT) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_UNLINK_ERROR,
                "unable to unlink %s: %d", GF_SM_NOTIFY_PIDFILE, errno);
         goto err;
@@ -2691,14 +2691,14 @@ nlm4svc_init(xlator_t *nfsx)
     }
 
     ret = sys_unlink(GF_RPC_STATD_PIDFILE);
-    if (ret == -1 && errno != ENOENT) {
+    if (IS_ERROR(ret) && errno != ENOENT) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_UNLINK_ERROR,
                "unable to unlink %s", pid_file);
         goto err;
     }
 
     ret = runcmd(nfs->rpc_statd, NULL);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(GF_NLM, GF_LOG_ERROR, errno, NFS_MSG_START_ERROR,
                "unable to start %s", nfs->rpc_statd);
         goto err;

--- a/xlators/performance/io-cache/src/io-cache.c
+++ b/xlators/performance/io-cache/src/io-cache.c
@@ -170,7 +170,7 @@ __ioc_inode_flush(ioc_inode_t *ioc_inode)
     {
         ret = __ioc_page_destroy(curr);
 
-        if (ret >= 0)
+        if (IS_SUCCESS(ret))
             destroy_size += ret;
     }
 
@@ -420,7 +420,7 @@ ioc_cache_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local_stbuf = stbuf;
 
     if (IS_ERROR((op_ret)) ||
-        ((op_ret >= 0) && !ioc_cache_still_valid(ioc_inode, stbuf))) {
+        (IS_SUCCESS((op_ret)) && !ioc_cache_still_valid(ioc_inode, stbuf))) {
         gf_msg_debug(ioc_inode->table->xl->name, 0,
                      "cache for inode(%p) is invalid. flushing all pages",
                      ioc_inode);
@@ -431,7 +431,7 @@ ioc_cache_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         ioc_inode_lock(ioc_inode);
         {
             destroy_size = __ioc_inode_flush(ioc_inode);
-            if (op_ret >= 0) {
+            if (IS_SUCCESS(op_ret)) {
                 ioc_inode->cache.mtime = stbuf->ia_mtime;
                 ioc_inode->cache.mtime_nsec = stbuf->ia_mtime_nsec;
             }
@@ -617,7 +617,7 @@ ioc_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     table = this->private;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         inode_ctx_get(fd->inode, this, &tmp_ioc_inode);
         ioc_inode = (ioc_inode_t *)(long)tmp_ioc_inode;
 
@@ -700,7 +700,7 @@ ioc_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     table = this->private;
     path = local->file_loc.path;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         /* assign weight */
         weight = ioc_get_priority(table, path);
 
@@ -780,7 +780,7 @@ ioc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     table = this->private;
     path = local->file_loc.path;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         /* assign weight */
         weight = ioc_get_priority(table, path);
 
@@ -1237,7 +1237,7 @@ ioc_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     inode_ctx_get(local->fd->inode, this, &ioc_inode);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         ioc_update_pages(frame, (ioc_inode_t *)(long)ioc_inode, local->vector,
                          local->op_ret, op_ret, local->offset);
     }

--- a/xlators/performance/io-cache/src/io-cache.c
+++ b/xlators/performance/io-cache/src/io-cache.c
@@ -170,7 +170,7 @@ __ioc_inode_flush(ioc_inode_t *ioc_inode)
     {
         ret = __ioc_page_destroy(curr);
 
-        if (ret != -1)
+        if (ret >= 0)
             destroy_size += ret;
     }
 
@@ -419,7 +419,7 @@ ioc_cache_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     ioc_inode = local->inode;
     local_stbuf = stbuf;
 
-    if ((op_ret == -1) ||
+    if (IS_ERROR((op_ret)) ||
         ((op_ret >= 0) && !ioc_cache_still_valid(ioc_inode, stbuf))) {
         gf_msg_debug(ioc_inode->table->xl->name, 0,
                      "cache for inode(%p) is invalid. flushing all pages",
@@ -448,7 +448,7 @@ ioc_cache_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         ioc_table_unlock(ioc_inode->table);
     }
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         local_stbuf = NULL;
 
     gettimeofday(&tv, NULL);
@@ -617,7 +617,7 @@ ioc_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     table = this->private;
 
-    if (op_ret != -1) {
+    if (op_ret >= 0) {
         inode_ctx_get(fd->inode, this, &tmp_ioc_inode);
         ioc_inode = (ioc_inode_t *)(long)tmp_ioc_inode;
 
@@ -700,7 +700,7 @@ ioc_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     table = this->private;
     path = local->file_loc.path;
 
-    if (op_ret != -1) {
+    if (op_ret >= 0) {
         /* assign weight */
         weight = ioc_get_priority(table, path);
 
@@ -780,7 +780,7 @@ ioc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     table = this->private;
     path = local->file_loc.path;
 
-    if (op_ret != -1) {
+    if (op_ret >= 0) {
         /* assign weight */
         weight = ioc_get_priority(table, path);
 
@@ -1041,7 +1041,7 @@ ioc_dispatch_requests(call_frame_t *frame, ioc_inode_t *ioc_inode, fd_t *fd,
                     }
 
                     ret = ioc_wait_on_inode(ioc_inode, trav);
-                    if (ret < 0) {
+                    if (IS_ERROR(ret)) {
                         local->op_ret = -1;
                         local->op_errno = -ret;
                         need_validate = 0;
@@ -1074,7 +1074,7 @@ ioc_dispatch_requests(call_frame_t *frame, ioc_inode_t *ioc_inode, fd_t *fd,
                          "inode(%s) at offset=%" PRId64 "",
                          uuid_utoa(fd->inode->gfid), trav_offset);
             ret = ioc_cache_validate(frame, ioc_inode, fd, trav);
-            if (ret == -1) {
+            if (IS_ERROR(ret)) {
                 ioc_inode_lock(ioc_inode);
                 {
                     waitq = __ioc_page_wakeup(trav, trav->op_errno);
@@ -1603,7 +1603,7 @@ out:
 
     GF_FREE(dup_str);
 
-    if (max_pri == -1) {
+    if (IS_ERROR(max_pri)) {
         list_for_each_entry_safe(curr, tmp, first, list)
         {
             list_del_init(&curr->list);
@@ -1652,7 +1652,7 @@ check_cache_size_ok(xlator_t *this, uint64_t cache_size)
     }
 
     total_mem = get_mem_size();
-    if (-1 == total_mem)
+    if (IS_ERROR(total_mem))
         max_cache_size = opt->max;
     else
         max_cache_size = total_mem;
@@ -1699,7 +1699,7 @@ reconfigure(xlator_t *this, dict_t *options)
             table->max_pri = ioc_get_priority_list(option_list,
                                                    &table->priority_list);
 
-            if (table->max_pri == -1) {
+            if (IS_ERROR(table->max_pri)) {
                 goto unlock;
             }
             table->max_pri++;
@@ -1800,7 +1800,7 @@ init(xlator_t *this)
         table->max_pri = ioc_get_priority_list(option_list,
                                                &table->priority_list);
 
-        if (table->max_pri == -1) {
+        if (IS_ERROR(table->max_pri)) {
             goto out;
         }
     }
@@ -1852,7 +1852,7 @@ init(xlator_t *this)
     ioc_log2_page_size = log_base2(ctx->page_size);
 
 out:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         if (table != NULL) {
             GF_FREE(table->inode_lru);
             GF_FREE(table);

--- a/xlators/performance/io-cache/src/ioc-inode.c
+++ b/xlators/performance/io-cache/src/ioc-inode.c
@@ -45,7 +45,7 @@ ptr_to_str(void *ptr)
     GF_VALIDATE_OR_GOTO("io-cache", ptr, out);
 
     ret = gf_asprintf(&str, "%p", ptr);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         gf_smsg("io-cache", GF_LOG_WARNING, 0,
                 IO_CACHE_MSG_STR_COVERSION_FAILED, NULL);
         str = NULL;

--- a/xlators/performance/io-cache/src/page.c
+++ b/xlators/performance/io-cache/src/page.c
@@ -164,7 +164,7 @@ __ioc_inode_prune(ioc_inode_t *curr, uint64_t *size_pruned,
         *size_pruned += page->size;
         ret = __ioc_page_destroy(page);
 
-        if (ret != -1)
+        if (ret >= 0)
             table->cache_used -= ret;
 
         gf_msg_trace(table->xl->name, 0,
@@ -434,7 +434,7 @@ ioc_fault_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     gettimeofday(&tv, NULL);
     ioc_inode_lock(ioc_inode);
     {
-        if (op_ret == -1 ||
+        if (IS_ERROR(op_ret) ||
             !(zero_filled || ioc_cache_still_valid(ioc_inode, stbuf))) {
             gf_msg_trace(ioc_inode->table->xl->name, 0,
                          "cache for inode(%p) is invalid. flushing "
@@ -450,7 +450,7 @@ ioc_fault_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
         memcpy(&ioc_inode->cache.tv, &tv, sizeof(struct timeval));
 
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             /* error, readv returned -1 */
             page = __ioc_page_get(ioc_inode, offset);
             if (page)
@@ -512,7 +512,7 @@ ioc_fault_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
                     waitq = __ioc_page_wakeup(page, op_errno);
                 } /* if(page->waitq) */
             }     /* if(!page)...else */
-        }         /* if(op_ret < 0)...else */
+        }         /* if(IS_ERROR(op_ret))...else */
     }             /* ioc_inode locked region end */
 unlock:
     ioc_inode_unlock(ioc_inode);
@@ -677,7 +677,7 @@ __ioc_frame_fill(ioc_page_t *page, call_frame_t *frame, off_t offset,
     /* immediately move this page to the end of the page_lru list */
     list_move_tail(&page->page_lru, &ioc_inode->cache.page_lru);
     /* fill local->pending_size bytes from local->pending_offset */
-    if (local->op_ret != -1) {
+    if (local->op_ret >= 0) {
         local->op_errno = op_errno;
 
         if (page->size == 0) {
@@ -699,7 +699,7 @@ __ioc_frame_fill(ioc_page_t *page, call_frame_t *frame, off_t offset,
          * or till the requested size */
         copy_size = min(page->size - src_offset, size - dst_offset);
 
-        if (copy_size < 0) {
+        if (IS_ERROR(copy_size)) {
             /* if page contains fewer bytes and the required offset
                is beyond the page size in the page */
             copy_size = src_offset = 0;
@@ -724,7 +724,7 @@ __ioc_frame_fill(ioc_page_t *page, call_frame_t *frame, off_t offset,
             new->iobref = iobref_ref(page->iobref);
             new->count = iov_subset(page->vector, page->count, src_offset,
                                     copy_size, &new->vector, 0);
-            if (new->count < 0) {
+            if (IS_ERROR(new->count)) {
                 local->op_ret = -1;
                 local->op_errno = ENOMEM;
 
@@ -802,7 +802,7 @@ ioc_frame_unwind(call_frame_t *frame)
         goto unwind;
     }
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         op_ret = local->op_ret;
         op_errno = local->op_errno;
         goto unwind;
@@ -851,7 +851,7 @@ ioc_frame_unwind(call_frame_t *frame)
         GF_FREE(fill);
     }
 
-    if (op_ret != -1) {
+    if (op_ret >= 0) {
         op_ret = iov_length(vector, count);
     }
 
@@ -940,7 +940,7 @@ __ioc_page_wakeup(ioc_page_t *page, int32_t op_errno)
         frame = trav->data;
         ret = __ioc_frame_fill(page, frame, trav->pending_offset,
                                trav->pending_size, op_errno);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             break;
         }
     }
@@ -983,7 +983,7 @@ __ioc_page_error(ioc_page_t *page, int32_t op_ret, int32_t op_errno)
         local = frame->local;
         ioc_local_lock(local);
         {
-            if (local->op_ret != -1) {
+            if (local->op_ret >= 0) {
                 local->op_ret = op_ret;
                 local->op_errno = op_errno;
             }
@@ -994,7 +994,7 @@ __ioc_page_error(ioc_page_t *page, int32_t op_ret, int32_t op_errno)
     table = page->inode->table;
     ret = __ioc_page_destroy(page);
 
-    if (ret != -1) {
+    if (ret >= 0) {
         table->cache_used -= ret;
     }
 

--- a/xlators/performance/io-cache/src/page.c
+++ b/xlators/performance/io-cache/src/page.c
@@ -164,7 +164,7 @@ __ioc_inode_prune(ioc_inode_t *curr, uint64_t *size_pruned,
         *size_pruned += page->size;
         ret = __ioc_page_destroy(page);
 
-        if (ret >= 0)
+        if (IS_SUCCESS(ret))
             table->cache_used -= ret;
 
         gf_msg_trace(table->xl->name, 0,
@@ -429,7 +429,7 @@ ioc_fault_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     table = ioc_inode->table;
     GF_ASSERT(table);
 
-    zero_filled = ((op_ret >= 0) && (stbuf->ia_mtime == 0));
+    zero_filled = (IS_SUCCESS((op_ret)) && (stbuf->ia_mtime == 0));
 
     gettimeofday(&tv, NULL);
     ioc_inode_lock(ioc_inode);
@@ -443,7 +443,7 @@ ioc_fault_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
             destroy_size = __ioc_inode_flush(ioc_inode);
         }
 
-        if ((op_ret >= 0) && !zero_filled) {
+        if (IS_SUCCESS((op_ret)) && !zero_filled) {
             ioc_inode->cache.mtime = stbuf->ia_mtime;
             ioc_inode->cache.mtime_nsec = stbuf->ia_mtime_nsec;
         }
@@ -677,7 +677,7 @@ __ioc_frame_fill(ioc_page_t *page, call_frame_t *frame, off_t offset,
     /* immediately move this page to the end of the page_lru list */
     list_move_tail(&page->page_lru, &ioc_inode->cache.page_lru);
     /* fill local->pending_size bytes from local->pending_offset */
-    if (local->op_ret >= 0) {
+    if (IS_SUCCESS(local->op_ret)) {
         local->op_errno = op_errno;
 
         if (page->size == 0) {
@@ -851,7 +851,7 @@ ioc_frame_unwind(call_frame_t *frame)
         GF_FREE(fill);
     }
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         op_ret = iov_length(vector, count);
     }
 
@@ -983,7 +983,7 @@ __ioc_page_error(ioc_page_t *page, int32_t op_ret, int32_t op_errno)
         local = frame->local;
         ioc_local_lock(local);
         {
-            if (local->op_ret >= 0) {
+            if (IS_SUCCESS(local->op_ret)) {
                 local->op_ret = op_ret;
                 local->op_errno = op_errno;
             }
@@ -994,7 +994,7 @@ __ioc_page_error(ioc_page_t *page, int32_t op_ret, int32_t op_errno)
     table = page->inode->table;
     ret = __ioc_page_destroy(page);
 
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         table->cache_used -= ret;
     }
 

--- a/xlators/performance/io-threads/src/io-threads.c
+++ b/xlators/performance/io-threads/src/io-threads.c
@@ -45,7 +45,7 @@ struct volume_options options[];
         __ret = iot_schedule(frame, this, __stub);                             \
                                                                                \
     out:                                                                       \
-        if (__ret < 0) {                                                       \
+        if (IS_ERROR(__ret)) {                                                 \
             default_##name##_failure_cbk(frame, -__ret);                       \
             if (__stub != NULL) {                                              \
                 call_stub_destroy(__stub);                                     \
@@ -135,7 +135,7 @@ __iot_enqueue(iot_conf_t *conf, call_stub_t *stub, int pri)
     client_t *client = stub->frame->root->client;
     iot_client_ctx_t *ctx;
 
-    if (pri < 0 || pri >= GF_FOP_PRI_MAX)
+    if (IS_ERROR(pri) || pri >= GF_FOP_PRI_MAX)
         pri = GF_FOP_PRI_MAX - 1;
 
     if (client) {
@@ -1259,7 +1259,7 @@ init(xlator_t *this)
     if (!this->pass_through) {
         ret = iot_workers_scale(conf);
 
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_smsg(this->name, GF_LOG_ERROR, 0,
                     IO_THREADS_MSG_WORKER_THREAD_INIT_FAILED, NULL);
             goto out;

--- a/xlators/performance/md-cache/src/md-cache.c
+++ b/xlators/performance/md-cache/src/md-cache.c
@@ -2357,7 +2357,7 @@ mdc_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     mdc_inode_xatt_update(this, local->loc.inode, local->xattr);
 
     ret = dict_get_iatt(xdata, GF_PRESTAT, &prestat);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         ret = dict_get_iatt(xdata, GF_POSTSTAT, &poststat);
         mdc_inode_iatt_set_validate(this, local->loc.inode, &prestat, &poststat,
                                     _gf_true, local->incident_time);
@@ -2416,7 +2416,7 @@ mdc_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     mdc_inode_xatt_update(this, local->fd->inode, local->xattr);
 
     ret = dict_get_iatt(xdata, GF_PRESTAT, &prestat);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         ret = dict_get_iatt(xdata, GF_POSTSTAT, &poststat);
         mdc_inode_iatt_set_validate(this, local->fd->inode, &prestat, &poststat,
                                     _gf_true, local->incident_time);
@@ -2654,7 +2654,7 @@ mdc_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         mdc_inode_xatt_invalidate(this, local->loc.inode);
 
     ret = dict_get_iatt(xdata, GF_PRESTAT, &prestat);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         ret = dict_get_iatt(xdata, GF_POSTSTAT, &poststat);
         mdc_inode_iatt_set_validate(this, local->loc.inode, &prestat, &poststat,
                                     _gf_true, local->incident_time);
@@ -2753,7 +2753,7 @@ mdc_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         mdc_inode_xatt_invalidate(this, local->fd->inode);
 
     ret = dict_get_iatt(xdata, GF_PRESTAT, &prestat);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         ret = dict_get_iatt(xdata, GF_POSTSTAT, &poststat);
         mdc_inode_iatt_set_validate(this, local->fd->inode, &prestat, &poststat,
                                     _gf_true, local->incident_time);

--- a/xlators/performance/nl-cache/src/nl-cache-helper.c
+++ b/xlators/performance/nl-cache/src/nl-cache-helper.c
@@ -190,7 +190,7 @@ nlc_inode_ctx_get(xlator_t *this, inode_t *inode, nlc_ctx_t **nlc_ctx_p)
     LOCK(&inode->lock);
     {
         ret = __nlc_inode_ctx_get(this, inode, nlc_ctx_p);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "inode ctx get failed for "
                          "inode:%p",
@@ -270,11 +270,11 @@ nlc_init_invalid_ctx(xlator_t *this, inode_t *inode, nlc_ctx_t *nlc_ctx)
          * and we need to start timer and add to lru, so that it is
          * ready to cache entries a fresh */
         ret = __nlc_inode_ctx_timer_start(this, inode, nlc_ctx);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto unlock;
 
         ret = __nlc_add_to_lru(this, inode, nlc_ctx);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             __nlc_inode_ctx_timer_delete(this, nlc_ctx);
             goto unlock;
         }
@@ -310,11 +310,11 @@ nlc_inode_ctx_get_set(xlator_t *this, inode_t *inode, nlc_ctx_t **nlc_ctx_p)
         INIT_LIST_HEAD(&nlc_ctx->ne);
 
         ret = __nlc_inode_ctx_timer_start(this, inode, nlc_ctx);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto unlock;
 
         ret = __nlc_add_to_lru(this, inode, nlc_ctx);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             __nlc_inode_ctx_timer_delete(this, nlc_ctx);
             goto unlock;
         }
@@ -341,7 +341,7 @@ unlock:
         nlc_init_invalid_ctx(this, inode, nlc_ctx);
     }
 
-    if (ret < 0 && nlc_ctx) {
+    if (IS_ERROR(ret) && nlc_ctx) {
         LOCK_DESTROY(&nlc_ctx->lock);
         GF_FREE(nlc_ctx);
         nlc_ctx = NULL;
@@ -505,7 +505,7 @@ __nlc_inode_ctx_timer_start(xlator_t *this, inode_t *inode, nlc_ctx_t *nlc_ctx)
     ret = 0;
 
 out:
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (tmp && tmp->inode)
             inode_unref(tmp->inode);
         GF_FREE(tmp);
@@ -1112,7 +1112,7 @@ nlc_get_real_file_name(xlator_t *this, loc_t *loc, const char *fname,
         if (found_file) {
             ret = dict_set_dynstr(dict, GF_XATTR_GET_REAL_FILENAME_KEY,
                                   gf_strdup(found_file));
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto unlock;
             *op_ret = strlen(found_file) + 1;
             hit = _gf_true;

--- a/xlators/performance/nl-cache/src/nl-cache.c
+++ b/xlators/performance/nl-cache/src/nl-cache.c
@@ -92,7 +92,7 @@ out:
                                                                                \
         conf = this->private;                                                  \
                                                                                \
-        if (op_ret < 0 || !IS_PEC_ENABLED(conf))                               \
+        if (IS_ERROR(op_ret) || !IS_PEC_ENABLED(conf))                         \
             goto out;                                                          \
         nlc_dentry_op(frame, this, multilink);                                 \
     out:                                                                       \
@@ -195,7 +195,7 @@ nlc_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     /* Donot add to pe, this may lead to duplicate entry and
      * requires search before adding if list of strings */
-    if (op_ret < 0 && op_errno == ENOENT) {
+    if (IS_ERROR(op_ret) && op_errno == ENOENT) {
         nlc_dir_add_ne(this, local->loc.parent, local->loc.name);
         GF_ATOMIC_INC(conf->nlc_counter.nlc_miss);
     }
@@ -279,7 +279,7 @@ nlc_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!IS_PEC_ENABLED(conf))
         goto out;
 
-    if (op_ret < 0 && op_errno == ENOENT) {
+    if (IS_ERROR(op_ret) && op_errno == ENOENT) {
         GF_ATOMIC_INC(conf->nlc_counter.getrealfilename_miss);
     }
 
@@ -744,7 +744,7 @@ nlc_init(xlator_t *this)
 
     ret = 0;
 out:
-    if (ret < 0)
+    if (IS_ERROR(ret))
         GF_FREE(conf);
 
     return ret;

--- a/xlators/performance/open-behind/src/open-behind.c
+++ b/xlators/performance/open-behind/src/open-behind.c
@@ -107,7 +107,7 @@ ob_inode_get(xlator_t *this, inode_t *inode)
 
             value = (uint64_t)(uintptr_t)ob_inode;
             ret = __inode_ctx_set(inode, this, &value);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 ob_inode_free(ob_inode);
                 ob_inode = NULL;
             }
@@ -248,7 +248,7 @@ ob_wake_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
         list_splice_init(&ob_fd->list, &fops_waiting_on_fd);
 
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             /* mark fd BAD for ever */
             ob_fd->op_errno = op_errno;
             ob_fd = NULL; /*shouldn't be freed*/
@@ -262,7 +262,7 @@ ob_wake_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         LOCK(&fd->inode->lock);
         {
             count = --ob_inode->count;
-            if (op_ret < 0) {
+            if (IS_ERROR(op_ret)) {
                 /* TODO: when to reset the error? */
                 ob_inode->op_ret = -1;
                 ob_inode->op_errno = op_errno;
@@ -286,7 +286,7 @@ ob_wake_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     {
         list_del_init(&stub->list);
 
-        if (op_ret < 0)
+        if (IS_ERROR(op_ret))
             call_unwind_error(stub, -1, op_errno);
         else
             call_resume(stub);
@@ -296,7 +296,7 @@ ob_wake_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     {
         list_del_init(&stub->list);
 
-        if (ob_inode_op_ret < 0)
+        if (IS_ERROR(ob_inode_op_ret))
             call_unwind_error(stub, -1, ob_inode_op_errno);
         else
             call_resume(stub);

--- a/xlators/performance/quick-read/src/quick-read.c
+++ b/xlators/performance/quick-read/src/quick-read.c
@@ -779,7 +779,7 @@ qr_readv_cached(call_frame_t *frame, qr_inode_t *qr_inode, size_t size,
 unlock:
     UNLOCK(&table->lock);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         iov.iov_base = iobuf->ptr;
         iov.iov_len = op_ret;
 

--- a/xlators/performance/quick-read/src/quick-read.c
+++ b/xlators/performance/quick-read/src/quick-read.c
@@ -400,7 +400,7 @@ qr_content_extract(dict_t *xdata)
     int ret = 0;
 
     ret = dict_get_with_ref(xdata, GF_CONTENT_KEY, &data);
-    if (ret < 0 || !data)
+    if (IS_ERROR(ret) || !data)
         return NULL;
 
     content = GF_MALLOC(data->len, gf_qr_mt_content_t);
@@ -590,7 +590,7 @@ qr_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     local = frame->local;
     inode = local->inode;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         qr_inode_prune(this, inode, local->incident_gen);
         goto out;
     }
@@ -809,7 +809,7 @@ qr_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     if (!qr_inode)
         goto wind;
 
-    if (qr_readv_cached(frame, qr_inode, size, offset, flags, xdata) < 0)
+    if (IS_ERROR(qr_readv_cached(frame, qr_inode, size, offset, flags, xdata)))
         goto wind;
 
     return 0;
@@ -1179,7 +1179,7 @@ check_cache_size_ok(xlator_t *this, int64_t cache_size)
     }
 
     total_mem = get_mem_size();
-    if (-1 == total_mem)
+    if (IS_ERROR(total_mem))
         max_cache_size = opt->max;
     else
         max_cache_size = total_mem;
@@ -1323,7 +1323,7 @@ out:
 
     GF_FREE(dup_str);
 
-    if (max_pri == -1) {
+    if (IS_ERROR(max_pri)) {
         list_for_each_entry_safe(curr, tmp, first, list)
         {
             list_del_init(&curr->list);
@@ -1388,7 +1388,7 @@ qr_init(xlator_t *this)
         /* parse the list of pattern:priority */
         conf->max_pri = qr_get_priority_list(option_list, &conf->priority_list);
 
-        if (conf->max_pri == -1) {
+        if (IS_ERROR(conf->max_pri)) {
             goto out;
         }
         conf->max_pri++;
@@ -1411,7 +1411,7 @@ qr_init(xlator_t *this)
     GF_ATOMIC_INIT(priv->generation, 0);
     this->private = priv;
 out:
-    if ((ret == -1) && priv) {
+    if (IS_ERROR(ret) && priv) {
         GF_FREE(priv);
     }
 

--- a/xlators/performance/read-ahead/src/page.c
+++ b/xlators/performance/read-ahead/src/page.c
@@ -195,7 +195,7 @@ ra_fault_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
             op_errno = ECANCELED;
         }
 
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             waitq = ra_page_error(page, op_ret, op_errno);
             goto unlock;
         }
@@ -314,7 +314,7 @@ ra_frame_fill(ra_page_t *page, call_frame_t *frame)
     local = frame->local;
     fill = &local->fill;
 
-    if (local->op_ret != -1 && page->size) {
+    if (local->op_ret >= 0 && page->size) {
         if (local->offset > page->offset)
             src_offset = local->offset - page->offset;
         else
@@ -322,7 +322,7 @@ ra_frame_fill(ra_page_t *page, call_frame_t *frame)
 
         copy_size = min(page->size - src_offset, local->size - dst_offset);
 
-        if (copy_size < 0) {
+        if (IS_ERROR(copy_size)) {
             /* if page contains fewer bytes and the required offset
                is beyond the page size in the page */
             copy_size = src_offset = 0;
@@ -348,7 +348,7 @@ ra_frame_fill(ra_page_t *page, call_frame_t *frame)
         new->iobref = iobref_ref(page->iobref);
         new->count = iov_subset(page->vector, page->count, src_offset,
                                 copy_size, &new->vector, 0);
-        if (new->count < 0) {
+        if (IS_ERROR(new->count)) {
             local->op_ret = -1;
             local->op_errno = ENOMEM;
             iobref_unref(new->iobref);
@@ -557,7 +557,7 @@ ra_page_error(ra_page_t *page, int32_t op_ret, int32_t op_errno)
         frame = trav->data;
 
         local = frame->local;
-        if (local->op_ret != -1) {
+        if (local->op_ret >= 0) {
             local->op_ret = op_ret;
             local->op_errno = op_errno;
         }

--- a/xlators/performance/read-ahead/src/page.c
+++ b/xlators/performance/read-ahead/src/page.c
@@ -157,7 +157,7 @@ ra_fault_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     ra_file_lock(file);
     {
-        if (op_ret >= 0)
+        if (IS_SUCCESS(op_ret))
             file->stbuf = *stbuf;
 
         page = ra_page_get(file, pending_offset);
@@ -314,7 +314,7 @@ ra_frame_fill(ra_page_t *page, call_frame_t *frame)
     local = frame->local;
     fill = &local->fill;
 
-    if (local->op_ret >= 0 && page->size) {
+    if (IS_SUCCESS(local->op_ret) && page->size) {
         if (local->offset > page->offset)
             src_offset = local->offset - page->offset;
         else
@@ -557,7 +557,7 @@ ra_page_error(ra_page_t *page, int32_t op_ret, int32_t op_errno)
         frame = trav->data;
 
         local = frame->local;
-        if (local->op_ret >= 0) {
+        if (IS_SUCCESS(local->op_ret)) {
             local->op_ret = op_ret;
             local->op_errno = op_errno;
         }

--- a/xlators/performance/read-ahead/src/read-ahead.c
+++ b/xlators/performance/read-ahead/src/read-ahead.c
@@ -41,7 +41,7 @@ ra_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     conf = this->private;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -83,7 +83,7 @@ ra_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     }
 
     ret = fd_ctx_set(fd, this, (uint64_t)(long)file);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(frame->this->name, GF_LOG_WARNING, 0, READ_AHEAD_MSG_NO_MEMORY,
                "cannot set read-ahead context"
                "information in fd (%p)",
@@ -115,7 +115,7 @@ ra_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     conf = this->private;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -154,7 +154,7 @@ ra_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     pthread_mutex_init(&file->file_lock, NULL);
 
     ret = fd_ctx_set(fd, this, (uint64_t)(long)file);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, 0, READ_AHEAD_MSG_NO_MEMORY,
                "cannot set read ahead context"
                "information in fd (%p)",
@@ -393,7 +393,7 @@ dispatch_requests(call_frame_t *frame, ra_file_t *file)
     unlock:
         ra_file_unlock(file);
 
-        if (local->op_ret == -1) {
+        if (IS_ERROR(local->op_ret)) {
             goto out;
         }
 
@@ -1153,7 +1153,7 @@ init(xlator_t *this)
     ret = 0;
 
 out:
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         GF_FREE(conf);
     }
 

--- a/xlators/performance/readdir-ahead/src/readdir-ahead.c
+++ b/xlators/performance/readdir-ahead/src/readdir-ahead.c
@@ -57,7 +57,7 @@ get_rda_fd_ctx(fd_t *fd, xlator_t *this)
 
     LOCK(&fd->lock);
 
-    if (__fd_ctx_get(fd, this, &val) < 0) {
+    if (IS_ERROR(__fd_ctx_get(fd, this, &val))) {
         ctx = GF_CALLOC(1, sizeof(struct rda_fd_ctx), gf_rda_mt_rda_fd_ctx);
         if (!ctx)
             goto out;
@@ -68,7 +68,7 @@ get_rda_fd_ctx(fd_t *fd, xlator_t *this)
         /* ctx offset values initialized to 0 */
         ctx->xattrs = NULL;
 
-        if (__fd_ctx_set(fd, this, (uint64_t)(uintptr_t)ctx) < 0) {
+        if (IS_ERROR(__fd_ctx_set(fd, this, (uint64_t)(uintptr_t)ctx))) {
             GF_FREE(ctx);
             ctx = NULL;
             goto out;
@@ -100,7 +100,7 @@ __rda_inode_ctx_get(inode_t *inode, xlator_t *this)
 
     ctx_uint = (uint64_t)(uintptr_t)ctx_p;
     ret = __inode_ctx_set1(inode, this, &ctx_uint);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         GF_FREE(ctx_p);
         return NULL;
     }
@@ -240,7 +240,7 @@ rda_mark_inode_dirty(xlator_t *this, inode_t *inode)
 
                         ret = dict_set_int8(fd_ctx->writes_during_prefetch,
                                             gfid, 1);
-                        if (ret < 0) {
+                        if (IS_ERROR(ret)) {
                             gf_log(this->name, GF_LOG_WARNING,
                                    "marking to invalidate stats of %s from an "
                                    "in progress "
@@ -569,7 +569,7 @@ rda_fill_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         ctx->state &= ~RDA_FD_RUNNING;
         ctx->state |= RDA_FD_EOD;
         ctx->op_errno = op_errno;
-    } else if (op_ret == -1) {
+    } else if (IS_ERROR(op_ret)) {
         /* kill the preload and pend the error */
         ctx->state &= ~RDA_FD_RUNNING;
         ctx->state |= RDA_FD_ERROR;
@@ -764,7 +764,7 @@ rda_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -800,7 +800,7 @@ rda_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -833,7 +833,7 @@ rda_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -866,7 +866,7 @@ rda_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -899,7 +899,7 @@ rda_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -932,7 +932,7 @@ rda_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -961,7 +961,7 @@ rda_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 {
     struct rda_local *local = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -988,7 +988,7 @@ rda_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 {
     struct rda_local *local = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -1019,7 +1019,7 @@ rda_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -1052,7 +1052,7 @@ rda_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -1081,7 +1081,7 @@ rda_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 {
     struct rda_local *local = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -1108,7 +1108,7 @@ rda_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 {
     struct rda_local *local = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -1135,7 +1135,7 @@ rda_releasedir(xlator_t *this, fd_t *fd)
     uint64_t val;
     struct rda_fd_ctx *ctx;
 
-    if (fd_ctx_del(fd, this, &val) < 0)
+    if (IS_ERROR(fd_ctx_del(fd, this, &val)))
         return -1;
 
     ctx = (struct rda_fd_ctx *)(uintptr_t)val;

--- a/xlators/performance/write-behind/src/write-behind.c
+++ b/xlators/performance/write-behind/src/write-behind.c
@@ -474,7 +474,7 @@ __wb_request_ref(wb_request_t *req)
 {
     GF_VALIDATE_OR_GOTO("write-behind", req, out);
 
-    if (req->refcount < 0) {
+    if (IS_ERROR(req->refcount)) {
         gf_msg("wb-request", GF_LOG_WARNING, 0,
                WRITE_BEHIND_MSG_RES_UNAVAILABLE, "refcount(%d) is < 0",
                req->refcount);
@@ -1097,7 +1097,7 @@ wb_fulfill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
      * </comment> */
     wb_set_invalidate(wb_inode);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         wb_fulfill_err(head, op_errno);
     } else if (op_ret < head->total_size) {
         wb_fulfill_short_write(head, op_ret);
@@ -1646,7 +1646,7 @@ __wb_pick_winds(wb_inode_t *wb_inode, list_head_t *tasks,
                          (conflict->op_ret == 1) ? "yes" : "no",
                          strerror(conflict->op_errno));
 
-            if (conflict->op_ret == -1) {
+            if (IS_ERROR(conflict->op_ret)) {
                 /* There is a conflicting liability which failed
                  * to sync in previous attempts, resume the req
                  * and fail, unless its an fsync/flush.
@@ -1738,7 +1738,7 @@ wb_do_winds(wb_inode_t *wb_inode, list_head_t *tasks)
     {
         list_del_init(&req->winds);
 
-        if (req->op_ret == -1) {
+        if (IS_ERROR(req->op_ret)) {
             call_unwind_error_keep_stub(req->stub, req->op_ret, req->op_errno);
         } else {
             call_resume_keep_stub(req->stub);

--- a/xlators/playground/rot-13/src/rot-13.c
+++ b/xlators/playground/rot-13/src/rot-13.c
@@ -119,7 +119,7 @@ init(xlator_t *this)
 
     data = dict_get(this->options, "encrypt-write");
     if (data) {
-        if (gf_string2boolean(data->data, &priv->encrypt_write) == -1) {
+        if (IS_ERROR(gf_string2boolean(data->data, &priv->encrypt_write))) {
             gf_log(this->name, GF_LOG_ERROR,
                    "encrypt-write takes only boolean options");
             GF_FREE(priv);
@@ -129,7 +129,7 @@ init(xlator_t *this)
 
     data = dict_get(this->options, "decrypt-read");
     if (data) {
-        if (gf_string2boolean(data->data, &priv->decrypt_read) == -1) {
+        if (IS_ERROR(gf_string2boolean(data->data, &priv->decrypt_read))) {
             gf_log(this->name, GF_LOG_ERROR,
                    "decrypt-read takes only boolean options");
             GF_FREE(priv);

--- a/xlators/protocol/auth/addr/src/addr.c
+++ b/xlators/protocol/auth/addr/src/addr.c
@@ -197,7 +197,7 @@ gf_auth(dict_t *input_params, dict_t *config_params)
     }
 
     ret = gf_asprintf(&searchstr, "auth.addr.%s.allow", name);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         gf_log("auth/addr", GF_LOG_DEBUG,
                "asprintf failed while setting search string");
         goto out;
@@ -207,7 +207,7 @@ gf_auth(dict_t *input_params, dict_t *config_params)
     GF_FREE(searchstr);
 
     ret = gf_asprintf(&searchstr, "auth.addr.%s.reject", name);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         gf_log("auth/addr", GF_LOG_ERROR,
                "asprintf failed while setting search string");
         goto out;
@@ -218,7 +218,7 @@ gf_auth(dict_t *input_params, dict_t *config_params)
     if (!allow_addr) {
         /* TODO: backward compatibility */
         ret = gf_asprintf(&searchstr, "auth.ip.%s.allow", name);
-        if (-1 == ret) {
+        if (IS_ERROR(ret)) {
             gf_log("auth/addr", GF_LOG_ERROR,
                    "asprintf failed while setting search string");
             goto out;
@@ -260,7 +260,7 @@ gf_auth(dict_t *input_params, dict_t *config_params)
             ret = dict_get_str(config_params, "rpc-auth-allow-insecure", &type);
             if (ret == 0) {
                 ret = gf_string2boolean(type, &allow_insecure);
-                if (ret < 0) {
+                if (IS_ERROR(ret)) {
                     gf_log("auth/addr", GF_LOG_WARNING,
                            "rpc-auth-allow-insecure option %s "
                            "is not a valid bool option",

--- a/xlators/protocol/auth/login/src/login.c
+++ b/xlators/protocol/auth/login/src/login.c
@@ -48,7 +48,7 @@ gf_auth(dict_t *input_params, dict_t *config_params)
     } else {
         ret = dict_get_str_boolean(config_params, "strict-auth-accept",
                                    _gf_false);
-        if (ret == -1)
+        if (IS_ERROR(ret))
             strict_auth = _gf_false;
         else
             strict_auth = ret;
@@ -94,7 +94,7 @@ gf_auth(dict_t *input_params, dict_t *config_params)
 
     ret = gf_asprintf(&searchstr, "auth.login.%s.%s", brick_name,
                       using_ssl ? "ssl-allow" : "allow");
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         gf_log("auth/login", GF_LOG_ERROR,
                "asprintf failed while setting search string, "
                "returning REJECT");
@@ -152,7 +152,7 @@ gf_auth(dict_t *input_params, dict_t *config_params)
                 }
                 ret = gf_asprintf(&searchstr, "auth.login.%s.password",
                                   username);
-                if (-1 == ret) {
+                if (IS_ERROR(ret)) {
                     gf_log("auth/login", GF_LOG_WARNING,
                            "asprintf failed while setting search string");
                     goto out;

--- a/xlators/protocol/client/src/client-callback.c
+++ b/xlators/protocol/client/src/client-callback.c
@@ -57,7 +57,7 @@ client_cbk_recall_lease(struct rpc_clnt *rpc, void *mydata, void *data)
     ret = xdr_to_generic(*iov, &recall_lease,
                          (xdrproc_t)xdr_gfs3_recall_lease_req);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(THIS->name, GF_LOG_WARNING, -ret, PC_MSG_RECALL_LEASE_FAIL,
                 NULL);
         goto out;
@@ -65,7 +65,7 @@ client_cbk_recall_lease(struct rpc_clnt *rpc, void *mydata, void *data)
 
     upcall_data.data = &rl_data;
     ret = gf_proto_recall_lease_to_upcall(&recall_lease, &upcall_data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     upcall_data.event_type = GF_UPCALL_RECALL_LEASE;
@@ -109,7 +109,7 @@ client_cbk_cache_invalidation(struct rpc_clnt *rpc, void *mydata, void *data)
     ret = xdr_to_generic(*iov, &ca_req,
                          (xdrproc_t)xdr_gfs3_cbk_cache_invalidation_req);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(THIS->name, GF_LOG_WARNING, -ret,
                 PC_MSG_CACHE_INVALIDATION_FAIL, NULL);
         goto out;
@@ -117,7 +117,7 @@ client_cbk_cache_invalidation(struct rpc_clnt *rpc, void *mydata, void *data)
 
     upcall_data.data = &ca_data;
     ret = gf_proto_cache_invalidation_to_upcall(THIS, &ca_req, &upcall_data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     gf_msg_trace(THIS->name, 0,
@@ -201,7 +201,7 @@ client_cbk_inodelk_contention(struct rpc_clnt *rpc, void *mydata, void *data)
     ret = xdr_to_generic(*iov, &proto_lc,
                          (xdrproc_t)xdr_gfs4_inodelk_contention_req);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(THIS->name, GF_LOG_WARNING, -ret,
                 PC_MSG_INODELK_CONTENTION_FAIL, NULL);
         goto out;
@@ -209,7 +209,7 @@ client_cbk_inodelk_contention(struct rpc_clnt *rpc, void *mydata, void *data)
 
     upcall_data.data = &lc;
     ret = gf_proto_inodelk_contention_to_upcall(&proto_lc, &upcall_data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     upcall_data.event_type = GF_UPCALL_INODELK_CONTENTION;
@@ -252,7 +252,7 @@ client_cbk_entrylk_contention(struct rpc_clnt *rpc, void *mydata, void *data)
     ret = xdr_to_generic(*iov, &proto_lc,
                          (xdrproc_t)xdr_gfs4_entrylk_contention_req);
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(THIS->name, GF_LOG_WARNING, -ret,
                 PC_MSG_ENTRYLK_CONTENTION_FAIL, NULL);
         goto out;
@@ -260,7 +260,7 @@ client_cbk_entrylk_contention(struct rpc_clnt *rpc, void *mydata, void *data)
 
     upcall_data.data = &lc;
     ret = gf_proto_entrylk_contention_to_upcall(&proto_lc, &upcall_data);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     upcall_data.event_type = GF_UPCALL_ENTRYLK_CONTENTION;

--- a/xlators/protocol/client/src/client-common.c
+++ b/xlators/protocol/client/src/client-common.c
@@ -1545,7 +1545,7 @@ client_post_readv(xlator_t *this, gfs3_read_rsp *rsp, struct iobref **iobref,
 {
     int ret = 0;
 
-    if (rsp->op_ret >= 0) {
+    if (IS_SUCCESS(rsp->op_ret)) {
         *iobref = rsp_iobref;
         gf_stat_to_iatt(&rsp->stat, stat);
 
@@ -1774,7 +1774,7 @@ client_post_lk(xlator_t *this, gfs3_lk_rsp *rsp, struct gf_flock *lock,
 {
     int ret = 0;
 
-    if (rsp->op_ret >= 0) {
+    if (IS_SUCCESS(rsp->op_ret)) {
         gf_proto_flock_to_flock(&rsp->flock, lock);
     }
     GF_PROTOCOL_DICT_UNSERIALIZE(this, *xdata, (rsp->xdata.xdata_val),
@@ -2103,7 +2103,7 @@ client_post_lease(xlator_t *this, gfs3_lease_rsp *rsp, struct gf_lease *lease,
 {
     int ret = 0;
 
-    if (rsp->op_ret >= 0) {
+    if (IS_SUCCESS(rsp->op_ret)) {
         gf_proto_lease_to_lease(&rsp->lease, lease);
     }
 
@@ -2175,7 +2175,7 @@ client_post_readv_v2(xlator_t *this, gfx_read_rsp *rsp, struct iobref **iobref,
 {
     int ret = -1;
 
-    if (rsp->op_ret >= 0) {
+    if (IS_SUCCESS(rsp->op_ret)) {
         *iobref = rsp_iobref;
         gfx_stat_to_iattx(&rsp->stat, stat);
 
@@ -3532,7 +3532,7 @@ int
 client_post_lease_v2(xlator_t *this, gfx_lease_rsp *rsp, struct gf_lease *lease,
                      dict_t **xdata)
 {
-    if (rsp->op_ret >= 0) {
+    if (IS_SUCCESS(rsp->op_ret)) {
         gf_proto_lease_to_lease(&rsp->lease, lease);
     }
 
@@ -3543,7 +3543,7 @@ int
 client_post_lk_v2(xlator_t *this, gfx_lk_rsp *rsp, struct gf_flock *lock,
                   dict_t **xdata)
 {
-    if (rsp->op_ret >= 0) {
+    if (IS_SUCCESS(rsp->op_ret)) {
         gf_proto_flock_to_flock(&rsp->flock, lock);
     }
     return xdr_to_dict(&rsp->xdata, xdata);

--- a/xlators/protocol/client/src/client-common.c
+++ b/xlators/protocol/client/src/client-common.c
@@ -1545,7 +1545,7 @@ client_post_readv(xlator_t *this, gfs3_read_rsp *rsp, struct iobref **iobref,
 {
     int ret = 0;
 
-    if (rsp->op_ret != -1) {
+    if (rsp->op_ret >= 0) {
         *iobref = rsp_iobref;
         gf_stat_to_iatt(&rsp->stat, stat);
 
@@ -2175,7 +2175,7 @@ client_post_readv_v2(xlator_t *this, gfx_read_rsp *rsp, struct iobref **iobref,
 {
     int ret = -1;
 
-    if (rsp->op_ret != -1) {
+    if (rsp->op_ret >= 0) {
         *iobref = rsp_iobref;
         gfx_stat_to_iattx(&rsp->stat, stat);
 

--- a/xlators/protocol/client/src/client-handshake.c
+++ b/xlators/protocol/client/src/client-handshake.c
@@ -120,7 +120,7 @@ client3_3_reopen_cbk(struct rpc_req *req, struct iovec *iov, int count,
     clnt_local_t *local = frame->local;
     clnt_fd_ctx_t *fdctx = local->fdctx;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, ENOTCONN,
                 PC_MSG_RPC_STATUS_ERROR, NULL);
         rsp.op_ret = -1;
@@ -129,7 +129,7 @@ client3_3_reopen_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_open_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(frame->this->name, GF_LOG_ERROR, EINVAL,
                 PC_MSG_XDR_DECODING_FAILED, NULL);
         rsp.op_ret = -1;
@@ -137,7 +137,7 @@ client3_3_reopen_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (rsp.op_ret < 0) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, rsp.op_errno,
                 PC_MSG_REOPEN_FAILED, "path=%s", local->loc.path);
     } else {
@@ -146,7 +146,7 @@ client3_3_reopen_cbk(struct rpc_req *req, struct iovec *iov, int count,
                      local->loc.path, rsp.fd);
     }
 
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         goto out;
     }
 
@@ -173,7 +173,7 @@ client3_3_reopendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     clnt_local_t *local = frame->local;
     clnt_fd_ctx_t *fdctx = local->fdctx;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, ENOTCONN,
                 PC_MSG_RPC_STATUS_ERROR, NULL);
         rsp.op_ret = -1;
@@ -182,7 +182,7 @@ client3_3_reopendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_opendir_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(frame->this->name, GF_LOG_ERROR, EINVAL,
                 PC_MSG_XDR_DECODING_FAILED, NULL);
         rsp.op_ret = -1;
@@ -190,7 +190,7 @@ client3_3_reopendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (rsp.op_ret < 0) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, rsp.op_errno,
                 PC_MSG_REOPEN_FAILED, "path=%s", local->loc.path, NULL);
     } else {
@@ -198,7 +198,7 @@ client3_3_reopendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
                 "path=%s", local->loc.path, "fd=%" PRId64, rsp.fd, NULL);
     }
 
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         goto out;
     }
 
@@ -235,7 +235,7 @@ protocol_client_reopendir(clnt_fd_ctx_t *fdctx, xlator_t *this)
 
     gf_uuid_copy(local->loc.gfid, fdctx->gfid);
     ret = loc_path(&local->loc, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     frame = create_frame(this, this->ctx->pool);
@@ -296,7 +296,7 @@ protocol_client_reopenfile(clnt_fd_ctx_t *fdctx, xlator_t *this)
     local->fdctx = fdctx;
     gf_uuid_copy(local->loc.gfid, fdctx->gfid);
     ret = loc_path(&local->loc, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     frame->local = local;
@@ -354,7 +354,7 @@ client4_0_reopen_cbk(struct rpc_req *req, struct iovec *iov, int count,
     clnt_local_t *local = frame->local;
     clnt_fd_ctx_t *fdctx = local->fdctx;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, ENOTCONN,
                 PC_MSG_RPC_STATUS_ERROR, NULL);
         rsp.op_ret = -1;
@@ -363,7 +363,7 @@ client4_0_reopen_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_open_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(frame->this->name, GF_LOG_ERROR, EINVAL,
                 PC_MSG_XDR_DECODING_FAILED, NULL);
         rsp.op_ret = -1;
@@ -371,7 +371,7 @@ client4_0_reopen_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (rsp.op_ret < 0) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, rsp.op_errno,
                 PC_MSG_REOPEN_FAILED, "path=%s", local->loc.path, NULL);
     } else {
@@ -380,7 +380,7 @@ client4_0_reopen_cbk(struct rpc_req *req, struct iovec *iov, int count,
                      local->loc.path, rsp.fd);
     }
 
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         goto out;
     }
 
@@ -407,7 +407,7 @@ client4_0_reopendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     clnt_local_t *local = frame->local;
     clnt_fd_ctx_t *fdctx = local->fdctx;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, ENOTCONN,
                 PC_MSG_RPC_STATUS_ERROR, NULL);
         rsp.op_ret = -1;
@@ -416,7 +416,7 @@ client4_0_reopendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_open_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(frame->this->name, GF_LOG_ERROR, EINVAL,
                 PC_MSG_XDR_DECODING_FAILED, NULL);
         rsp.op_ret = -1;
@@ -424,7 +424,7 @@ client4_0_reopendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (rsp.op_ret < 0) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, rsp.op_errno,
                 PC_MSG_DIR_OP_FAILED, "dir-path=%s", local->loc.path, NULL);
     } else {
@@ -432,7 +432,7 @@ client4_0_reopendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
                 "path=%s", local->loc.path, "fd=%" PRId64, rsp.fd, NULL);
     }
 
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         goto out;
     }
 
@@ -467,7 +467,7 @@ protocol_client_reopendir_v2(clnt_fd_ctx_t *fdctx, xlator_t *this)
 
     gf_uuid_copy(local->loc.gfid, fdctx->gfid);
     ret = loc_path(&local->loc, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     frame = create_frame(this, this->ctx->pool);
@@ -528,7 +528,7 @@ protocol_client_reopenfile_v2(clnt_fd_ctx_t *fdctx, xlator_t *this)
     local->fdctx = fdctx;
     gf_uuid_copy(local->loc.gfid, fdctx->gfid);
     ret = loc_path(&local->loc, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     frame->local = local;
@@ -706,7 +706,7 @@ client_setvolume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ctx = this->ctx;
     GF_VALIDATE_OR_GOTO(this->name, ctx, out);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, ENOTCONN,
                 PC_MSG_RPC_STATUS_ERROR, NULL);
         op_ret = -1;
@@ -714,7 +714,7 @@ client_setvolume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_setvolume_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         op_ret = -1;
@@ -722,7 +722,7 @@ client_setvolume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     op_ret = rsp.op_ret;
     op_errno = gf_error_to_errno(rsp.op_errno);
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, op_errno,
                 PC_MSG_VOL_SET_FAIL, NULL);
     }
@@ -733,7 +733,7 @@ client_setvolume_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     if (rsp.dict.dict_len) {
         ret = dict_unserialize(rsp.dict.dict_val, rsp.dict.dict_len, &reply);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_smsg(frame->this->name, GF_LOG_WARNING, 0,
                     PC_MSG_DICT_UNSERIALIZE_FAIL, NULL);
             goto out;
@@ -741,18 +741,18 @@ client_setvolume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = dict_get_str_sizen(reply, "ERROR", &remote_error);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, EINVAL, PC_MSG_DICT_GET_FAILED,
                 "ERROR string", NULL);
     }
 
     ret = dict_get_str_sizen(reply, "process-uuid", &process_uuid);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, EINVAL, PC_MSG_DICT_GET_FAILED,
                 "process-uuid", NULL);
     }
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, PC_MSG_SETVOLUME_FAIL,
                 "remote-error=%s", remote_error, NULL);
 
@@ -788,7 +788,7 @@ client_setvolume_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = dict_get_str_sizen(reply, "volume-id", &volume_id);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /* this can happen if the server is of old version, so treat it as
            just debug message */
         gf_msg_debug(this->name, EINVAL,
@@ -870,7 +870,7 @@ out:
         conf->connected = 0;
         ret = -1;
     }
-    if (-1 == op_ret) {
+    if (IS_ERROR(op_ret)) {
         /* Let the connection/re-connection happen in
          * background, for now, don't hang here,
          * tell the parents that i am all ok..
@@ -921,7 +921,7 @@ client_setvolume(xlator_t *this, struct rpc_clnt *rpc)
     if (conf->fops) {
         ret = dict_set_int32_sizen(options, "fops-version",
                                    conf->fops->prognum);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_smsg(this->name, GF_LOG_ERROR, 0, PC_MSG_DICT_SET_FAILED,
                     "version-fops=%d", conf->fops->prognum, NULL);
             goto fail;
@@ -931,7 +931,7 @@ client_setvolume(xlator_t *this, struct rpc_clnt *rpc)
     if (conf->mgmt) {
         ret = dict_set_int32_sizen(options, "mgmt-version",
                                    conf->mgmt->prognum);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_smsg(this->name, GF_LOG_ERROR, 0, PC_MSG_DICT_SET_FAILED,
                     "version-mgmt=%d", conf->mgmt->prognum, NULL);
             goto fail;
@@ -948,7 +948,7 @@ client_setvolume(xlator_t *this, struct rpc_clnt *rpc)
     snprintf(counter_str, sizeof(counter_str), "-%" PRIu64, conf->setvol_count);
     conf->setvol_count++;
 
-    if (gethostname(hostname, 256) == -1) {
+    if (IS_ERROR(gethostname(hostname, 256))) {
         gf_smsg(this->name, GF_LOG_ERROR, errno, PC_MSG_GETHOSTNAME_FAILED,
                 NULL);
 
@@ -958,14 +958,14 @@ client_setvolume(xlator_t *this, struct rpc_clnt *rpc)
     ret = gf_asprintf(&process_uuid_xl, GLUSTER_PROCESS_UUID_FMT,
                       this->ctx->process_uuid, this->graph->id, getpid(),
                       hostname, this->name, counter_str);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PC_MSG_PROCESS_UUID_SET_FAIL,
                 NULL);
         goto fail;
     }
 
     ret = dict_set_dynstr_sizen(options, "process-uuid", process_uuid_xl);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PC_MSG_DICT_SET_FAILED,
                 "process-uuid=%s", process_uuid_xl, NULL);
         goto fail;
@@ -974,14 +974,14 @@ client_setvolume(xlator_t *this, struct rpc_clnt *rpc)
     if (this->ctx->cmd_args.process_name) {
         ret = dict_set_str_sizen(options, "process-name",
                                  this->ctx->cmd_args.process_name);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_smsg(this->name, GF_LOG_INFO, 0, PC_MSG_DICT_SET_FAILED,
                     "process-name", NULL);
         }
     }
 
     ret = dict_set_str_sizen(options, "client-version", PACKAGE_VERSION);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, 0, PC_MSG_DICT_SET_FAILED,
                 "client-version=%s", PACKAGE_VERSION, NULL);
     }
@@ -1003,7 +1003,7 @@ client_setvolume(xlator_t *this, struct rpc_clnt *rpc)
         }
         if (this->ctx->volume_id[0]) {
             ret = dict_set_str(options, "volume-id", this->ctx->volume_id);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_smsg(this->name, GF_LOG_INFO, 0, PC_MSG_DICT_SET_FAILED,
                         "volume-id", NULL);
             }
@@ -1040,13 +1040,13 @@ client_setvolume(xlator_t *this, struct rpc_clnt *rpc)
      * clnt-lk-version with new clients.
      */
     ret = dict_set_uint32(options, "clnt-lk-version", 1);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, 0, PC_MSG_DICT_SET_FAILED,
                 "clnt-lk-version(1)", NULL);
     }
 
     ret = dict_set_int32_sizen(options, "opversion", GD_OP_VERSION_MAX);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PC_MSG_DICT_SET_FAILED,
                 "client opversion", NULL);
     }
@@ -1182,20 +1182,20 @@ client_query_portmap_cbk(struct rpc_req *req, struct iovec *iov, int count,
     this = frame->this;
     conf = frame->this->private;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_smsg(this->name, GF_LOG_WARNING, ENOTCONN, PC_MSG_RPC_STATUS_ERROR,
                 NULL);
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_pmap_port_by_brick_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         goto out;
     }
 
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         ret = -1;
         if (!conf->portmap_err_logged) {
             gf_smsg(this->name, GF_LOG_ERROR, 0, PC_MSG_PORT_NUM_ERROR, NULL);
@@ -1249,7 +1249,7 @@ client_query_portmap(xlator_t *this, struct rpc_clnt *rpc)
     options = this->options;
 
     ret = dict_get_str_sizen(options, "remote-subvolume", &remote_subvol);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PC_MSG_REMOTE_SUBVOL_SET_FAIL,
                 NULL);
         goto fail;
@@ -1294,19 +1294,19 @@ client_dump_version_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     conf = frame->this->private;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, ENOTCONN,
                 PC_MSG_RPC_STATUS_ERROR, NULL);
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_dump_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(frame->this->name, GF_LOG_ERROR, EINVAL,
                 PC_MSG_XDR_DECODING_FAILED, NULL);
         goto out;
     }
-    if (-1 == rsp.op_ret) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(frame->this->name, GF_LOG_WARNING, 0, PC_MSG_VERSION_ERROR,
                 NULL);
         goto out;

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -89,7 +89,7 @@ this_fd_set_ctx(fd_t *file, xlator_t *this, loc_t *loc, clnt_fd_ctx_t *ctx)
     GF_VALIDATE_OR_GOTO(this->name, file, out);
 
     ret = fd_ctx_get(file, this, &oldaddr);
-    if (ret >= 0) {
+    if (IS_SUCCESS(ret)) {
         if (loc)
             gf_smsg(this->name, GF_LOG_INFO, 0, PC_MSG_FD_DUPLICATE_TRY,
                     "path=%s", loc->path, "gfid=%s",

--- a/xlators/protocol/client/src/client-helpers.c
+++ b/xlators/protocol/client/src/client-helpers.c
@@ -52,7 +52,7 @@ this_fd_del_ctx(fd_t *file, xlator_t *this)
 
     dict_ret = fd_ctx_del(file, this, &ctxaddr);
 
-    if (dict_ret < 0) {
+    if (IS_ERROR(dict_ret)) {
         ctxaddr = 0;
     }
 
@@ -71,7 +71,7 @@ this_fd_get_ctx(fd_t *file, xlator_t *this)
 
     dict_ret = fd_ctx_get(file, this, &ctxaddr);
 
-    if (dict_ret < 0) {
+    if (IS_ERROR(dict_ret)) {
         ctxaddr = 0;
     }
 
@@ -100,7 +100,7 @@ this_fd_set_ctx(fd_t *file, xlator_t *this, loc_t *loc, clnt_fd_ctx_t *ctx)
     }
 
     ret = fd_ctx_set(file, this, (uint64_t)(unsigned long)ctx);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         if (loc)
             gf_smsg(this->name, GF_LOG_WARNING, 0, PC_MSG_FD_SET_FAIL,
                     "path=%s", loc->path, "gfid=%s",
@@ -212,7 +212,7 @@ unserialize_rsp_direntp(xlator_t *this, fd_t *fd, struct gfs3_readdirp_rsp *rsp,
 
             ret = dict_unserialize(trav->dict.dict_val, trav->dict.dict_len,
                                    &entry->dict);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_smsg(THIS->name, GF_LOG_WARNING, EINVAL,
                         PC_MSG_DICT_UNSERIALIZE_FAIL, "xattr", NULL);
                 goto out;
@@ -432,7 +432,7 @@ client_get_remote_fd(xlator_t *this, fd_t *fd, int flags, int64_t *remote_fd)
     }
     pthread_spin_unlock(&conf->fd_lock);
 
-    if ((flags & FALLBACK_TO_ANON_FD) && (*remote_fd == -1) && (!locks_held))
+    if ((flags & FALLBACK_TO_ANON_FD) && IS_ERROR(*remote_fd) && (!locks_held))
         *remote_fd = GF_ANON_FD_NO;
 
     return 0;
@@ -451,7 +451,7 @@ client_is_reopen_needed(fd_t *fd, xlator_t *this, int64_t remote_fd)
     pthread_spin_lock(&conf->fd_lock);
     {
         fdctx = this_fd_get_ctx(fd, this);
-        if (fdctx && (fdctx->remote_fd == -1) && (remote_fd == GF_ANON_FD_NO))
+        if (fdctx && IS_ERROR(fdctx->remote_fd) && (remote_fd == GF_ANON_FD_NO))
             res = _gf_true;
     }
     pthread_spin_unlock(&conf->fd_lock);
@@ -855,7 +855,7 @@ client_fdctx_destroy(xlator_t *this, clnt_fd_ctx_t *fdctx)
 
     conf = (clnt_conf_t *)this->private;
 
-    if (fdctx->remote_fd == -1) {
+    if (IS_ERROR(fdctx->remote_fd)) {
         gf_msg_debug(this->name, 0, "not a valid fd");
         goto out;
     }

--- a/xlators/protocol/client/src/client-rpc-fops.c
+++ b/xlators/protocol/client/src/client-rpc-fops.c
@@ -63,13 +63,13 @@ client3_3_symlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
     inode = local->loc.inode;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_symlink_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -81,7 +81,7 @@ client3_3_symlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
                               &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
             /* no need to print the gfid, because it will be null,
              * since symlink operation failed.
@@ -135,13 +135,13 @@ client3_3_mknod_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     inode = local->loc.inode;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_mknod_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -153,7 +153,7 @@ client3_3_mknod_cbk(struct rpc_req *req, struct iovec *iov, int count,
                             &xdata);
 
 out:
-    if (rsp.op_ret == -1 &&
+    if (IS_ERROR(rsp.op_ret) &&
         GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_MKNOD, gf_error_to_errno(rsp.op_errno)),
@@ -203,13 +203,13 @@ client3_3_mkdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
     inode = local->loc.inode;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_mkdir_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -221,7 +221,7 @@ client3_3_mkdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
                             &xdata);
 
 out:
-    if (rsp.op_ret == -1 &&
+    if (IS_ERROR(rsp.op_ret) &&
         GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_MKDIR, gf_error_to_errno(rsp.op_errno)),
@@ -333,13 +333,13 @@ client3_3_open_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     fd = local->fd;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_open_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -359,7 +359,7 @@ client3_3_open_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_open(this, &rsp, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_OPEN, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
@@ -397,13 +397,13 @@ client3_3_stat_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_stat_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -413,7 +413,7 @@ client3_3_stat_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_stat(this, &rsp, &iatt, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         /* stale filehandles are possible during normal operations, no
          * need to spam the logs with these */
         if (rsp.op_errno == ESTALE) {
@@ -455,13 +455,13 @@ client3_3_readlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_readlink_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -472,7 +472,7 @@ client3_3_readlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_readlink(this, &rsp, &iatt, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (gf_error_to_errno(rsp.op_errno) == ENOENT) {
             gf_msg_debug(this->name, 0,
                          "remote operation failed:"
@@ -522,13 +522,13 @@ client3_3_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_unlink_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -539,7 +539,7 @@ client3_3_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_unlink(this, &rsp, &preparent, &postparent, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (gf_error_to_errno(rsp.op_errno) == ENOENT) {
             gf_msg_debug(this->name, 0,
                          "remote operation failed:"
@@ -585,13 +585,13 @@ client3_3_rmdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_rmdir_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -602,7 +602,7 @@ client3_3_rmdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_rmdir(this, &rsp, &preparent, &postparent, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
             gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -642,13 +642,13 @@ client3_3_truncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_truncate_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -659,7 +659,7 @@ client3_3_truncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_truncate(this, &rsp, &prestat, &poststat, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -694,13 +694,13 @@ client3_3_statfs_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_statfs_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -711,7 +711,7 @@ client3_3_statfs_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_statfs(this, &rsp, &statfs, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -750,14 +750,14 @@ client3_3_writev_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_write_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -766,10 +766,10 @@ client3_3_writev_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = client_post_writev(this, &rsp, &prestat, &poststat, &xdata);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     } else if (rsp.op_ret >= 0) {
@@ -806,13 +806,13 @@ client3_3_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
     this = THIS;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -831,7 +831,7 @@ client3_3_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_flush(this, &rsp, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_FLUSH, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -869,14 +869,14 @@ client3_3_fsync_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_fsync_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -885,11 +885,11 @@ client3_3_fsync_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = client_post_fsync(this, &rsp, &prestat, &poststat, &xdata);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -922,14 +922,14 @@ client3_3_setxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -938,12 +938,12 @@ client3_3_setxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = client_post_setxattr(this, &rsp, &xdata);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
 out:
     op_errno = gf_error_to_errno(rsp.op_errno);
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (op_errno == ENOTSUP) {
             gf_msg_debug(this->name, 0,
                          "remote operation failed:"
@@ -985,14 +985,14 @@ client3_3_getxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_getxattr_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1008,7 +1008,7 @@ client3_3_getxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if ((op_errno == ENOTSUP) || (op_errno == ENODATA) ||
             (op_errno == ESTALE) || (op_errno == ENOENT)) {
             gf_msg_debug(this->name, 0,
@@ -1059,13 +1059,13 @@ client3_3_fgetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_fgetxattr_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1080,7 +1080,7 @@ client3_3_fgetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if ((op_errno == ENOTSUP) || (op_errno == ERANGE) ||
             (op_errno == ENODATA) || (op_errno == ENOENT)) {
             gf_msg_debug(this->name, 0, "remote operation failed: %s",
@@ -1123,14 +1123,14 @@ client3_3_removexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1140,7 +1140,7 @@ client3_3_removexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_removexattr(this, &rsp, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         /* EPERM/EACCESS is returned some times in case of selinux
            attributes, or other system attributes which may not be
            possible to remove from an user process is encountered.
@@ -1182,14 +1182,14 @@ client3_3_fremovexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1199,7 +1199,7 @@ client3_3_fremovexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_fremovexattr(this, &rsp, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1230,13 +1230,13 @@ client3_3_fsyncdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1247,7 +1247,7 @@ client3_3_fsyncdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_fsyncdir(this, &rsp, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1278,13 +1278,13 @@ client3_3_access_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1295,7 +1295,7 @@ client3_3_access_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_access(this, &rsp, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1332,13 +1332,13 @@ client3_3_ftruncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_ftruncate_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1349,7 +1349,7 @@ client3_3_ftruncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_ftruncate(this, &rsp, &prestat, &poststat, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1384,13 +1384,13 @@ client3_3_fstat_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_fstat_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1401,7 +1401,7 @@ client3_3_fstat_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_fstat(this, &rsp, &stat, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1432,13 +1432,13 @@ client3_3_inodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1448,7 +1448,7 @@ client3_3_inodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_inodelk(this, &rsp, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_INODELK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -1481,13 +1481,13 @@ client3_3_finodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     this = frame->this;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1497,7 +1497,7 @@ client3_3_finodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_finodelk(this, &rsp, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_FINODELK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -1532,13 +1532,13 @@ client3_3_entrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1548,7 +1548,7 @@ client3_3_entrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_entrylk(this, &rsp, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_ENTRYLK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -1581,13 +1581,13 @@ client3_3_fentrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1598,7 +1598,7 @@ client3_3_fentrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_fentrylk(this, &rsp, &xdata);
 
 out:
-    if ((rsp.op_ret == -1) && (EAGAIN != gf_error_to_errno(rsp.op_errno))) {
+    if (IS_ERROR((rsp.op_ret)) && (EAGAIN != gf_error_to_errno(rsp.op_errno))) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1634,13 +1634,13 @@ client3_3_xattrop_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_xattrop_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1655,7 +1655,7 @@ client3_3_xattrop_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_XATTROP, op_errno),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
                 "Path=%s", local->loc.path, "gfid=%s",
@@ -1698,14 +1698,14 @@ client3_3_fxattrop_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_fxattrop_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         rsp.op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
@@ -1721,7 +1721,7 @@ client3_3_fxattrop_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 out:
 
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     } else if (rsp.op_ret == 0) {
@@ -1761,13 +1761,13 @@ client3_3_fsetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gf_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1779,7 +1779,7 @@ client3_3_fsetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     op_errno = gf_error_to_errno(rsp.op_errno);
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (op_errno == ENOTSUP) {
             gf_msg_debug(this->name, 0,
                          "remote operation failed:"
@@ -1823,13 +1823,13 @@ client3_3_fsetattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_fsetattr_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1839,7 +1839,7 @@ client3_3_fsetattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_fsetattr(this, &rsp, &prestat, &poststat, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1877,13 +1877,13 @@ client3_3_fallocate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_fallocate_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1892,14 +1892,14 @@ client3_3_fallocate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = client_post_fallocate(this, &rsp, &prestat, &poststat, &xdata);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
     GF_PROTOCOL_DICT_UNSERIALIZE(this, xdata, (rsp.xdata.xdata_val),
                                  (rsp.xdata.xdata_len), ret, rsp.op_errno, out);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1937,13 +1937,13 @@ client3_3_discard_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_discard_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1954,7 +1954,7 @@ client3_3_discard_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_discard(this, &rsp, &prestat, &poststat, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1992,13 +1992,13 @@ client3_3_zerofill_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_zerofill_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2008,7 +2008,7 @@ client3_3_zerofill_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_zerofill(this, &rsp, &prestat, &poststat, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2040,13 +2040,13 @@ client3_3_ipc_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_ipc_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2056,7 +2056,7 @@ client3_3_ipc_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_ipc(this, &rsp, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2087,13 +2087,13 @@ client3_3_seek_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_seek_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2104,7 +2104,7 @@ client3_3_seek_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_seek(this, &rsp, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2141,14 +2141,14 @@ client3_3_setattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_setattr_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2159,7 +2159,7 @@ client3_3_setattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_setattr(this, &rsp, &prestat, &poststat, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2206,14 +2206,14 @@ client3_3_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
     fd = local->fd;
     inode = local->loc.inode;
 
-    if (-1 == req->rpc_status) {
+    if (0 > req->rpc_status) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_create_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2221,10 +2221,10 @@ client3_3_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (-1 != rsp.op_ret) {
+    if (rsp.op_ret >= 0) {
         ret = client_post_create(this, &rsp, &stbuf, &preparent, &postparent,
                                  local, &xdata);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
         ret = client_add_fd_to_saved_fds(frame->this, fd, &local->loc,
                                          local->flags, rsp.fd, 0);
@@ -2236,7 +2236,7 @@ client3_3_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, "Path=%s", local->loc.path, NULL);
     }
@@ -2269,14 +2269,14 @@ client3_3_rchecksum_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_rchecksum_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2287,7 +2287,7 @@ client3_3_rchecksum_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_rchecksum(this, &rsp, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2329,7 +2329,7 @@ client3_3_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_smsg(this->name, GF_LOG_ERROR, ENOTCONN, PC_MSG_LEASE_FOP_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2338,7 +2338,7 @@ client3_3_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_lease_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2349,7 +2349,7 @@ client3_3_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_lease(this, &rsp, &lease, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2386,14 +2386,14 @@ client3_3_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_lk_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2403,7 +2403,7 @@ client3_3_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     if (rsp.op_ret >= 0) {
         ret = client_post_lk(this, &rsp, &lock, &xdata);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         /* Save the lock to the client lock cache to be able
@@ -2412,7 +2412,7 @@ client3_3_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
         if (client_is_setlk(local->cmd)) {
             ret = client_add_lock_for_recovery(local->fd, &lock, &local->owner,
                                                local->cmd);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 rsp.op_ret = -1;
                 rsp.op_errno = -ret;
             }
@@ -2420,7 +2420,7 @@ client3_3_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
 out:
-    if ((rsp.op_ret == -1) && (EAGAIN != gf_error_to_errno(rsp.op_errno))) {
+    if (IS_ERROR((rsp.op_ret)) && (EAGAIN != gf_error_to_errno(rsp.op_errno))) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2459,14 +2459,14 @@ client3_3_readdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     INIT_LIST_HEAD(&entries.list);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_readdir_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2477,14 +2477,14 @@ client3_3_readdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_readdir(this, &rsp, &entries, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, "remote_fd=%d", local->cmd, NULL);
     }
     CLIENT_STACK_UNWIND(readdir, frame, rsp.op_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
-    if (rsp.op_ret != -1) {
+    if (rsp.op_ret >= 0) {
         gf_dirent_free(&entries);
     }
 
@@ -2519,14 +2519,14 @@ client3_3_readdirp_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     INIT_LIST_HEAD(&entries.list);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_readdirp_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2536,14 +2536,14 @@ client3_3_readdirp_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_readdirp(this, &rsp, local->fd, &entries, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(readdirp, frame, rsp.op_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
-    if (rsp.op_ret != -1) {
+    if (rsp.op_ret >= 0) {
         gf_dirent_free(&entries);
     }
     free(rsp.xdata.xdata_val);
@@ -2587,14 +2587,14 @@ client3_3_rename_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_rename_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2606,7 +2606,7 @@ client3_3_rename_cbk(struct rpc_req *req, struct iovec *iov, int count,
                              &prenewparent, &postnewparent, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2652,14 +2652,14 @@ client3_3_link_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
     inode = local->loc.inode;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_link_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2669,7 +2669,7 @@ client3_3_link_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_link(this, &rsp, &stbuf, &preparent, &postparent, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
             gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, "loc1=%s", local->loc.path,
@@ -2710,14 +2710,14 @@ client3_3_opendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     fd = local->fd;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_opendir_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2737,7 +2737,7 @@ client3_3_opendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_opendir(this, &rsp, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_OPENDIR, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
@@ -2782,14 +2782,14 @@ client3_3_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
     inode = local->loc.inode;
 
-    if (-1 == req->rpc_status) {
+    if (0 > req->rpc_status) {
         rsp.op_ret = -1;
         op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_lookup_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2801,7 +2801,7 @@ client3_3_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
     op_errno = gf_error_to_errno(rsp.op_errno);
 
     ret = client_post_lookup(this, &rsp, &stbuf, &postparent, &xdata);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /* Don't change the op_errno if the fop failed on server */
         if (rsp.op_ret == 0)
             op_errno = rsp.op_errno;
@@ -2809,7 +2809,7 @@ client3_3_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (rsp.op_ret < 0)
+    if (IS_ERROR(rsp.op_ret))
         goto out;
 
     if ((!gf_uuid_is_null(inode->gfid)) &&
@@ -2830,7 +2830,7 @@ client3_3_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     /* Restore the correct op_errno to rsp.op_errno */
     rsp.op_errno = op_errno;
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         /* any error other than ENOENT */
         if (!(local->loc.name && rsp.op_errno == ENOENT) &&
             !(rsp.op_errno == ESTALE))
@@ -2879,14 +2879,14 @@ client3_3_readv_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_read_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2899,7 +2899,7 @@ client3_3_readv_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_readv(this, &rsp, &iobref, req->rsp_iobref, &stat, vector,
                             &req->rsp[1], &rspcount, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     } else if (rsp.op_ret >= 0) {
@@ -2956,14 +2956,14 @@ client3_3_getactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_getactivelk_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2981,7 +2981,7 @@ client3_3_getactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
                                  (rsp.xdata.xdata_len), ret, rsp.op_errno, out);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -3015,14 +3015,14 @@ client3_3_setactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfs3_setactivelk_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -3034,7 +3034,7 @@ client3_3_setactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
                                  (rsp.xdata.xdata_len), ret, rsp.op_errno, out);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -3076,7 +3076,7 @@ client3_3_releasedir(call_frame_t *frame, xlator_t *this, void *data)
                reopen_cbk handle releasing
             */
 
-            if (remote_fd == -1) {
+            if (IS_ERROR(remote_fd)) {
                 fdctx->released = 1;
             } else {
                 list_del_init(&fdctx->sfd_pos);
@@ -3119,7 +3119,7 @@ client3_3_release(call_frame_t *frame, xlator_t *this, void *data)
                in progress. Just mark ->released = 1 and let
                reopen_cbk handle releasing
             */
-            if (remote_fd == -1) {
+            if (IS_ERROR(remote_fd)) {
                 fdctx->released = 1;
             } else {
                 list_del_init(&fdctx->sfd_pos);
@@ -5031,7 +5031,7 @@ client3_3_lease(call_frame_t *frame, xlator_t *this, void *data)
     conf = this->private;
 
     ret = client_pre_lease(this, &req, args->loc, args->lease, args->xdata);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto unwind;
     }

--- a/xlators/protocol/client/src/client-rpc-fops.c
+++ b/xlators/protocol/client/src/client-rpc-fops.c
@@ -772,7 +772,7 @@ out:
     if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
-    } else if (rsp.op_ret >= 0) {
+    } else if (IS_SUCCESS(rsp.op_ret)) {
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
@@ -820,7 +820,7 @@ client3_3_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if ((rsp.op_ret >= 0 || (rsp.op_errno == ENOTCONN)) &&
+    if (IS_SUCCESS((rsp.op_ret) || (rsp.op_errno == ENOTCONN)) &&
         !fd_is_anonymous(local->fd)) {
         /* Delete all saved locks of the owner issuing flush */
         ret = delete_granted_locks_owner(local->fd, &local->owner);
@@ -2221,7 +2221,7 @@ client3_3_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (rsp.op_ret >= 0) {
+    if (IS_SUCCESS(rsp.op_ret)) {
         ret = client_post_create(this, &rsp, &stbuf, &preparent, &postparent,
                                  local, &xdata);
         if (IS_ERROR(ret))
@@ -2401,7 +2401,7 @@ client3_3_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (rsp.op_ret >= 0) {
+    if (IS_SUCCESS(rsp.op_ret)) {
         ret = client_post_lk(this, &rsp, &lock, &xdata);
         if (IS_ERROR(ret))
             goto out;
@@ -2484,7 +2484,7 @@ out:
     CLIENT_STACK_UNWIND(readdir, frame, rsp.op_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
-    if (rsp.op_ret >= 0) {
+    if (IS_SUCCESS(rsp.op_ret)) {
         gf_dirent_free(&entries);
     }
 
@@ -2543,7 +2543,7 @@ out:
     CLIENT_STACK_UNWIND(readdirp, frame, rsp.op_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
-    if (rsp.op_ret >= 0) {
+    if (IS_SUCCESS(rsp.op_ret)) {
         gf_dirent_free(&entries);
     }
     free(rsp.xdata.xdata_val);
@@ -2902,7 +2902,7 @@ out:
     if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
-    } else if (rsp.op_ret >= 0) {
+    } else if (IS_SUCCESS(rsp.op_ret)) {
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }

--- a/xlators/protocol/client/src/client-rpc-fops.c
+++ b/xlators/protocol/client/src/client-rpc-fops.c
@@ -820,7 +820,7 @@ client3_3_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (IS_SUCCESS((rsp.op_ret) || (rsp.op_errno == ENOTCONN)) &&
+    if ((IS_SUCCESS(rsp.op_ret) || (rsp.op_errno == ENOTCONN)) &&
         !fd_is_anonymous(local->fd)) {
         /* Delete all saved locks of the owner issuing flush */
         ret = delete_granted_locks_owner(local->fd, &local->owner);

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -52,13 +52,13 @@ client4_0_symlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
     inode = local->loc.inode;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -70,7 +70,7 @@ client4_0_symlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
                                    &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
             /* no need to print the gfid, because it will be null,
              * since symlink operation failed.
@@ -122,13 +122,13 @@ client4_0_mknod_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     inode = local->loc.inode;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -140,7 +140,7 @@ client4_0_mknod_cbk(struct rpc_req *req, struct iovec *iov, int count,
                                    &xdata);
 
 out:
-    if (rsp.op_ret == -1 &&
+    if (IS_ERROR(rsp.op_ret) &&
         GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_MKNOD, gf_error_to_errno(rsp.op_errno)),
@@ -188,13 +188,13 @@ client4_0_mkdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
     inode = local->loc.inode;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -206,7 +206,7 @@ client4_0_mkdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
                                    &xdata);
 
 out:
-    if (rsp.op_ret == -1 &&
+    if (IS_ERROR(rsp.op_ret) &&
         GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_MKDIR, gf_error_to_errno(rsp.op_errno)),
@@ -245,13 +245,13 @@ client4_0_open_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     fd = local->fd;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_open_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -271,7 +271,7 @@ client4_0_open_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_OPEN, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
@@ -307,13 +307,13 @@ client4_0_stat_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -323,7 +323,7 @@ client4_0_stat_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_common_iatt(this, &rsp, &iatt, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         /* stale filehandles are possible during normal operations, no
          * need to spam the logs with these */
         if (rsp.op_errno == ESTALE) {
@@ -363,13 +363,13 @@ client4_0_readlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_readlink_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -380,7 +380,7 @@ client4_0_readlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (gf_error_to_errno(rsp.op_errno) == ENOENT) {
             gf_msg_debug(this->name, 0,
                          "remote operation failed:"
@@ -428,13 +428,13 @@ client4_0_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -445,7 +445,7 @@ client4_0_unlink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_common_2iatt(this, &rsp, &preparent, &postparent, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (gf_error_to_errno(rsp.op_errno) == ENOENT) {
             gf_msg_debug(this->name, 0,
                          "remote operation failed:"
@@ -489,13 +489,13 @@ client4_0_rmdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -506,7 +506,7 @@ client4_0_rmdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_common_2iatt(this, &rsp, &preparent, &postparent, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
             gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -544,13 +544,13 @@ client4_0_truncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -561,7 +561,7 @@ client4_0_truncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -594,13 +594,13 @@ client4_0_statfs_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_statfs_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -613,7 +613,7 @@ client4_0_statfs_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
     ret = xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -650,14 +650,14 @@ client4_0_writev_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -666,10 +666,10 @@ client4_0_writev_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     } else if (rsp.op_ret >= 0) {
@@ -703,13 +703,13 @@ client4_0_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
     this = THIS;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -728,7 +728,7 @@ client4_0_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_FLUSH, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -764,14 +764,14 @@ client4_0_fsync_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -780,11 +780,11 @@ client4_0_fsync_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -814,14 +814,14 @@ client4_0_setxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -832,7 +832,7 @@ client4_0_setxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
     op_errno = gf_error_to_errno(rsp.op_errno);
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (op_errno == ENOTSUP) {
             gf_msg_debug(this->name, 0,
                          "remote operation failed:"
@@ -872,14 +872,14 @@ client4_0_getxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_dict_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -895,7 +895,7 @@ client4_0_getxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if ((op_errno == ENOTSUP) || (op_errno == ENODATA) ||
             (op_errno == ESTALE) || (op_errno == ENOENT)) {
             gf_msg_debug(this->name, 0,
@@ -947,13 +947,13 @@ client4_0_fgetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_dict_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -968,7 +968,7 @@ client4_0_fgetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if ((op_errno == ENOTSUP) || (op_errno == ERANGE) ||
             (op_errno == ENODATA) || (op_errno == ENOENT)) {
             gf_msg_debug(this->name, 0, "remote operation failed: %s",
@@ -1013,14 +1013,14 @@ client4_0_removexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1030,7 +1030,7 @@ client4_0_removexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         /* EPERM/EACCESS is returned some times in case of selinux
            attributes, or other system attributes which may not be
            possible to remove from an user process is encountered.
@@ -1070,14 +1070,14 @@ client4_0_fremovexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1087,7 +1087,7 @@ client4_0_fremovexattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1116,13 +1116,13 @@ client4_0_fsyncdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1133,7 +1133,7 @@ client4_0_fsyncdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1162,13 +1162,13 @@ client4_0_access_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1179,7 +1179,7 @@ client4_0_access_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1214,13 +1214,13 @@ client4_0_ftruncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1231,7 +1231,7 @@ client4_0_ftruncate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1264,13 +1264,13 @@ client4_0_fstat_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1281,7 +1281,7 @@ client4_0_fstat_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_common_iatt(this, &rsp, &stat, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1310,13 +1310,13 @@ client4_0_inodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1326,7 +1326,7 @@ client4_0_inodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_INODELK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -1357,13 +1357,13 @@ client4_0_finodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     this = frame->this;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1373,7 +1373,7 @@ client4_0_finodelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_FINODELK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -1406,13 +1406,13 @@ client4_0_entrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1422,7 +1422,7 @@ client4_0_entrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_ENTRYLK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
@@ -1453,13 +1453,13 @@ client4_0_fentrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1470,7 +1470,7 @@ client4_0_fentrylk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 
 out:
-    if ((rsp.op_ret == -1) && (EAGAIN != gf_error_to_errno(rsp.op_errno))) {
+    if (IS_ERROR((rsp.op_ret)) && (EAGAIN != gf_error_to_errno(rsp.op_errno))) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1504,13 +1504,13 @@ client4_0_xattrop_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_dict_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1525,7 +1525,7 @@ client4_0_xattrop_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_XATTROP, op_errno),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
                 "Path=%s", local->loc.path, "gfid=%s",
@@ -1570,14 +1570,14 @@ client4_0_fxattrop_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_dict_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         rsp.op_ret = -1;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
@@ -1593,7 +1593,7 @@ client4_0_fxattrop_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 out:
 
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     } else {
@@ -1635,13 +1635,13 @@ client4_0_fsetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1653,7 +1653,7 @@ client4_0_fsetxattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
 out:
     op_errno = gf_error_to_errno(rsp.op_errno);
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (op_errno == ENOTSUP) {
             gf_msg_debug(this->name, 0,
                          "remote operation failed:"
@@ -1695,13 +1695,13 @@ client4_0_fallocate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1710,11 +1710,11 @@ client4_0_fallocate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1750,13 +1750,13 @@ client4_0_discard_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1767,7 +1767,7 @@ client4_0_discard_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1802,13 +1802,13 @@ client4_0_zerofill_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1818,7 +1818,7 @@ client4_0_zerofill_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1848,13 +1848,13 @@ client4_0_ipc_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1864,7 +1864,7 @@ client4_0_ipc_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1893,13 +1893,13 @@ client4_0_seek_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_seek_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1909,7 +1909,7 @@ client4_0_seek_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1944,14 +1944,14 @@ client4_0_setattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -1962,7 +1962,7 @@ client4_0_setattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -1998,14 +1998,14 @@ client4_0_fsetattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2016,7 +2016,7 @@ client4_0_fsetattr_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_common_2iatt(this, &rsp, &prestat, &poststat, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2061,14 +2061,14 @@ client4_0_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
     fd = local->fd;
     inode = local->loc.inode;
 
-    if (-1 == req->rpc_status) {
+    if (0 > req->rpc_status) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_create_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2078,10 +2078,10 @@ client4_0_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_create_v2(this, &rsp, &stbuf, &preparent, &postparent,
                                 local, &xdata);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
-    if (-1 != rsp.op_ret) {
+    if (rsp.op_ret >= 0) {
         ret = client_add_fd_to_saved_fds(frame->this, fd, &local->loc,
                                          local->flags, rsp.fd, 0);
         if (ret) {
@@ -2092,7 +2092,7 @@ client4_0_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, "path=%s", local->loc.path, NULL);
     }
@@ -2126,7 +2126,7 @@ client4_0_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         gf_smsg(this->name, GF_LOG_ERROR, ENOTCONN, PC_MSG_REMOTE_OP_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2135,7 +2135,7 @@ client4_0_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_lease_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2146,7 +2146,7 @@ client4_0_lease_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_lease_v2(this, &rsp, &lease, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2181,14 +2181,14 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_lk_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2198,7 +2198,7 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     if (rsp.op_ret >= 0) {
         ret = client_post_lk_v2(this, &rsp, &lock, &xdata);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
 
         /* Save the lock to the client lock cache to be able
@@ -2207,7 +2207,7 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
         if (client_is_setlk(local->cmd)) {
             ret = client_add_lock_for_recovery(local->fd, &lock, &local->owner,
                                                local->cmd);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 rsp.op_ret = -1;
                 rsp.op_errno = -ret;
             }
@@ -2215,7 +2215,7 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     }
 
 out:
-    if ((rsp.op_ret == -1) && (EAGAIN != gf_error_to_errno(rsp.op_errno))) {
+    if (IS_ERROR((rsp.op_ret)) && (EAGAIN != gf_error_to_errno(rsp.op_errno))) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2252,14 +2252,14 @@ client4_0_readdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     INIT_LIST_HEAD(&entries.list);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_readdir_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2270,14 +2270,14 @@ client4_0_readdir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_readdir_v2(this, &rsp, &entries, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, "remote_fd=%d", local->cmd, NULL);
     }
     CLIENT_STACK_UNWIND(readdir, frame, rsp.op_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
-    if (rsp.op_ret != -1) {
+    if (rsp.op_ret >= 0) {
         gf_dirent_free(&entries);
     }
 
@@ -2310,14 +2310,14 @@ client4_0_readdirp_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     INIT_LIST_HEAD(&entries.list);
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_readdirp_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2327,14 +2327,14 @@ client4_0_readdirp_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_readdirp_v2(this, &rsp, local->fd, &entries, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
     CLIENT_STACK_UNWIND(readdirp, frame, rsp.op_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
-    if (rsp.op_ret != -1) {
+    if (rsp.op_ret >= 0) {
         gf_dirent_free(&entries);
     }
 
@@ -2377,14 +2377,14 @@ client4_0_rename_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_rename_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2395,7 +2395,7 @@ client4_0_rename_cbk(struct rpc_req *req, struct iovec *iov, int count,
     client_post_rename_v2(this, &rsp, &stbuf, &preoldparent, &postoldparent,
                           &prenewparent, &postnewparent, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2439,14 +2439,14 @@ client4_0_link_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
     inode = local->loc.inode;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2457,7 +2457,7 @@ client4_0_link_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_common_3iatt(this, &rsp, &stbuf, &preparent, &postparent,
                                    &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         if (GF_IGNORE_IF_GSYNCD_SAFE_ERROR(frame, rsp.op_errno)) {
             gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                     PC_MSG_REMOTE_OP_FAILED, "source=%s", local->loc.path,
@@ -2496,7 +2496,7 @@ client4_0_opendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     fd = local->fd;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
@@ -2505,7 +2505,7 @@ client4_0_opendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
     /* open and opendir are two operations dealing with same thing,
        but separated by fop number only */
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_open_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2525,7 +2525,7 @@ client4_0_opendir_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name,
                 fop_log_level(GF_FOP_OPENDIR, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED,
@@ -2568,14 +2568,14 @@ client4_0_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
     inode = local->loc.inode;
 
-    if (-1 == req->rpc_status) {
+    if (0 > req->rpc_status) {
         rsp.op_ret = -1;
         op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2587,7 +2587,7 @@ client4_0_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
     op_errno = gf_error_to_errno(rsp.op_errno);
 
     ret = client_post_common_2iatt(this, &rsp, &stbuf, &postparent, &xdata);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /* Don't change the op_errno if the fop failed on server */
         if (rsp.op_ret == 0)
             op_errno = rsp.op_errno;
@@ -2595,7 +2595,7 @@ client4_0_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (rsp.op_ret < 0)
+    if (IS_ERROR(rsp.op_ret))
         goto out;
 
     if ((!gf_uuid_is_null(inode->gfid)) &&
@@ -2616,7 +2616,7 @@ client4_0_lookup_cbk(struct rpc_req *req, struct iovec *iov, int count,
 out:
     /* Restore the correct op_errno to rsp.op_errno */
     rsp.op_errno = op_errno;
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         /* any error other than ENOENT */
         if (!(local->loc.name && rsp.op_errno == ENOENT) &&
             !(rsp.op_errno == ESTALE))
@@ -2663,14 +2663,14 @@ client4_0_readv_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_read_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2683,7 +2683,7 @@ client4_0_readv_cbk(struct rpc_req *req, struct iovec *iov, int count,
     ret = client_post_readv_v2(this, &rsp, &iobref, req->rsp_iobref, &stat,
                                vector, &req->rsp[1], &rspcount, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     } else if (rsp.op_ret >= 0) {
@@ -2738,14 +2738,14 @@ client4_0_getactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_getactivelk_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2762,7 +2762,7 @@ client4_0_getactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
     xdr_to_dict(&rsp.xdata, &xdata);
 
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2793,14 +2793,14 @@ client4_0_setactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2810,7 +2810,7 @@ client4_0_setactivelk_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -2851,14 +2851,14 @@ client4_0_copy_file_range_cbk(struct rpc_req *req, struct iovec *iov, int count,
     frame = myframe;
     local = frame->local;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -2868,10 +2868,10 @@ client4_0_copy_file_range_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     ret = client_post_common_3iatt(this, &rsp, &stbuf, &prestat, &poststat,
                                    &xdata);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     } else if (rsp.op_ret >= 0) {
@@ -2916,7 +2916,7 @@ client4_0_releasedir(call_frame_t *frame, xlator_t *this, void *data)
                reopen_cbk handle releasing
             */
 
-            if (remote_fd == -1) {
+            if (IS_ERROR(remote_fd)) {
                 fdctx->released = 1;
             } else {
                 list_del_init(&fdctx->sfd_pos);
@@ -2959,7 +2959,7 @@ client4_0_release(call_frame_t *frame, xlator_t *this, void *data)
                in progress. Just mark ->released = 1 and let
                reopen_cbk handle releasing
             */
-            if (remote_fd == -1) {
+            if (IS_ERROR(remote_fd)) {
                 fdctx->released = 1;
             } else {
                 list_del_init(&fdctx->sfd_pos);
@@ -4673,7 +4673,7 @@ client4_0_lease(call_frame_t *frame, xlator_t *this, void *data)
     conf = this->private;
 
     ret = client_pre_lease_v2(this, &req, args->loc, args->lease, args->xdata);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         op_errno = -ret;
         goto unwind;
     }
@@ -5530,14 +5530,14 @@ client4_rchecksum_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_rchecksum_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -5547,7 +5547,7 @@ client4_rchecksum_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
@@ -5588,20 +5588,20 @@ client4_namelink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     frame = myframe;
 
-    if (req->rpc_status == -1) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_2iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
         goto out;
     }
 
-    if (rsp.op_ret != -1) {
+    if (rsp.op_ret >= 0) {
         gfx_stat_to_iattx(&rsp.prestat, &prebuf);
         gfx_stat_to_iattx(&rsp.poststat, &postbuf);
     }
@@ -5637,20 +5637,20 @@ client4_icreate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     inode = local->loc.inode;
 
-    if (req->rpc_status == -1) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         rsp.op_ret = -1;
         rsp.op_errno = EINVAL;
         goto out;
     }
 
-    if (rsp.op_ret != -1)
+    if (rsp.op_ret >= 0)
         gfx_stat_to_iattx(&rsp.stat, &stbuf);
 
     xdr_to_dict(&rsp.xdata, &xdata);
@@ -5691,14 +5691,14 @@ client4_0_put_cbk(struct rpc_req *req, struct iovec *iov, int count,
     local = frame->local;
     inode = local->loc.inode;
 
-    if (-1 == req->rpc_status) {
+    if (IS_ERROR(req->rpc_status)) {
         rsp.op_ret = -1;
         rsp.op_errno = ENOTCONN;
         goto out;
     }
 
     ret = xdr_to_generic(*iov, &rsp, (xdrproc_t)xdr_gfx_common_3iatt_rsp);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, EINVAL, PC_MSG_XDR_DECODING_FAILED,
                 NULL);
         rsp.op_ret = -1;
@@ -5709,11 +5709,11 @@ client4_0_put_cbk(struct rpc_req *req, struct iovec *iov, int count,
     if (-1 != rsp.op_ret) {
         ret = client_post_common_3iatt(this, &rsp, &stbuf, &preparent,
                                        &postparent, &xdata);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             goto out;
     }
 out:
-    if (rsp.op_ret == -1) {
+    if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -672,7 +672,7 @@ out:
     if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
-    } else if (rsp.op_ret >= 0) {
+    } else if (IS_SUCCESS(rsp.op_ret)) {
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
@@ -717,7 +717,7 @@ client4_0_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if ((rsp.op_ret >= 0 || (rsp.op_errno == ENOTCONN)) &&
+    if (IS_SUCCESS((rsp.op_ret) || (rsp.op_errno == ENOTCONN)) &&
         !fd_is_anonymous(local->fd)) {
         /* Delete all saved locks of the owner issuing flush */
         ret = delete_granted_locks_owner(local->fd, &local->owner);
@@ -2081,7 +2081,7 @@ client4_0_create_cbk(struct rpc_req *req, struct iovec *iov, int count,
     if (IS_ERROR(ret))
         goto out;
 
-    if (rsp.op_ret >= 0) {
+    if (IS_SUCCESS(rsp.op_ret)) {
         ret = client_add_fd_to_saved_fds(frame->this, fd, &local->loc,
                                          local->flags, rsp.fd, 0);
         if (ret) {
@@ -2196,7 +2196,7 @@ client4_0_lk_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (rsp.op_ret >= 0) {
+    if (IS_SUCCESS(rsp.op_ret)) {
         ret = client_post_lk_v2(this, &rsp, &lock, &xdata);
         if (IS_ERROR(ret))
             goto out;
@@ -2277,7 +2277,7 @@ out:
     CLIENT_STACK_UNWIND(readdir, frame, rsp.op_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
-    if (rsp.op_ret >= 0) {
+    if (IS_SUCCESS(rsp.op_ret)) {
         gf_dirent_free(&entries);
     }
 
@@ -2334,7 +2334,7 @@ out:
     CLIENT_STACK_UNWIND(readdirp, frame, rsp.op_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
-    if (rsp.op_ret >= 0) {
+    if (IS_SUCCESS(rsp.op_ret)) {
         gf_dirent_free(&entries);
     }
 
@@ -2686,7 +2686,7 @@ out:
     if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
-    } else if (rsp.op_ret >= 0) {
+    } else if (IS_SUCCESS(rsp.op_ret)) {
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
@@ -2874,7 +2874,7 @@ out:
     if (IS_ERROR(rsp.op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
-    } else if (rsp.op_ret >= 0) {
+    } else if (IS_SUCCESS(rsp.op_ret)) {
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
         if (local->attempt_reopen_out)
@@ -5601,7 +5601,7 @@ client4_namelink_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (rsp.op_ret >= 0) {
+    if (IS_SUCCESS(rsp.op_ret)) {
         gfx_stat_to_iattx(&rsp.prestat, &prebuf);
         gfx_stat_to_iattx(&rsp.poststat, &postbuf);
     }
@@ -5650,7 +5650,7 @@ client4_icreate_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (rsp.op_ret >= 0)
+    if (IS_SUCCESS(rsp.op_ret))
         gfx_stat_to_iattx(&rsp.stat, &stbuf);
 
     xdr_to_dict(&rsp.xdata, &xdata);

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -717,7 +717,7 @@ client4_0_flush_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (IS_SUCCESS((rsp.op_ret) || (rsp.op_errno == ENOTCONN)) &&
+    if ((IS_SUCCESS(rsp.op_ret) || (rsp.op_errno == ENOTCONN)) &&
         !fd_is_anonymous(local->fd)) {
         /* Delete all saved locks of the owner issuing flush */
         ret = delete_granted_locks_owner(local->fd, &local->owner);

--- a/xlators/protocol/client/src/client.c
+++ b/xlators/protocol/client/src/client.c
@@ -238,7 +238,7 @@ client_submit_request(xlator_t *this, void *req, call_frame_t *frame,
 
         /* Create the xdr payload */
         ret = xdr_serialize_generic(iov, req, xdrproc);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             /* callingfn so that, we can get to know which xdr
                function was called */
             gf_log_callingfn(this->name, GF_LOG_WARNING,
@@ -270,7 +270,7 @@ client_submit_request(xlator_t *this, void *req, call_frame_t *frame,
                               NULL);
     }
 
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_debug(this->name, 0, "rpc_clnt_submit failed");
     }
 
@@ -2328,7 +2328,7 @@ notify(xlator_t *this, int32_t event, void *data, ...)
             pthread_mutex_unlock(&conf->lock);
 
             ret = rpc_clnt_disable(conf->rpc);
-            if (ret == -1 && graph) {
+            if (IS_ERROR(ret) && graph) {
                 pthread_mutex_lock(&graph->mutex);
                 {
                     graph->parent_down++;
@@ -2361,7 +2361,7 @@ client_check_remote_host(xlator_t *this, dict_t *options)
     int ret = -1;
 
     ret = dict_get_str_sizen(options, "remote-host", &remote_host);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_INFO, EINVAL, PC_MSG_REMOTE_HOST_NOT_SET,
                 NULL);
 
@@ -2373,7 +2373,7 @@ client_check_remote_host(xlator_t *this, dict_t *options)
 
         ret = dict_set_str_sizen(options, "remote-host",
                                  this->ctx->cmd_args.volfile_server);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             gf_smsg(this->name, GF_LOG_ERROR, 0, PC_MSG_REMOTE_HOST_SET_FAILED,
                     NULL);
             goto out;
@@ -2640,7 +2640,7 @@ init(xlator_t *this)
     */
 
     ret = build_client_config(this, conf);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         goto out;
 
     if (ret) {

--- a/xlators/protocol/client/src/client.h
+++ b/xlators/protocol/client/src/client.h
@@ -58,11 +58,11 @@ typedef enum {
     do {                                                                       \
         int _ret = 0;                                                          \
         _ret = client_get_remote_fd(xl, fd, flags, &remote_fd);                \
-        if (_ret < 0) {                                                        \
+        if (IS_ERROR(_ret)) {                                                  \
             op_errno = errno;                                                  \
             goto label;                                                        \
         }                                                                      \
-        if (remote_fd == -1) {                                                 \
+        if (IS_ERROR(remote_fd)) {                                             \
             gf_smsg(xl->name, GF_LOG_WARNING, EBADFD, PC_MSG_BAD_FD,           \
                     "gfid=%s", uuid_utoa(fd->inode->gfid), NULL);              \
             op_errno = EBADFD;                                                 \

--- a/xlators/protocol/server/src/authenticate.c
+++ b/xlators/protocol/server/src/authenticate.c
@@ -43,7 +43,7 @@ init(dict_t *this, char *key, data_t *value, void *data)
     }
 
     ret = gf_asprintf(&auth_file, "%s/%s.so", LIBDIR, key);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         dict_set(this, key, data_from_dynptr(NULL, 0));
         *error = -1;
         return -1;

--- a/xlators/protocol/server/src/server-common.c
+++ b/xlators/protocol/server/src/server-common.c
@@ -757,8 +757,7 @@ server4_post_create(call_frame_t *frame, gfx_create_rsp *rsp,
     serv_ctx = server_ctx_get(frame->root->client, this);
     if (serv_ctx == NULL) {
         gf_msg(this->name, GF_LOG_INFO, 0, PS_MSG_SERVER_CTX_GET_FAILED,
-               "server_ctx_get() "
-               "failed");
+               "server_ctx_get() failed");
         goto out;
     }
 
@@ -768,6 +767,9 @@ server4_post_create(call_frame_t *frame, gfx_create_rsp *rsp,
 
     if ((fd_no > UINT64_MAX) || (fd == 0)) {
         op_errno = errno;
+        gf_msg(this->name, GF_LOG_INFO, 0, PS_MSG_SERVER_CTX_GET_FAILED,
+               "fd range failed");
+	goto out;
     }
 
     rsp->fd = fd_no;

--- a/xlators/protocol/server/src/server-handshake.c
+++ b/xlators/protocol/server/src/server-handshake.c
@@ -665,7 +665,7 @@ fail:
        because if lookup itself can't succeed, we should communicate this
        to client. Very important in case of subdirectory mounts, where if
        client is trying to mount a non-existing directory */
-    if (op_ret >= 0 && client->bound_xl->itable) {
+    if (IS_SUCCESS(op_ret) && client->bound_xl->itable) {
         if (client->bound_xl->cleanup_starting) {
             op_ret = -1;
             op_errno = EAGAIN;

--- a/xlators/protocol/server/src/server-handshake.c
+++ b/xlators/protocol/server/src/server-handshake.c
@@ -49,7 +49,7 @@ server_getspec(rpcsvc_request_t *req)
     };
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_gf_getspec_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         op_errno = EINVAL;
@@ -105,7 +105,7 @@ do_path_lookup(xlator_t *xl, dict_t *dict, inode_t *parinode, char *basename)
     }
 
     ret = syncop_lookup(xl, &loc, &iatt, NULL, dict, NULL);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(xl->name, GF_LOG_ERROR, "first lookup on subdir (%s) failed: %s",
                basename, strerror(errno));
     }
@@ -151,7 +151,7 @@ server_first_lookup(xlator_t *this, client_t *client, dict_t *reply)
     gf_uuid_copy(loc.gfid, loc.inode->gfid);
 
     ret = syncop_lookup(xl, &loc, &iatt, NULL, NULL, NULL);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_log(xl->name, GF_LOG_ERROR, "lookup on root failed: %s",
                strerror(errno));
     /* Ignore error from lookup, don't set
@@ -191,12 +191,12 @@ fail:
        to connect */
     ret = gf_asprintf(&msg, "subdirectory for mount \"%s\" is not found",
                       client->subdir_mount);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, PS_MSG_ASPRINTF_FAILED,
                "asprintf failed while setting error msg");
     }
     ret = dict_set_dynstr(reply, "ERROR", msg);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         gf_msg_debug(this->name, 0,
                      "failed to set error "
                      "msg");
@@ -254,7 +254,7 @@ server_setvolume(rpcsvc_request_t *req)
     params = dict_new();
     reply = dict_new();
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_gf_setvolume_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         req->rpc_err = GARBAGE_ARGS;
         goto fail;
@@ -268,11 +268,11 @@ server_setvolume(rpcsvc_request_t *req)
     config_params = dict_copy_with_ref(this->options, NULL);
 
     ret = dict_unserialize(args.dict.dict_val, args.dict.dict_len, &params);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = dict_set_sizen_str_sizen(reply, "ERROR",
                                        "Internal error: failed to unserialize "
                                        "request dictionary");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "failed to set error "
                          "msg \"%s\"",
@@ -285,10 +285,10 @@ server_setvolume(rpcsvc_request_t *req)
     }
 
     ret = dict_get_str(params, "remote-subvolume", &name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = dict_set_str(reply, "ERROR",
                            "No remote-subvolume option specified");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "failed to set error "
                          "msg");
@@ -309,13 +309,13 @@ server_setvolume(rpcsvc_request_t *req)
     UNLOCK(&ctx->volfile_lock);
     if (xl == NULL) {
         ret = gf_asprintf(&msg, "remote-subvolume \"%s\" is not found", name);
-        if (-1 == ret) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, PS_MSG_ASPRINTF_FAILED,
                    "asprintf failed while setting error msg");
             goto fail;
         }
         ret = dict_set_dynstr(reply, "ERROR", msg);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "failed to set error "
                          "msg");
@@ -338,7 +338,7 @@ server_setvolume(rpcsvc_request_t *req)
         ret = dict_set_str(reply, "ERROR",
                            "xlator graph in server is not initialised "
                            "yet. Try again later");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "failed to set error: "
                          "xlator graph in server is not "
@@ -358,7 +358,7 @@ server_setvolume(rpcsvc_request_t *req)
                "No xlator %s is found in child status list", name);
     } else {
         ret = dict_set_int32(reply, "child_up", tmp->child_up);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg(this->name, GF_LOG_ERROR, 0, PS_MSG_DICT_GET_FAILED,
                    "Failed to set 'child_up' for xlator %s "
                    "in the reply dict",
@@ -366,7 +366,7 @@ server_setvolume(rpcsvc_request_t *req)
         if (!tmp->child_up) {
             ret = dict_set_str(reply, "ERROR",
                                "Not received child_up for this xlator");
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 gf_msg_debug(this->name, 0, "failed to set error msg");
 
             gf_msg(this->name, GF_LOG_ERROR, 0, PS_MSG_CHILD_STATUS_FAILED,
@@ -380,9 +380,9 @@ server_setvolume(rpcsvc_request_t *req)
     pthread_mutex_unlock(&conf->mutex);
 
     ret = dict_get_str(params, "process-uuid", &client_uid);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = dict_set_str(reply, "ERROR", "UUID not specified");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "failed to set error "
                          "msg");
@@ -393,11 +393,11 @@ server_setvolume(rpcsvc_request_t *req)
     }
 
     ret = dict_get_str(params, "subdir-mount", &subdir_mount);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /* Not a problem at all as the key is optional */
     }
     ret = dict_get_str(params, "process-name", &client_name);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         client_name = "unknown";
     }
 
@@ -409,7 +409,7 @@ server_setvolume(rpcsvc_request_t *req)
             ret = dict_set_str(reply, "ERROR",
                                "Volume-ID different, possible case "
                                "of same brick re-used in another volume");
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 gf_msg_debug(this->name, 0, "failed to set error msg");
 
             op_ret = -1;
@@ -454,7 +454,7 @@ server_setvolume(rpcsvc_request_t *req)
         ret = dict_set_str(reply, "ERROR",
                            "cleanup flag is set for xlator. "
                            " Try again later");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "failed to set error: "
                          "cleanup flag is set for xlator. "
@@ -474,18 +474,18 @@ server_setvolume(rpcsvc_request_t *req)
     }
 
     ret = dict_get_int32(params, "fops-version", &fop_version);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = dict_set_str(reply, "ERROR", "No FOP version number specified");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "failed to set error "
                          "msg");
     }
 
     ret = dict_get_int32(params, "mgmt-version", &mgmt_version);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         ret = dict_set_str(reply, "ERROR", "No MGMT version number specified");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "failed to set error "
                          "msg");
@@ -498,14 +498,14 @@ server_setvolume(rpcsvc_request_t *req)
                           " - client-mgmt(%d)",
                           fop_version, mgmt_version);
         /* get_supported_version (req)); */
-        if (-1 == ret) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, PS_MSG_ASPRINTF_FAILED,
                    "asprintf failed while"
                    "setting up error msg");
             goto fail;
         }
         ret = dict_set_dynstr(reply, "ERROR", msg);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "failed to set error "
                          "msg");
@@ -518,7 +518,7 @@ server_setvolume(rpcsvc_request_t *req)
     peerinfo = &req->trans->peerinfo;
     if (peerinfo) {
         ret = dict_set_static_ptr(params, "peer-info", peerinfo);
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "failed to set "
                          "peer-info");
@@ -574,7 +574,7 @@ server_setvolume(rpcsvc_request_t *req)
            be Success), key checked on client is 'ERROR' and hence
            we send 'Success' in this key */
         ret = dict_set_str(reply, "ERROR", "Success");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "failed to set error "
                          "msg");
@@ -603,7 +603,7 @@ server_setvolume(rpcsvc_request_t *req)
             op_errno = EACCES;
             ret = dict_set_str(reply, "ERROR", "Authentication failed");
         }
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "failed to set error "
                          "msg");
@@ -614,7 +614,7 @@ server_setvolume(rpcsvc_request_t *req)
         ret = dict_set_str(reply, "ERROR",
                            "Check volfile and handshake "
                            "options in protocol/client");
-        if (ret < 0)
+        if (IS_ERROR(ret))
             gf_msg_debug(this->name, 0,
                          "failed to set error "
                          "msg");
@@ -676,7 +676,7 @@ fail:
             (void)(ret);
         } else {
             op_ret = server_first_lookup(this, client, reply);
-            if (op_ret == -1)
+            if (IS_ERROR(op_ret))
                 op_errno = ENOENT;
         }
     }
@@ -760,7 +760,7 @@ server_set_lk_version(rpcsvc_request_t *req)
     };
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_gf_set_lk_ver_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         /* failed to decode msg */
         req->rpc_err = GARBAGE_ARGS;
         goto fail;

--- a/xlators/protocol/server/src/server-helpers.c
+++ b/xlators/protocol/server/src/server-helpers.c
@@ -66,7 +66,7 @@ gid_resolve(server_conf_t *conf, call_stack_t *root)
     gf_msg_trace("gid-cache", 0, "mapped %u => %s", root->uid, result->pw_name);
 
     ngroups = gf_getgrouplist(result->pw_name, root->gid, &mygroups);
-    if (ngroups == -1) {
+    if (IS_ERROR(ngroups)) {
         gf_smsg("gid-cache", GF_LOG_ERROR, 0, PS_MSG_MAPPING_ERROR,
                 "pw_name=%s", result->pw_name, "root->ngtps=%d", root->ngrps,
                 NULL);
@@ -585,7 +585,7 @@ server_build_config(xlator_t *this, server_conf_t *conf)
 
     ret = dict_get_int32(this->options, "inode-lru-limit",
                          &conf->inode_lru_limit);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         conf->inode_lru_limit = 16384;
     }
 
@@ -611,7 +611,7 @@ server_build_config(xlator_t *this, server_conf_t *conf)
     /* TODO: build_rpc_config (); */
     ret = dict_get_int32(this->options, "limits.transaction-size",
                          &conf->rpc_conf.max_block_size);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg_trace(this->name, 0,
                      "defaulting limits.transaction-"
                      "size to %d",
@@ -631,7 +631,7 @@ server_build_config(xlator_t *this, server_conf_t *conf)
             goto out;
         }
         /* Make sure that conf-dir doesn't contain ".." in path */
-        if ((gf_strstr(data->data, "/", "..")) == -1) {
+        if (IS_ERROR((gf_strstr(data->data, "/", "..")))) {
             ret = -1;
             gf_smsg(this->name, GF_LOG_ERROR, 0, PS_MSG_CONF_DIR_INVALID,
                     "data=%s", data->data, NULL);
@@ -1372,7 +1372,7 @@ auth_set_username_passwd(dict_t *input_params, dict_t *config_params,
     }
 
     ret = gf_asprintf(&searchstr, "auth.login.%s.allow", brick_name);
-    if (-1 == ret) {
+    if (IS_ERROR(ret)) {
         ret = 0;
         goto out;
     }
@@ -1391,7 +1391,7 @@ auth_set_username_passwd(dict_t *input_params, dict_t *config_params,
             if (!fnmatch(username_str, username, 0)) {
                 ret = gf_asprintf(&searchstr, "auth.login.%s.password",
                                   username);
-                if (-1 == ret)
+                if (IS_ERROR(ret))
                     goto out;
 
                 passwd_data = dict_get(config_params, searchstr);

--- a/xlators/protocol/server/src/server-resolve.c
+++ b/xlators/protocol/server/src/server-resolve.c
@@ -564,8 +564,8 @@ server_resolve_fd(call_frame_t *frame)
         state->fd = gf_fd_fdptr_get(serv_ctx->fdtable, fd_no);
         if (!state->fd) {
             gf_msg("", GF_LOG_INFO, EBADF, PS_MSG_FD_NOT_FOUND,
-                   "fd not "
-                   "found in context");
+                   "fd (%"PRId64") not found in context : %s", fd_no,
+		   gf_fop_list[frame->root->op]);
             resolve->op_ret = -1;
             resolve->op_errno = EBADF;
         }
@@ -573,8 +573,7 @@ server_resolve_fd(call_frame_t *frame)
         state->fd_out = gf_fd_fdptr_get(serv_ctx->fdtable, fd_no);
         if (!state->fd_out) {
             gf_msg("", GF_LOG_INFO, EBADF, PS_MSG_FD_NOT_FOUND,
-                   "fd not "
-                   "found in context");
+                   "fd not found in context");
             resolve->op_ret = -1;
             resolve->op_errno = EBADF;
         }

--- a/xlators/protocol/server/src/server-resolve.c
+++ b/xlators/protocol/server/src/server-resolve.c
@@ -53,7 +53,7 @@ resolve_gfid_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     resolve = state->resolve_now;
     resolve_loc = &resolve->resolve_loc;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ENOENT) {
             gf_msg_debug(this->name, 0, "%s/%s: failed to resolve (%s)",
                          uuid_utoa(resolve_loc->pargfid), resolve_loc->name,
@@ -116,7 +116,7 @@ resolve_gfid_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     resolve = state->resolve_now;
     resolve_loc = &resolve->resolve_loc;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ENOENT) {
             gf_msg_debug(this->name, GF_LOG_DEBUG, "%s: failed to resolve (%s)",
                          uuid_utoa(resolve_loc->gfid), strerror(op_errno));

--- a/xlators/protocol/server/src/server-rpc-fops.c
+++ b/xlators/protocol/server/src/server-rpc-fops.c
@@ -68,7 +68,7 @@ server_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, PS_MSG_STATFS,
                "%" PRId64 ": STATFS, client: %s, error-xlator: %s",
                frame->root->unique, STACK_CLIENT_NAME(frame->root),
@@ -107,7 +107,7 @@ server_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (state->is_revalidate == 1 && op_ret == -1) {
+    if ((state->is_revalidate == 1) && IS_ERROR(op_ret)) {
         state->is_revalidate = 2;
         loc_copy(&fresh_loc, &state->loc);
         inode_unref(fresh_loc.inode);
@@ -285,7 +285,7 @@ server_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_INODELK, op_errno), op_errno,
                PS_MSG_INODELK_INFO,
                "%" PRId64
@@ -325,7 +325,7 @@ server_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_FINODELK, op_errno), op_errno,
                PS_MSG_INODELK_INFO,
                "%" PRId64 ": FINODELK %" PRId64
@@ -365,7 +365,7 @@ server_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_ENTRYLK, op_errno), op_errno,
                PS_MSG_ENTRYLK_INFO,
                "%" PRId64
@@ -405,7 +405,7 @@ server_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_FENTRYLK, op_errno), op_errno,
                PS_MSG_ENTRYLK_INFO,
                "%" PRId64 ": FENTRYLK %" PRId64
@@ -527,7 +527,7 @@ server_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_MKDIR, op_errno), op_errno,
                PS_MSG_DIR_INFO,
                "%" PRId64
@@ -570,7 +570,7 @@ server_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_MKNOD, op_errno), op_errno,
                PS_MSG_MKNOD_INFO,
                "%" PRId64
@@ -609,7 +609,7 @@ server_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FSYNCDIR, op_errno), op_errno,
                PS_MSG_DIR_INFO,
@@ -650,7 +650,7 @@ server_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_READDIR, op_errno), op_errno,
                PS_MSG_DIR_INFO,
@@ -666,7 +666,7 @@ server_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     /* (op_ret == 0) is valid, and means EOF */
     if (op_ret) {
         ret = server_post_readdir(&rsp, entries);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             op_ret = -1;
             op_errno = ENOMEM;
             goto out;
@@ -702,7 +702,7 @@ server_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_OPENDIR, op_errno), op_errno,
                PS_MSG_DIR_INFO,
@@ -753,7 +753,7 @@ server_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (ENODATA == op_errno || ENOATTR == op_errno)
             loglevel = GF_LOG_DEBUG;
@@ -802,7 +802,7 @@ server_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FREMOVEXATTR, op_errno),
                op_errno, PS_MSG_REMOVEXATTR_INFO,
@@ -842,7 +842,7 @@ server_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_GETXATTR, op_errno), op_errno,
                PS_MSG_GETXATTR_INFO,
@@ -887,7 +887,7 @@ server_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FGETXATTR, op_errno), op_errno,
                PS_MSG_GETXATTR_INFO,
@@ -957,7 +957,7 @@ server_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (op_errno != ENOTSUP)
             dict_foreach(state->dict, _gf_server_log_setxattr_failure, frame);
@@ -1027,7 +1027,7 @@ server_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (op_errno != ENOTSUP) {
             dict_foreach(state->dict, _gf_server_log_fsetxattr_failure, frame);
@@ -1081,7 +1081,7 @@ server_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(state->resolve.pargfid, oldpar_str);
         uuid_utoa_r(state->resolve2.pargfid, newpar_str);
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_RENAME_INFO,
@@ -1183,7 +1183,7 @@ server_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_LINK_INFO,
                "%" PRId64
                ": SYMLINK %s (%s/%s), client: %s, "
@@ -1398,7 +1398,7 @@ server_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FLUSH, op_errno), op_errno,
                PS_MSG_FLUSH_INFO,
@@ -1438,7 +1438,7 @@ server_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FSYNC, op_errno), op_errno,
                PS_MSG_SYNC_INFO,
@@ -1480,7 +1480,7 @@ server_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_WRITE, op_errno), op_errno,
                PS_MSG_WRITE_INFO,
@@ -1533,7 +1533,7 @@ server_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_READ, op_errno), op_errno,
                PS_MSG_READ_INFO,
@@ -1575,7 +1575,7 @@ server_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_RCHECKSUM, op_errno), op_errno,
                PS_MSG_CHKSUM_INFO,
@@ -1615,7 +1615,7 @@ server_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_OPEN, op_errno), op_errno,
                PS_MSG_OPEN_INFO,
@@ -1659,7 +1659,7 @@ server_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_CREATE_INFO,
                "%" PRId64
                ": CREATE %s (%s/%s), client: %s, "
@@ -1715,7 +1715,7 @@ server_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_LINK_INFO,
                "%" PRId64
@@ -1879,7 +1879,7 @@ server_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_XATTROP, op_errno), op_errno,
                PS_MSG_XATTROP_INFO,
@@ -1924,7 +1924,7 @@ server_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FXATTROP, op_errno), op_errno,
                PS_MSG_XATTROP_INFO,
@@ -1972,7 +1972,7 @@ server_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_READDIRP, op_errno), op_errno,
                PS_MSG_DIR_INFO,
@@ -1988,7 +1988,7 @@ server_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     /* (op_ret == 0) is valid, and means EOF */
     if (op_ret) {
         ret = server_post_readdirp(&rsp, entries);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             op_ret = -1;
             op_errno = ENOMEM;
             goto out;
@@ -2234,7 +2234,7 @@ server_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, GF_LOG_INFO, op_errno, 0,
                "%" PRId64
@@ -3301,7 +3301,7 @@ server_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
 
         gf_msg(this->name, GF_LOG_INFO, op_errno, 0,
@@ -3318,7 +3318,7 @@ server_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     /* (op_ret == 0) means there are no locks on the file*/
     if (op_ret > 0) {
         ret = serialize_rsp_locklist(locklist, &rsp);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             op_ret = -1;
             op_errno = ENOMEM;
             goto out;
@@ -3390,7 +3390,7 @@ rpc_receive_common(rpcsvc_request_t *req, call_frame_t **fr,
     ssize_t len = 0;
 
     len = xdr_to_generic(req->msg[0], args, (xdrproc_t)xdrfn);
-    if (len < 0) {
+    if (IS_ERROR(len)) {
         /* failed to decode msg; */
         SERVER_REQ_SET_ERROR(req, ret);
         goto out;
@@ -4094,7 +4094,7 @@ server3_3_release(rpcsvc_request_t *req)
     int ret = -1;
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_gfs3_release_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         SERVER_REQ_SET_ERROR(req, ret);
         goto out;
@@ -4143,7 +4143,7 @@ server3_3_releasedir(rpcsvc_request_t *req)
     int ret = -1;
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_gfs3_release_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         // failed to decode msg;
         SERVER_REQ_SET_ERROR(req, ret);
         goto out;

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -55,7 +55,7 @@ server4_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, op_errno, PS_MSG_STATFS,
                 "frame=%" PRId64, frame->root->unique, "client=%s",
                 STACK_CLIENT_NAME(frame->root), "error-xlator=%s",
@@ -94,7 +94,7 @@ server4_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (state->is_revalidate == 1 && op_ret == -1) {
+    if ((state->is_revalidate == 1) && IS_ERROR(op_ret)) {
         state->is_revalidate = 2;
         loc_copy(&fresh_loc, &state->loc);
         inode_unref(fresh_loc.inode);
@@ -152,14 +152,16 @@ out:
                     "uuid_utoa=%s", uuid_utoa(state->resolve.pargfid),
                     "bname=%s", state->resolve.bname, "client=%s",
                     STACK_CLIENT_NAME(frame->root), "error-xlator=%s",
-                    STACK_ERR_XL_NAME(frame->root), NULL);
+                    STACK_ERR_XL_NAME(frame->root), "ret=%s",
+                    gf_strerror(op_ret), NULL);
         } else {
             gf_smsg(this->name, fop_log_level(GF_FOP_LOOKUP, op_errno),
                     op_errno, PS_MSG_LOOKUP_INFO, "frame=%" PRId64,
                     frame->root->unique, "path=%s", state->loc.path,
                     "uuid_utoa=%s", uuid_utoa(state->resolve.gfid), "client=%s",
                     STACK_CLIENT_NAME(frame->root), "error-xlator=%s",
-                    STACK_ERR_XL_NAME(frame->root), NULL);
+                    STACK_ERR_XL_NAME(frame->root), "ret=%s",
+                    gf_strerror(op_ret), NULL);
         }
     }
 
@@ -260,7 +262,7 @@ server4_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_INODELK, op_errno), op_errno,
                 PS_MSG_INODELK_INFO, "frame=%" PRId64, frame->root->unique,
                 "path=%s", state->loc.path, "uuuid_utoa=%s",
@@ -297,7 +299,7 @@ server4_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_FINODELK, op_errno), op_errno,
                 PS_MSG_INODELK_INFO, "frame=%" PRId64, frame->root->unique,
                 "FINODELK_fd_no=%" PRId64, state->resolve.fd_no, "uuid_utoa=%s",
@@ -334,7 +336,7 @@ server4_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_ENTRYLK, op_errno), op_errno,
                 PS_MSG_ENTRYLK_INFO, "frame=%" PRId64, frame->root->unique,
                 "path=%s", state->loc.path, "uuid_utoa=%s",
@@ -371,7 +373,7 @@ server4_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_FENTRYLK, op_errno), op_errno,
                 PS_MSG_ENTRYLK_INFO, "frame=%" PRId64, frame->root->unique,
                 "FENTRYLK_fd_no=%" PRId64, state->resolve.fd_no, "uuid_utoa=%s",
@@ -487,7 +489,7 @@ server4_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_MKDIR, op_errno), op_errno,
                 PS_MSG_DIR_INFO, "frame=%" PRId64, frame->root->unique,
                 "MKDIR_path=%s", (state->loc.path) ? state->loc.path : "",
@@ -528,7 +530,7 @@ server4_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, fop_log_level(GF_FOP_MKNOD, op_errno), op_errno,
                 PS_MSG_MKNOD_INFO, "frame=%" PRId64, frame->root->unique,
                 "path=%s", state->loc.path, "uuid_utoa=%s",
@@ -565,7 +567,7 @@ server4_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FSYNCDIR, op_errno), op_errno,
                 PS_MSG_DIR_INFO, "frame=%" PRId64, frame->root->unique,
@@ -603,7 +605,7 @@ server4_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_READDIR, op_errno), op_errno,
                 PS_MSG_DIR_INFO, "frame=%" PRId64, frame->root->unique,
@@ -617,7 +619,7 @@ server4_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     /* (op_ret == 0) is valid, and means EOF */
     if (op_ret) {
         ret = server4_post_readdir(&rsp, entries);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             op_ret = -1;
             op_errno = ENOMEM;
             goto out;
@@ -652,7 +654,7 @@ server4_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_OPENDIR, op_errno), op_errno,
                 PS_MSG_DIR_INFO, "frame=%" PRId64, frame->root->unique,
@@ -694,7 +696,7 @@ server4_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (ENODATA == op_errno || ENOATTR == op_errno)
             loglevel = GF_LOG_DEBUG;
@@ -735,7 +737,7 @@ server4_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FREMOVEXATTR, op_errno),
                 op_errno, PS_MSG_REMOVEXATTR_INFO, "frame=%" PRId64,
@@ -773,7 +775,7 @@ server4_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_GETXATTR, op_errno), op_errno,
                 PS_MSG_GETXATTR_INFO, "frame=%" PRId64, frame->root->unique,
@@ -813,7 +815,7 @@ server4_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FGETXATTR, op_errno), op_errno,
                 PS_MSG_GETXATTR_INFO, "frame=%" PRId64, frame->root->unique,
@@ -852,7 +854,7 @@ server4_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (op_errno != ENOTSUP)
             dict_foreach(state->dict, _gf_server_log_setxattr_failure, frame);
@@ -892,7 +894,7 @@ server4_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (op_errno != ENOTSUP) {
             dict_foreach(state->dict, _gf_server_log_setxattr_failure, frame);
@@ -943,7 +945,7 @@ server4_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(state->resolve.pargfid, oldpar_str);
         uuid_utoa_r(state->resolve2.pargfid, newpar_str);
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_RENAME_INFO,
@@ -1036,7 +1038,7 @@ server4_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_LINK_INFO,
                 "frame=%" PRId64, frame->root->unique, "SYMLINK_path= %s",
                 (state->loc.path) ? state->loc.path : "", "uuid_utoa=%s",
@@ -1238,7 +1240,7 @@ server4_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FLUSH, op_errno), op_errno,
                 PS_MSG_FLUSH_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1275,7 +1277,7 @@ server4_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FSYNC, op_errno), op_errno,
                 PS_MSG_SYNC_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1314,7 +1316,7 @@ server4_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_WRITE, op_errno), op_errno,
                 PS_MSG_WRITE_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1364,7 +1366,7 @@ server4_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 #endif
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_READ, op_errno), op_errno,
                 PS_MSG_READ_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1403,7 +1405,7 @@ server4_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_RCHECKSUM, op_errno), op_errno,
                 PS_MSG_CHKSUM_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1440,7 +1442,7 @@ server4_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_OPEN, op_errno), op_errno,
                 PS_MSG_OPEN_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1483,7 +1485,7 @@ server4_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(
             this->name, GF_LOG_INFO, op_errno, PS_MSG_CREATE_INFO,
             "frame=%" PRId64, frame->root->unique, "path=%s", state->loc.path,
@@ -1503,14 +1505,14 @@ server4_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     op_ret = server4_post_create(frame, &rsp, state, this, fd, inode, stbuf,
                                  preparent, postparent);
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         op_errno = -op_ret;
         op_ret = -1;
         goto out;
     }
 
 out:
-    if (op_ret)
+    if (op_ret >= 0)
         rsp.fd = fd_no;
     rsp.op_ret = op_ret;
     rsp.op_errno = gf_errno_to_error(op_errno);
@@ -1537,7 +1539,7 @@ server4_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_LINK_INFO,
                 "frame=%" PRId64, frame->root->unique, "READLINK_path=%s",
@@ -1692,7 +1694,7 @@ server4_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_XATTROP, op_errno), op_errno,
                 PS_MSG_XATTROP_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1732,7 +1734,7 @@ server4_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_FXATTROP, op_errno), op_errno,
                 PS_MSG_XATTROP_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1776,7 +1778,7 @@ server4_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, fop_log_level(GF_FOP_READDIRP, op_errno), op_errno,
                 PS_MSG_DIR_INFO, "frame=%" PRId64, frame->root->unique,
@@ -1790,7 +1792,7 @@ server4_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     /* (op_ret == 0) is valid, and means EOF */
     if (op_ret) {
         ret = server4_post_readdirp(&rsp, entries);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             op_ret = -1;
             op_errno = ENOMEM;
             goto out;
@@ -2021,7 +2023,7 @@ server4_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_SETACTIVELK_INFO,
                 "frame=%" PRId64, frame->root->unique, "path==%s",
@@ -2056,7 +2058,7 @@ server4_namelink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     rpcsvc_request_t *req = NULL;
 
     dict_to_xdr(xdata, &rsp.xdata);
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     gfx_stat_from_iattx(&rsp.prestat, prebuf);
@@ -2095,7 +2097,7 @@ server4_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     dict_to_xdr(xdata, &rsp.xdata);
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_CREATE_INFO,
                 "frame=%" PRId64, uuid_utoa(state->resolve.gfid),
                 "ICREATE_gfid=%s", uuid_utoa(state->resolve.gfid),
@@ -2151,7 +2153,7 @@ server4_put_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(
             this->name, GF_LOG_INFO, op_errno, PS_MSG_PUT_INFO,
             "frame=%" PRId64, frame->root->unique, "path=%s", state->loc.path,
@@ -2199,7 +2201,7 @@ server4_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
 
         uuid_utoa_r(state->resolve.gfid, in_gfid);
@@ -3305,7 +3307,7 @@ server4_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     dict_to_xdr(xdata, &rsp.xdata);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
 
         gf_smsg(this->name, GF_LOG_INFO, op_errno, PS_MSG_GETACTIVELK_INFO,
@@ -3320,7 +3322,7 @@ server4_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     /* (op_ret == 0) means there are no locks on the file*/
     if (op_ret > 0) {
         ret = serialize_rsp_locklist_v2(locklist, &rsp);
-        if (ret == -1) {
+        if (IS_ERROR(ret)) {
             op_ret = -1;
             op_errno = ENOMEM;
             goto out;
@@ -4019,7 +4021,7 @@ server4_0_release(rpcsvc_request_t *req)
     int ret = -1;
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_gfx_release_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         SERVER_REQ_SET_ERROR(req, ret);
         goto out;
     }
@@ -4065,7 +4067,7 @@ server4_0_releasedir(rpcsvc_request_t *req)
     int ret = -1;
 
     ret = xdr_to_generic(req->msg[0], &args, (xdrproc_t)xdr_gfx_release_req);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         SERVER_REQ_SET_ERROR(req, ret);
         goto out;
     }

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -1476,7 +1476,6 @@ server4_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 {
     server_state_t *state = NULL;
     rpcsvc_request_t *req = NULL;
-    uint64_t fd_no = 0;
     gfx_create_rsp rsp = {
         0,
     };
@@ -1512,8 +1511,6 @@ server4_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    if (IS_SUCCESS(op_ret))
-        rsp.fd = fd_no;
     rsp.op_ret = op_ret;
     rsp.op_errno = gf_errno_to_error(op_errno);
 

--- a/xlators/protocol/server/src/server-rpc-fops_v2.c
+++ b/xlators/protocol/server/src/server-rpc-fops_v2.c
@@ -1512,7 +1512,7 @@ server4_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         rsp.fd = fd_no;
     rsp.op_ret = op_ret;
     rsp.op_errno = gf_errno_to_error(op_errno);

--- a/xlators/protocol/server/src/server.c
+++ b/xlators/protocol/server/src/server.c
@@ -60,7 +60,7 @@ gfs_serialize_reply(rpcsvc_request_t *req, void *arg, struct iovec *outmsg,
          */
 
         retlen = xdr_serialize_generic(*outmsg, arg, xdrproc);
-        if (retlen == -1) {
+        if (IS_ERROR(retlen)) {
             /* Failed to Encode 'GlusterFS' msg in RPC is not exactly
                failure of RPC return values.. client should get
                notified about this, so there are no missing frames */
@@ -126,7 +126,7 @@ server_submit_reply(call_frame_t *frame, rpcsvc_request_t *req, void *arg,
      * ref'ed the iob on receiving into the txlist.
      */
     iobuf_unref(iob);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg_callingfn("", GF_LOG_ERROR, 0, PS_MSG_REPLY_SUBMIT_FAILED,
                          "Reply submission failed");
         if (frame && client) {
@@ -305,7 +305,7 @@ get_auth_types(dict_t *this, char *key, data_t *value, void *data)
             gf_smsg("server", GF_LOG_WARNING, 0, PS_MSG_AUTH_IP_ERROR, NULL);
         }
         ret = dict_set_dynptr(auth_dict, tmp, NULL, 0);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg_debug("server", 0,
                          "failed to "
                          "dict_set_dynptr");
@@ -374,7 +374,7 @@ validate_auth_options(xlator_t *this, dict_t *dict)
     while (trav) {
         error = dict_foreach(dict, _check_for_auth_option, trav->xlator);
 
-        if (-1 == error) {
+        if (IS_ERROR(error)) {
             gf_smsg(this->name, GF_LOG_ERROR, 0, PS_MSG_AUTHENTICATE_ERROR,
                     "name=%s", trav->xlator->name, NULL);
             break;
@@ -796,7 +796,7 @@ do_auth:
 
     dict_foreach(options, get_auth_types, conf->auth_modules);
     ret = validate_auth_options(kid, options);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         /* logging already done in validate_auth_options function. */
         goto out;
     }
@@ -815,7 +815,7 @@ do_auth:
 
     GF_OPTION_RECONF("gid-timeout", conf->gid_cache_timeout, options, int32,
                      do_rpc);
-    if (gid_cache_reconf(&conf->gid_cache, conf->gid_cache_timeout) < 0) {
+    if (IS_ERROR(gid_cache_reconf(&conf->gid_cache, conf->gid_cache_timeout))) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PS_MSG_GRP_CACHE_ERROR, NULL);
         goto do_rpc;
     }
@@ -828,7 +828,7 @@ do_rpc:
     }
 
     ret = rpcsvc_auth_reconf(rpc_conf, options);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_log(GF_RPCSVC, GF_LOG_ERROR, "Failed to reconfigure authentication");
         goto out;
     }
@@ -901,7 +901,7 @@ do_rpc:
 
     ret = rpcsvc_set_outstanding_rpc_limit(
         rpc_conf, options, RPCSVC_DEFAULT_OUTSTANDING_RPC_LIMIT);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PS_MSG_RECONFIGURE_FAILED, NULL);
         goto out;
     }
@@ -1095,7 +1095,7 @@ server_init(xlator_t *this)
 
     dict_foreach(this->options, get_auth_types, conf->auth_modules);
     ret = validate_auth_options(this, this->options);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         /* logging already done in validate_auth_options function. */
         goto out;
     }
@@ -1108,25 +1108,25 @@ server_init(xlator_t *this)
     }
 
     ret = dict_get_str_boolean(this->options, "manage-gids", _gf_false);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         conf->server_manage_gids = _gf_false;
     else
         conf->server_manage_gids = ret;
 
     GF_OPTION_INIT("gid-timeout", conf->gid_cache_timeout, int32, out);
-    if (gid_cache_init(&conf->gid_cache, conf->gid_cache_timeout) < 0) {
+    if (IS_ERROR(gid_cache_init(&conf->gid_cache, conf->gid_cache_timeout))) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PS_MSG_INIT_GRP_CACHE_ERROR, NULL);
         goto out;
     }
 
     ret = dict_get_str_boolean(this->options, "strict-auth-accept", _gf_false);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         conf->strict_auth_enabled = _gf_false;
     else
         conf->strict_auth_enabled = ret;
 
     ret = dict_get_str_boolean(this->options, "dynamic-auth", _gf_true);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         conf->dync_auth = _gf_true;
     else
         conf->dync_auth = ret;
@@ -1141,7 +1141,7 @@ server_init(xlator_t *this)
 
     ret = rpcsvc_set_outstanding_rpc_limit(
         conf->rpc, this->options, RPCSVC_DEFAULT_OUTSTANDING_RPC_LIMIT);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, PS_MSG_RPC_CONFIGURE_FAILED, NULL);
         goto out;
     }
@@ -1234,13 +1234,13 @@ server_init(xlator_t *this)
         lim.rlim_cur = 1048576;
         lim.rlim_max = 1048576;
 
-        if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
+        if (IS_ERROR(setrlimit(RLIMIT_NOFILE, &lim))) {
             gf_smsg(this->name, GF_LOG_WARNING, errno, PS_MSG_ULIMIT_SET_FAILED,
                     "errno=%s", strerror(errno), NULL);
             lim.rlim_cur = 65536;
             lim.rlim_max = 65536;
 
-            if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
+            if (IS_ERROR(setrlimit(RLIMIT_NOFILE, &lim))) {
                 gf_smsg(this->name, GF_LOG_WARNING, errno, PS_MSG_FD_NOT_FOUND,
                         "errno=%s", strerror(errno), NULL);
             } else {
@@ -1353,7 +1353,7 @@ server_process_event_upcall(xlator_t *this, void *data)
         case GF_UPCALL_CACHE_INVALIDATION:
             ret = gf_proto_cache_invalidation_from_upcall(this, &gf_c_req,
                                                           upcall_data);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
 
             up_req = &gf_c_req;
@@ -1363,7 +1363,7 @@ server_process_event_upcall(xlator_t *this, void *data)
         case GF_UPCALL_RECALL_LEASE:
             ret = gf_proto_recall_lease_from_upcall(this, &gf_recall_lease,
                                                     upcall_data);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
 
             up_req = &gf_recall_lease;
@@ -1373,7 +1373,7 @@ server_process_event_upcall(xlator_t *this, void *data)
         case GF_UPCALL_INODELK_CONTENTION:
             ret = gf_proto_inodelk_contention_from_upcall(
                 this, &gf_inodelk_contention, upcall_data);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
 
             up_req = &gf_inodelk_contention;
@@ -1383,7 +1383,7 @@ server_process_event_upcall(xlator_t *this, void *data)
         case GF_UPCALL_ENTRYLK_CONTENTION:
             ret = gf_proto_entrylk_contention_from_upcall(
                 this, &gf_entrylk_contention, upcall_data);
-            if (ret < 0)
+            if (IS_ERROR(ret))
                 goto out;
 
             up_req = &gf_entrylk_contention;
@@ -1411,7 +1411,7 @@ server_process_event_upcall(xlator_t *this, void *data)
             ret = rpcsvc_request_submit(conf->rpc, xprt, &server_cbk_prog,
                                         cbk_procnum, up_req, this->ctx,
                                         xdrproc);
-            if (ret < 0) {
+            if (IS_ERROR(ret)) {
                 gf_msg_debug(this->name, 0,
                              "Failed to send "
                              "upcall to client:%s upcall "

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -772,7 +772,7 @@ posix_init(xlator_t *this)
             ret = -1;
             goto out;
         }
-    } else if (size >= 0) {
+    } else if (IS_SUCCESS(size)) {
         /* Wrong 'gfid' is set, it should be error */
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_GFID_SET_FAILED,
                "%s: wrong value set as gfid", dir_data->data);
@@ -1164,19 +1164,19 @@ posix_init(xlator_t *this)
 out:
     if (ret) {
         if (_private) {
-            if (_private->dirfd >= 0) {
+            if (IS_SUCCESS(_private->dirfd)) {
                 sys_close(_private->dirfd);
                 _private->dirfd = -1;
             }
 
             for (i = 0; i < 256; i++) {
-                if (_private->arrdfd[i] >= 0) {
+                if (IS_SUCCESS(_private->arrdfd[i])) {
                     sys_close(_private->arrdfd[i]);
                     _private->arrdfd[i] = -1;
                 }
             }
             /*unlock brick dir*/
-            if (_private->mount_lock >= 0) {
+            if (IS_SUCCESS(_private->mount_lock)) {
                 (void)sys_close(_private->mount_lock);
                 _private->mount_lock = -1;
             }
@@ -1212,13 +1212,13 @@ posix_fini(xlator_t *this)
     }
     UNLOCK(&priv->lock);
 
-    if (priv->dirfd >= 0) {
+    if (IS_SUCCESS(priv->dirfd)) {
         sys_close(priv->dirfd);
         priv->dirfd = -1;
     }
 
     for (i = 0; i < 256; i++) {
-        if (priv->arrdfd[i] >= 0) {
+        if (IS_SUCCESS(priv->arrdfd[i])) {
             sys_close(priv->arrdfd[i]);
             priv->arrdfd[i] = -1;
         }
@@ -1251,7 +1251,7 @@ posix_fini(xlator_t *this)
         priv->fsyncer = 0;
     }
     /*unlock brick dir*/
-    if (priv->mount_lock >= 0) {
+    if (IS_SUCCESS(priv->mount_lock)) {
         (void)sys_close(priv->mount_lock);
         priv->mount_lock = -1;
     }

--- a/xlators/storage/posix/src/posix-common.c
+++ b/xlators/storage/posix/src/posix-common.c
@@ -549,15 +549,15 @@ posix_create_open_directory_based_fd(xlator_t *this, int pdirfd, char *dir_name)
     int ret = -1;
 
     ret = sys_openat(pdirfd, dir_name, (O_DIRECTORY | O_RDONLY), 0);
-    if (ret < 0 && errno == ENOENT) {
+    if (IS_ERROR(ret) && errno == ENOENT) {
         ret = sys_mkdirat(pdirfd, dir_name, 0700);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_HANDLE_CREATE,
                    "Creating directory %s failed", dir_name);
             goto out;
         }
         ret = sys_openat(pdirfd, dir_name, (O_DIRECTORY | O_RDONLY), 0);
-        if (ret < 0 && errno != EEXIST) {
+        if (IS_ERROR(ret) && errno != EEXIST) {
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_HANDLE_CREATE,
                    "error mkdir hash-1 %s ", dir_name);
             goto out;
@@ -666,7 +666,7 @@ posix_init(xlator_t *this)
             goto out;
         }
         ret = gethostname(_private->hostname, 256);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_HOSTNAME_MISSING,
                    "could not find hostname ");
         }
@@ -675,12 +675,13 @@ posix_init(xlator_t *this)
     /* Check for Extended attribute support, if not present, log it */
     size = sys_lgetxattr(dir_data->data, "user.x", &value, sizeof(value));
 
-    if ((size == -1) && (errno == EOPNOTSUPP)) {
+    if (IS_ERROR((size)) && (errno == EOPNOTSUPP)) {
         gf_msg(this->name, GF_LOG_DEBUG, 0, P_MSG_XDATA_GETXATTR,
                "getxattr returned %zd", size);
+
         tmp_data = dict_get(this->options, "mandate-attribute");
         if (tmp_data) {
-            if (gf_string2boolean(tmp_data->data, &tmp_bool) == -1) {
+            if (IS_ERROR(gf_string2boolean(tmp_data->data, &tmp_bool))) {
                 gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_INVALID_OPTION,
                        "wrong option provided for key "
                        "\"mandate-attribute\"");
@@ -709,7 +710,7 @@ posix_init(xlator_t *this)
     tmp_data = dict_get(this->options, "volume-id");
     if (tmp_data) {
         op_ret = gf_uuid_parse(tmp_data->data, dict_uuid);
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_INVALID_VOLUME_ID,
                    "wrong volume-id (%s) set"
                    " in volume file",
@@ -731,7 +732,7 @@ posix_init(xlator_t *this)
                 ret = -1;
                 goto out;
             }
-        } else if ((size == -1) && (errno == ENODATA || errno == ENOATTR)) {
+        } else if (IS_ERROR((size)) && (errno == ENODATA || errno == ENOATTR)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_VOLUME_ID_ABSENT,
                    "Extended attribute trusted.glusterfs."
                    "volume-id is absent");
@@ -740,7 +741,8 @@ posix_init(xlator_t *this)
             ret = -1;
             goto out;
 
-        } else if ((size == -1) && (errno != ENODATA) && (errno != ENOATTR)) {
+        } else if (IS_ERROR((size)) && (errno != ENODATA) &&
+                   (errno != ENOATTR)) {
             /* Wrong 'volume-id' is set, it should be error */
             gf_event(EVENT_POSIX_BRICK_VERIFICATION_FAILED, "brick=%s:%s",
                      _private->hostname, _private->base_path);
@@ -770,13 +772,13 @@ posix_init(xlator_t *this)
             ret = -1;
             goto out;
         }
-    } else if (size != -1) {
+    } else if (size >= 0) {
         /* Wrong 'gfid' is set, it should be error */
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_GFID_SET_FAILED,
                "%s: wrong value set as gfid", dir_data->data);
         ret = -1;
         goto out;
-    } else if ((size == -1) && (errno != ENODATA) && (errno != ENOATTR)) {
+    } else if (IS_ERROR((size)) && (errno != ENODATA) && (errno != ENOATTR)) {
         /* Wrong 'gfid' is set, it should be error */
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_GFID_SET_FAILED,
                "%s: failed to fetch gfid", dir_data->data);
@@ -786,7 +788,7 @@ posix_init(xlator_t *this)
         /* First time volume, set the GFID */
         size = sys_lsetxattr(dir_data->data, "trusted.gfid", rootgfid, 16,
                              XATTR_CREATE);
-        if (size == -1) {
+        if (IS_ERROR(size)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_GFID_SET_FAILED,
                    "%s: failed to set gfid", dir_data->data);
             ret = -1;
@@ -797,7 +799,7 @@ posix_init(xlator_t *this)
     ret = 0;
 
     size = sys_lgetxattr(dir_data->data, POSIX_ACL_ACCESS_XATTR, NULL, 0);
-    if ((size < 0) && (errno == ENOTSUP)) {
+    if (IS_ERROR((size)) && (errno == ENOTSUP)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_ACL_NOTSUP,
                "Posix access control list is not supported.");
         gf_event(EVENT_POSIX_ACL_NOT_SUPPORTED, "brick=%s:%s",
@@ -843,7 +845,8 @@ posix_init(xlator_t *this)
     _private->export_statfs = 1;
     tmp_data = dict_get(this->options, "export-statfs-size");
     if (tmp_data) {
-        if (gf_string2boolean(tmp_data->data, &_private->export_statfs) == -1) {
+        if (IS_ERROR(
+                gf_string2boolean(tmp_data->data, &_private->export_statfs))) {
             ret = -1;
             gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_INVALID_OPTION_VAL,
                    "'export-statfs-size' takes only boolean "
@@ -873,7 +876,7 @@ posix_init(xlator_t *this)
 
     tmp_data = dict_get(this->options, "o-direct");
     if (tmp_data) {
-        if (gf_string2boolean(tmp_data->data, &_private->o_direct) == -1) {
+        if (IS_ERROR(gf_string2boolean(tmp_data->data, &_private->o_direct))) {
             ret = -1;
             gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_INVALID_OPTION_VAL,
                    "wrong option provided for 'o-direct'");
@@ -928,8 +931,8 @@ posix_init(xlator_t *this)
      */
     _private->mount_lock = sys_open(dir_data->data, (O_DIRECTORY | O_RDONLY),
                                     0);
-    if (_private->mount_lock < 0) {
-        ret = -1;
+    if (IS_ERROR(_private->mount_lock)) {
+        ret = _private->mount_lock;
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_DIR_OPERATION_FAILED,
                "Could not lock brick directory (%s)", strerror(op_errno));
@@ -941,14 +944,14 @@ posix_init(xlator_t *this)
         lim.rlim_cur = 1048576;
         lim.rlim_max = 1048576;
 
-        if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
+        if (IS_ERROR(setrlimit(RLIMIT_NOFILE, &lim))) {
             gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_SET_ULIMIT_FAILED,
                    "Failed to set 'ulimit -n "
                    " 1048576'");
             lim.rlim_cur = 65536;
             lim.rlim_max = 65536;
 
-            if (setrlimit(RLIMIT_NOFILE, &lim) == -1) {
+            if (IS_ERROR(setrlimit(RLIMIT_NOFILE, &lim))) {
                 gf_msg(this->name, GF_LOG_WARNING, errno,
                        P_MSG_SET_FILE_MAX_FAILED,
                        "Failed to set maximum allowed open "
@@ -964,7 +967,7 @@ posix_init(xlator_t *this)
     _private->shared_brick_count = 1;
     ret = dict_get_int32(this->options, "shared-brick-count",
                          &_private->shared_brick_count);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_INVALID_OPTION_VAL,
                "'shared-brick-count' takes only integer "
                "values");
@@ -976,7 +979,7 @@ posix_init(xlator_t *this)
              GF_HIDDEN_PATH);
     hdirfd = posix_create_open_directory_based_fd(this, _private->mount_lock,
                                                   dir_handle);
-    if (hdirfd < 0) {
+    if (IS_ERROR(hdirfd)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_HANDLE_CREATE,
                "error open directory failed for dir %s", dir_handle);
         ret = -1;
@@ -987,7 +990,7 @@ posix_init(xlator_t *this)
         snprintf(fhash, sizeof(fhash), "%02x", i);
         _private->arrdfd[i] = posix_create_open_directory_based_fd(this, hdirfd,
                                                                    fhash);
-        if (_private->arrdfd[i] < 0) {
+        if (IS_ERROR(_private->arrdfd[i])) {
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_HANDLE_CREATE,
                    "error openat failed for file %s", fhash);
             ret = -1;
@@ -996,7 +999,7 @@ posix_init(xlator_t *this)
     }
 
     op_ret = posix_handle_init(this);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_HANDLE_CREATE,
                "Posix handle setup failed");
         ret = -1;
@@ -1004,7 +1007,7 @@ posix_init(xlator_t *this)
     }
 
     op_ret = posix_handle_trash_init(this);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_HANDLE_CREATE_TRASH,
                "Posix landfill setup failed");
         ret = -1;
@@ -1012,7 +1015,7 @@ posix_init(xlator_t *this)
     }
 
     op_ret = posix_create_unlink_dir(this);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_HANDLE_CREATE,
                "Creation of unlink directory failed");
         ret = -1;
@@ -1032,7 +1035,7 @@ posix_init(xlator_t *this)
     if (_private->aio_configured) {
         op_ret = posix_aio_on(this);
 
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_POSIX_AIO,
                    "Posix AIO init failed");
             ret = -1;
@@ -1235,7 +1238,7 @@ posix_fini(xlator_t *this)
     if (priv->janitor) {
         /*TODO: Make sure the synctask is also complete */
         ret = gf_tw_del_timer(this->ctx->tw->timer_wheel, priv->janitor);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_TIMER_DELETE_FAILED,
                    "Failed to delete janitor timer");
         }

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -109,7 +109,7 @@ posix_symlinks_match(xlator_t *this, loc_t *loc, uuid_t gfid)
 
     MAKE_HANDLE_GFID_PATH(dir_handle, this, gfid);
     len = sys_readlink(dir_handle, linkname_actual, PATH_MAX);
-    if (len < 0 || len == PATH_MAX) {
+    if (IS_ERROR(len) || len == PATH_MAX) {
         if (len == PATH_MAX) {
             errno = EINVAL;
         }
@@ -143,7 +143,7 @@ posix_dict_set_nlink(dict_t *req, dict_t *res, int32_t nlink)
         goto out;
 
     ret = dict_set_uint32(res, GF_RESPONSE_LINK_COUNT_XDATA, nlink);
-    if (ret == -1)
+    if (IS_ERROR(ret))
         gf_msg("posix", GF_LOG_WARNING, 0, P_MSG_SET_XDATA_FAIL,
                "Failed to set GF_RESPONSE_LINK_COUNT_XDATA");
 out:
@@ -190,31 +190,29 @@ posix_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     if (__is_root_gfid(loc->pargfid) && loc->name &&
         (strcmp(loc->name, GF_HIDDEN_PATH) == 0)) {
         gf_msg(this->name, GF_LOG_WARNING, EPERM, P_MSG_LOOKUP_NOT_PERMITTED,
-               "Lookup issued on %s,"
-               " which is not permitted",
-               GF_HIDDEN_PATH);
+               "Lookup issued on %s, which is not permitted", GF_HIDDEN_PATH);
         op_errno = EPERM;
-        op_ret = -1;
+        op_ret = SET_ERROR(0, GF_XLATOR_POSIX, P_MSG_LOOKUP_NOT_PERMITTED);
         goto out;
     }
 
     op_ret = dict_get_int32_sizen(xdata, GF_GFIDLESS_LOOKUP, &gfidless);
-    op_ret = -1;
+    op_ret = SET_ERROR(0, GF_XLATOR_POSIX, P_MSG_LSTAT_FAILED);
     if (gf_uuid_is_null(loc->pargfid) || (loc->name == NULL)) {
         /* nameless lookup */
         MAKE_INODE_HANDLE(real_path, this, loc, &buf);
     } else {
         MAKE_ENTRY_HANDLE(real_path, par_path, this, loc, &buf);
         if (!real_path || !par_path) {
-            op_ret = -1;
+            op_ret = SET_ERROR(0, GF_XLATOR_POSIX, P_MSG_LSTAT_FAILED);
             op_errno = ESTALE;
             goto out;
         }
         if (gf_uuid_is_null(loc->inode->gfid)) {
             op_ret = posix_gfid_heal(this, real_path, loc, xdata);
-            if (op_ret < 0) {
+            if (IS_ERROR(op_ret)) {
                 op_errno = -op_ret;
-                op_ret = -1;
+                op_ret = SET_ERROR(0, GF_XLATOR_POSIX, P_MSG_LSTAT_FAILED);
                 goto out;
             }
             MAKE_ENTRY_HANDLE(real_path, par_path, this, loc, &buf);
@@ -222,13 +220,12 @@ posix_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     }
 
     op_errno = errno;
-
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno != ENOENT) {
             gf_msg(this->name, GF_LOG_WARNING, op_errno, P_MSG_LSTAT_FAILED,
                    "lstat on %s failed", real_path ? real_path : "null");
         }
-        entry_ret = -1;
+        entry_ret = op_ret;
         if (loc_is_nameless(loc)) {
             if (!op_errno)
                 op_errno = ESTALE;
@@ -259,7 +256,7 @@ posix_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
         if (dict_get_sizen(xdata, GF_CLEAN_WRITE_PROTECTION)) {
             ret = sys_lremovexattr(real_path, GF_PROTECT_FROM_EXTERNAL_WRITES);
-            if (ret == -1 && (errno != ENODATA && errno != ENOATTR))
+            if (IS_ERROR(ret) && (errno != ENODATA && errno != ENOATTR))
                 gf_msg(this->name, GF_LOG_ERROR, P_MSG_XATTR_NOT_REMOVED, errno,
                        "removexattr failed. key %s path %s",
                        GF_PROTECT_FROM_EXTERNAL_WRITES, loc->path);
@@ -273,7 +270,7 @@ posix_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
                                  loc->pargfid);
 
             op_ret = posix_inode_ctx_get_all(loc->inode, this, &ctx);
-            if (op_ret < 0) {
+            if (IS_ERROR(op_ret)) {
                 op_errno = ENOMEM;
                 goto out;
             }
@@ -293,7 +290,7 @@ parent:
     if (par_path) {
         op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path,
                              &postparent, _gf_false);
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             op_errno = errno;
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                    "post-operation lstat on"
@@ -313,10 +310,8 @@ parent:
 out:
     if (!op_ret && !gfidless && gf_uuid_is_null(buf.ia_gfid)) {
         gf_msg(this->name, GF_LOG_ERROR, ENODATA, P_MSG_NULL_GFID,
-               "buf->ia_gfid is null for "
-               "%s",
-               (real_path) ? real_path : "");
-        op_ret = -1;
+               "buf->ia_gfid is null for %s", (real_path) ? real_path : "");
+        op_ret = SET_ERROR(0, GF_XLATOR_POSIX, P_MSG_NULL_GFID);
         op_errno = ENODATA;
     }
 
@@ -355,7 +350,7 @@ posix_set_gfid2path_xattr(xlator_t *this, const char *path, uuid_t pgfid,
     snprintf(key, key_size, GFID2PATH_XATTR_KEY_PREFIX "%s", xxh64);
 
     ret = sys_lsetxattr(path, key, pgfid_bname, len, XATTR_CREATE);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_PGFID_OP,
                "setting gfid2path xattr failed on %s: key = %s ", path, key);
     }
@@ -421,7 +416,7 @@ posix_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "pre-operation lstat on parent of %s failed", real_path);
@@ -467,13 +462,13 @@ real_op:
 #endif /* __NetBSD__ */
         op_ret = sys_mknod(real_path, mode, dev);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         if ((op_errno == EINVAL) && S_ISREG(mode)) {
             /* Over Darwin, mknod with (S_IFREG|mode)
                doesn't work */
             tmp_fd = sys_creat(real_path, mode);
-            if (tmp_fd == -1) {
+            if (IS_ERROR(tmp_fd)) {
                 gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_CREATE_FAILED,
                        "create failed on"
                        "%s",
@@ -496,7 +491,7 @@ real_op:
 
 #ifndef HAVE_SET_FSID
     op_ret = sys_lchown(real_path, frame->root->uid, gid);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LCHOWN_FAILED,
                "lchown on %s failed", real_path);
@@ -515,7 +510,7 @@ post_op:
         MAKE_PGFID_XATTR_KEY(pgfid_xattr_key, PGFID_XATTR_KEY_PREFIX,
                              loc->pargfid);
         op_ret = posix_inode_ctx_get_all(loc->inode, this, &ctx);
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             op_errno = ENOMEM;
             goto out;
         }
@@ -556,7 +551,7 @@ post_op:
     }
 
     op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_MKNOD_FAILED,
                "mknod on %s failed", real_path);
@@ -567,7 +562,7 @@ post_op:
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "post-operation lstat on parent %s failed", par_path);
@@ -581,7 +576,7 @@ post_op:
 out:
     SET_TO_OLD_FS_ID();
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if (entry_created) {
             if (S_ISREG(mode))
                 sys_unlink(real_path);
@@ -727,7 +722,7 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "pre-operation lstat on parent %s failed", par_path);
@@ -764,7 +759,7 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
             disk_xattr[size] = '\0';
 
             size = sys_lgetxattr(par_path, xattr_name, disk_xattr, size);
-            if (size == -1) {
+            if (IS_ERROR(size)) {
                 if (disk_xattr) {
                     GF_FREE(disk_xattr);
                     disk_xattr = NULL;
@@ -785,7 +780,7 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
                        " buffer overflow",
                        pgfid, loc->name, xattr_name, par_path);
                 size = sys_lgetxattr(par_path, xattr_name, NULL, 0);
-                if (size == -1) {
+                if (IS_ERROR(size)) {
                     op_ret = -1;
                     op_errno = errno;
                     gf_msg(this->name, GF_LOG_ERROR, errno,
@@ -808,7 +803,7 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
                 }
                 disk_xattr[size] = '\0';
                 size = sys_lgetxattr(par_path, xattr_name, disk_xattr, size);
-                if (size == -1) {
+                if (IS_ERROR(size)) {
                     op_errno = errno;
                     gf_msg(this->name, GF_LOG_ERROR, errno,
                            P_MSG_PREOP_CHECK_FAILED,
@@ -843,7 +838,7 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
                 }
 
                 op_errno = dict_set_int8(xdata_rsp, GF_PREOP_CHECK_FAILED, 1);
-                if (op_errno < 0)
+                if (IS_ERROR(op_errno))
                     op_errno = errno;
                 goto out;
             }
@@ -855,7 +850,7 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 
     op_ret = sys_mkdir(real_path, mode);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_MKDIR_FAILED,
                "mkdir of %s failed", real_path);
@@ -866,7 +861,7 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
 #ifndef HAVE_SET_FSID
     op_ret = sys_chown(real_path, frame->root->uid, gid);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_CHOWN_FAILED,
                "chown on %s failed", real_path);
@@ -896,7 +891,7 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 
     op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "lstat on %s failed", real_path);
@@ -907,7 +902,7 @@ posix_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "post-operation lstat on parent of %s failed", real_path);
@@ -924,7 +919,7 @@ out:
     if (disk_xattr)
         GF_FREE(disk_xattr);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if (entry_created)
             sys_rmdir(real_path);
 
@@ -957,7 +952,7 @@ posix_add_unlink_to_ctx(inode_t *inode, xlator_t *this, char *unlink_path)
 
     ctx = GF_UNLINK_TRUE;
     ret = posix_inode_ctx_set_unlink_flag(inode, this, ctx);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         goto out;
     }
 
@@ -986,13 +981,13 @@ posix_move_gfid_to_unlink(xlator_t *this, uuid_t gfid, loc_t *loc)
     gf_msg_debug(this->name, 0, "Moving gfid: %s to unlink_path : %s",
                  gfid_path, unlink_path);
     ret = sys_rename(gfid_path, unlink_path);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_UNLINK_FAILED,
                "Creation of unlink entry failed for gfid: %s", unlink_path);
         goto out;
     }
     ret = posix_add_unlink_to_ctx(loc->inode, this, unlink_path);
-    if (ret < 0)
+    if (IS_ERROR(ret))
         goto out;
 
 out:
@@ -1058,7 +1053,7 @@ posix_unlink_gfid_handle_and_entry(call_frame_t *frame, xlator_t *this,
         locked = _gf_false;
     }
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         if (op_errno)
             *op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_UNLINK_FAILED,
@@ -1143,7 +1138,7 @@ posix_remove_gfid2path_xattr(xlator_t *this, const char *path, uuid_t pgfid,
     snprintf(key, key_size, GFID2PATH_XATTR_KEY_PREFIX "%s", xxh64);
 
     ret = sys_lremovexattr(path, key);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_PGFID_OP,
                "removing gfid2path xattr failed on %s: key = %s", path, key);
     }
@@ -1200,7 +1195,7 @@ posix_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "pre-operation lstat on parent %s failed", par_path);
@@ -1253,7 +1248,7 @@ posix_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     if (fdstat_requested ||
         (priv->background_unlink && IA_ISREG(loc->inode->ia_type))) {
         fd = sys_open(real_path, O_RDONLY, 0);
-        if (fd == -1) {
+        if (IS_ERROR(fd)) {
             op_ret = -1;
             op_errno = errno;
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_OPEN_FAILED,
@@ -1266,7 +1261,7 @@ posix_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
         MAKE_PGFID_XATTR_KEY(pgfid_xattr_key, PGFID_XATTR_KEY_PREFIX,
                              loc->pargfid);
         op_ret = posix_inode_ctx_get_all(loc->inode, this, &ctx);
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             op_errno = ENOMEM;
             goto out;
         }
@@ -1278,7 +1273,7 @@ posix_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     unlock:
         pthread_mutex_unlock(&ctx->pgfid_lock);
 
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_XATTR_FAILED,
                    "modification of "
                    "parent gfid xattr failed (path:%s gfid:%s)",
@@ -1292,7 +1287,7 @@ posix_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     if (priv->gfid2path && (stbuf.ia_nlink > 1)) {
         op_ret = posix_remove_gfid2path_xattr(this, real_path, loc->pargfid,
                                               loc->name);
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             /* Allow unlink if pgfid xattr is not set. */
             if (errno != ENOATTR)
                 goto out;
@@ -1319,13 +1314,13 @@ posix_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     op_ret = posix_unlink_gfid_handle_and_entry(frame, this, real_path, &stbuf,
                                                 &op_errno, loc, get_link_count,
                                                 unwind_dict);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
     if (fdstat_requested) {
         op_ret = posix_fdstat(this, loc->inode, fd, &postbuf);
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             op_errno = errno;
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
                    "post operation "
@@ -1334,7 +1329,7 @@ posix_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
             goto out;
         }
         op_ret = posix_set_iatt_in_dict(unwind_dict, NULL, &postbuf);
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             op_errno = ENOMEM;
             gf_msg(this->name, GF_LOG_ERROR, ENOMEM, P_MSG_DICT_SET_FAILED,
                    "failed to set fdstat in dict");
@@ -1343,7 +1338,7 @@ posix_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "post-operation lstat on parent %s failed", par_path);
@@ -1427,7 +1422,7 @@ posix_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "pre-operation lstat on parent %s failed", par_path);
@@ -1436,7 +1431,7 @@ posix_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     if (flags) {
         op_ret = sys_mkdir(priv->trash_path, 0755);
-        if (errno != EEXIST && op_ret == -1) {
+        if (IS_ERROR(errno != EEXIST && op_ret)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_MKDIR_FAILED,
                    "mkdir of %s failed", priv->trash_path);
         } else {
@@ -1461,12 +1456,12 @@ posix_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
         op_errno = ENOTEMPTY;
 
     /* No need to log a common error as ENOTEMPTY */
-    if (op_ret == -1 && op_errno != ENOTEMPTY) {
+    if (IS_ERROR(op_ret) && op_errno != ENOTEMPTY) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_RMDIR_FAILED,
                "rmdir of %s failed", real_path);
     }
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ENOTEMPTY) {
             gf_msg_debug(this->name, 0, "%s on %s failed",
                          (flags) ? "rename" : "rmdir", real_path);
@@ -1480,7 +1475,7 @@ posix_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "post-operation lstat on parent of %s failed", par_path);
@@ -1550,7 +1545,7 @@ posix_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "pre-operation lstat on parent %s failed", par_path);
@@ -1563,7 +1558,7 @@ posix_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
 
     op_ret = sys_symlink(linkname, real_path);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_SYMLINK_FAILED,
                "symlink of %s --> %s failed", real_path, linkname);
@@ -1576,7 +1571,7 @@ posix_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
 
 #ifndef HAVE_SET_FSID
     op_ret = sys_lchown(real_path, frame->root->uid, gid);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LCHOWN_FAILED,
                "lchown failed on %s", real_path);
@@ -1619,7 +1614,7 @@ ignore:
     }
 
     op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "lstat failed on %s", real_path);
@@ -1628,7 +1623,7 @@ ignore:
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "post-operation lstat on parent %s failed", par_path);
@@ -1642,7 +1637,7 @@ ignore:
 out:
     SET_TO_OLD_FS_ID();
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if (entry_created)
             sys_unlink(real_path);
 
@@ -1732,7 +1727,7 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     op_ret = posix_pstat(this, oldloc->parent, oldloc->pargfid, par_oldpath,
                          &preoldparent, _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "pre-operation lstat on parent %s failed", par_oldpath);
@@ -1741,7 +1736,7 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     op_ret = posix_pstat(this, newloc->parent, newloc->pargfid, par_newpath,
                          &prenewparent, _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "pre-operation lstat on parent of %s failed", par_newpath);
@@ -1750,7 +1745,7 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     op_ret = posix_pstat(this, newloc->inode, NULL, real_newpath, &stbuf,
                          _gf_false);
-    if ((op_ret == -1) && (errno == ENOENT)) {
+    if (IS_ERROR((op_ret)) && (errno == ENOENT)) {
         was_present = 0;
     } else {
         gf_uuid_copy(victim, stbuf.ia_gfid);
@@ -1779,7 +1774,7 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 
     op_ret = posix_inode_ctx_get_all(oldloc->inode, this, &ctx_old);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         op_ret = -1;
         op_errno = ENOMEM;
         goto out;
@@ -1787,7 +1782,7 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     if (newloc->inode) {
         op_ret = posix_inode_ctx_get_all(newloc->inode, this, &ctx_new);
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             op_ret = -1;
             op_errno = ENOMEM;
             goto out;
@@ -1813,7 +1808,7 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
             get_link_count = _gf_true;
             op_ret = posix_pstat(this, newloc->inode, newloc->gfid,
                                  real_newpath, &stbuf, _gf_false);
-            if ((op_ret == -1) && (errno != ENOENT)) {
+            if (IS_ERROR((op_ret)) && (errno != ENOENT)) {
                 op_errno = errno;
                 gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                        "lstat on %s failed", real_newpath);
@@ -1822,7 +1817,7 @@ posix_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
         }
 
         op_ret = sys_rename(real_oldpath, real_newpath);
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             op_errno = errno;
             if (op_errno == ENOTEMPTY) {
                 gf_msg_debug(this->name, 0,
@@ -1878,7 +1873,7 @@ unlock:
     }
     pthread_mutex_unlock(&ctx_old->pgfid_lock);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_XATTR_FAILED,
                "modification of "
                "parent gfid xattr failed (gfid:%s)",
@@ -1899,7 +1894,7 @@ unlock:
 
     op_ret = posix_pstat(this, newloc->inode, NULL, real_newpath, &stbuf,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "lstat on %s failed", real_newpath);
@@ -1913,7 +1908,7 @@ unlock:
 
     op_ret = posix_pstat(this, oldloc->parent, oldloc->pargfid, par_oldpath,
                          &postoldparent, _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "post-operation lstat on parent %s failed", par_oldpath);
@@ -1925,7 +1920,7 @@ unlock:
 
     op_ret = posix_pstat(this, newloc->parent, newloc->pargfid, par_newpath,
                          &postnewparent, _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "post-operation lstat on parent %s failed", par_newpath);
@@ -2012,7 +2007,7 @@ posix_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     op_ret = posix_pstat(this, newloc->parent, newloc->pargfid, par_newpath,
                          &preparent, _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "lstat failed: %s", par_newpath);
@@ -2021,7 +2016,7 @@ posix_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     op_ret = sys_link(real_oldpath, real_newpath);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LINK_FAILED,
                "link %s to %s failed", real_oldpath, real_newpath);
@@ -2032,7 +2027,7 @@ posix_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     op_ret = posix_pstat(this, newloc->inode, NULL, real_newpath, &stbuf,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "lstat on %s failed", real_newpath);
@@ -2043,7 +2038,7 @@ posix_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     op_ret = posix_pstat(this, newloc->parent, newloc->pargfid, par_newpath,
                          &postparent, _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "lstat failed: %s", par_newpath);
@@ -2058,7 +2053,7 @@ posix_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
                              newloc->pargfid);
 
         op_ret = posix_inode_ctx_get_all(newloc->inode, this, &ctx);
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             op_errno = ENOMEM;
             goto out;
         }
@@ -2071,7 +2066,7 @@ posix_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     unlock:
         pthread_mutex_unlock(&ctx->pgfid_lock);
 
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_XATTR_FAILED,
                    "modification of "
                    "parent gfid xattr failed (path:%s gfid:%s)",
@@ -2105,7 +2100,7 @@ out:
                         (oldloc) ? oldloc->inode : NULL, &stbuf, &preparent,
                         &postparent, NULL);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if (entry_created)
             sys_unlink(real_newpath);
     }
@@ -2168,14 +2163,14 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
     SET_FS_ID(frame->root->uid, gid);
     if (!real_path || !par_path) {
-        op_ret = -1;
+        op_ret = SET_ERROR(0, GF_XLATOR_POSIX, P_MSG_NULL_GFID);
         op_errno = ESTALE;
         goto out;
     }
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "pre-operation lstat on parent %s failed", par_path);
@@ -2193,13 +2188,14 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     }
 
     op_ret = posix_pstat(this, loc->inode, NULL, real_path, &stbuf, _gf_false);
-    if ((op_ret == -1) && (errno == ENOENT)) {
+    if (IS_ERROR(op_ret) && (errno == ENOENT)) {
         was_present = 0;
     }
 
     if (!was_present) {
         if (posix_is_layout_stale(xdata, par_path, this)) {
-            op_ret = -1;
+            /* FIXME: relook at error 'reasons' */
+            op_ret = SET_ERROR(0, GF_XLATOR_POSIX, P_MSG_NULL_GFID);
             op_errno = EIO;
             if (!xdata_rsp) {
                 xdata_rsp = dict_new();
@@ -2209,8 +2205,8 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
                 }
             }
 
-            if (dict_set_int32_sizen(xdata_rsp, GF_PREOP_CHECK_FAILED, 1) ==
-                -1) {
+            if (IS_ERROR(dict_set_int32_sizen(xdata_rsp, GF_PREOP_CHECK_FAILED,
+                                              1))) {
                 gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_DICT_SET_FAILED,
                        "setting key %s in dict failed", GF_PREOP_CHECK_FAILED);
             }
@@ -2226,9 +2222,9 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     mode = posix_override_umask(mode, mode_bit);
     _fd = sys_open(real_path, _flags, mode);
 
-    if (_fd == -1) {
+    if (IS_ERROR(_fd)) {
         op_errno = errno;
-        op_ret = -1;
+        op_ret = SET_ERROR(0, GF_XLATOR_BACKEND, P_MSG_OPEN_FAILED);
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_OPEN_FAILED,
                "open on %s failed", real_path);
         goto out;
@@ -2243,14 +2239,16 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
 #ifndef HAVE_SET_FSID
     op_ret = sys_chown(real_path, frame->root->uid, gid);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
+        op_ret = SET_ERROR(0, GF_XLATOR_BACKEND, P_MSG_CHOWN_FAILED);
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_CHOWN_FAILED,
                "chown on %s failed", real_path);
     }
 #endif
     op_ret = posix_acl_xattr_set(this, real_path, xdata);
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
+        op_ret = SET_ERROR(0, GF_XLATOR_POSIX, P_MSG_ACL_FAILED);
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_ACL_FAILED,
                "setting ACLs on %s failed", real_path);
     }
@@ -2268,7 +2266,9 @@ posix_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     }
 ignore:
     op_ret = posix_entry_create_xattr_set(this, loc, real_path, xdata);
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
+        /* FIXME: isn't op_ret already set properly in below layer? */
+        op_ret = SET_ERROR(0, GF_XLATOR_POSIX, P_MSG_XATTR_FAILED);
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_XATTR_FAILED,
                "setting xattrs on %s failed ", real_path);
     }
@@ -2276,7 +2276,8 @@ ignore:
 fill_stat:
     op_ret = posix_gfid_set(this, real_path, loc, xdata, frame->root->pid,
                             &op_errno);
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
+        op_ret = SET_ERROR(0, GF_XLATOR_POSIX, P_MSG_GFID_FAILED);
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_GFID_FAILED,
                "setting gfid on %s failed", real_path);
         goto out;
@@ -2285,7 +2286,7 @@ fill_stat:
     }
 
     op_ret = posix_fdstat(this, loc->inode, _fd, &stbuf);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_FSTAT_FAILED,
                "fstat on %d failed", _fd);
@@ -2296,7 +2297,7 @@ fill_stat:
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
                          _gf_false);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "post-operation lstat on parent %s failed", par_path);
@@ -2305,7 +2306,7 @@ fill_stat:
 
     posix_set_parent_ctime(frame, this, par_path, -1, loc->parent, &postparent);
 
-    op_ret = -1;
+    op_ret = SET_ERROR(0, GF_XLATOR_POSIX, P_MSG_LSTAT_FAILED);
     pfd = GF_CALLOC(1, sizeof(*pfd), gf_posix_mt_posix_fd);
     if (!pfd) {
         op_errno = errno;
@@ -2325,7 +2326,7 @@ fill_stat:
 out:
     SET_TO_OLD_FS_ID();
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if (_fd != -1)
             sys_close(_fd);
 
@@ -2380,7 +2381,7 @@ posix_put(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &preparent,
                          _gf_false);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "pre-operation lstat on parent %s failed", par_path);
@@ -2400,7 +2401,7 @@ posix_put(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
      * call posix_create() as it calls STACK_UNWIND. Hence using syncop()
      */
     op_ret = syncop_create(this, loc, flags, mode, fd, &stbuf, xdata, NULL);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_CREATE_FAILED,
                "create of %s failed", loc->path);
@@ -2409,7 +2410,7 @@ posix_put(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     op_ret = posix_pstat(this, loc->parent, loc->pargfid, par_path, &postparent,
                          _gf_false);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "post-operation lstat on parent %s failed", par_path);
@@ -2418,7 +2419,7 @@ posix_put(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     op_ret = syncop_writev(this, fd, vector, count, offset, iobref, flags, NULL,
                            NULL, xdata, NULL);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_WRITE_FAILED,
                "write on file %s failed", loc->path);
@@ -2426,7 +2427,7 @@ posix_put(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 
     op_ret = syncop_fsetxattr(this, fd, xattr, flags, xdata, NULL);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_XATTR_FAILED,
                "setxattr on file %s failed", loc->path);
@@ -2434,7 +2435,7 @@ posix_put(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 
     op_ret = syncop_flush(this, fd, xdata, NULL);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_CLOSE_FAILED,
                "setxattr on file %s failed", loc->path);
@@ -2443,7 +2444,7 @@ posix_put(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     op_ret = posix_pstat(this, loc->inode, loc->gfid, real_path, &stbuf,
                          _gf_false);
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_LSTAT_FAILED,
                "post-operation lstat on %s failed", real_path);

--- a/xlators/storage/posix/src/posix-entry-ops.c
+++ b/xlators/storage/posix/src/posix-entry-ops.c
@@ -1431,7 +1431,7 @@ posix_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     if (flags) {
         op_ret = sys_mkdir(priv->trash_path, 0755);
-        if (IS_ERROR(errno != EEXIST && op_ret)) {
+        if ((errno != EEXIST) && IS_ERROR(op_ret)) {
             gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_MKDIR_FAILED,
                    "mkdir of %s failed", priv->trash_path);
         } else {

--- a/xlators/storage/posix/src/posix-gfid-path.c
+++ b/xlators/storage/posix/src/posix-gfid-path.c
@@ -67,12 +67,12 @@ posix_get_gfid2path(xlator_t *this, inode_t *inode, const char *real_path,
     if (IA_ISDIR(inode->ia_type)) {
         ret = posix_resolve_dirgfid_to_path(inode->gfid, priv->base_path, NULL,
                                             &path);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             ret = -1;
             goto err;
         }
         ret = dict_set_dynstr(dict, GFID2PATH_VIRT_XATTR_KEY, path);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             gf_msg(this->name, GF_LOG_WARNING, -ret, P_MSG_DICT_SET_FAILED,
                    "could not set "
                    "value for key (%s)",
@@ -99,7 +99,7 @@ posix_get_gfid2path(xlator_t *this, inode_t *inode, const char *real_path,
                        real_path);
                 size = sys_llistxattr(real_path, NULL, 0);
             }
-            if (size == -1) {
+            if (IS_ERROR(size)) {
                 *op_errno = errno;
                 if ((errno == ENOTSUP) || (errno == ENOSYS)) {
                     GF_LOG_OCCASIONALLY(gf_posix_xattr_enotsup_log, this->name,
@@ -126,7 +126,7 @@ posix_get_gfid2path(xlator_t *this, inode_t *inode, const char *real_path,
             memcpy(list, value_buf, size);
         } else {
             size = sys_llistxattr(real_path, list, size);
-            if (size < 0) {
+            if (IS_ERROR(size)) {
                 ret = -1;
                 *op_errno = errno;
                 goto err;
@@ -145,7 +145,7 @@ posix_get_gfid2path(xlator_t *this, inode_t *inode, const char *real_path,
             found = _gf_true;
             size = sys_lgetxattr(real_path, keybuffer, xattr_value,
                                  sizeof(xattr_value) - 1);
-            if (size == -1) {
+            if (IS_ERROR(size)) {
                 ret = -1;
                 *op_errno = errno;
                 gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_XATTR_FAILED,
@@ -214,7 +214,7 @@ posix_get_gfid2path(xlator_t *this, inode_t *inode, const char *real_path,
         value[bytes] = '\0';
 
         ret = dict_set_dynptr(dict, GFID2PATH_VIRT_XATTR_KEY, value, bytes);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             *op_errno = -ret;
             gf_msg(this->name, GF_LOG_ERROR, *op_errno, P_MSG_DICT_SET_FAILED,
                    "dict set operation "

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -218,7 +218,7 @@ posix_make_ancestryfromgfid(xlator_t *this, char *path, int pathsize,
         goto out;
     }
 
-    while (top >= 0) {
+    while (IS_SUCCESS(top)) {
         if (!*parent) {
             /* There's no real "root" cause for how we end up here,
              * so for now let's log this and bail out to prevent

--- a/xlators/storage/posix/src/posix-handle.c
+++ b/xlators/storage/posix/src/posix-handle.c
@@ -35,7 +35,7 @@ posix_resolve(xlator_t *this, inode_table_t *itable, inode_t *parent,
     int ret = -1;
 
     ret = posix_istat(this, NULL, parent->gfid, bname, iabuf);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_log(this->name, GF_LOG_WARNING,
                "gfid: %s, bname: %s "
                "failed",
@@ -185,7 +185,7 @@ posix_make_ancestryfromgfid(xlator_t *this, char *path, int pathsize,
                      uuid_utoa(tmp_gfid));
 
             len = sys_readlink(dir_handle, linkname, PATH_MAX);
-            if (len < 0) {
+            if (IS_ERROR(len)) {
                 *op_errno = errno;
                 gf_msg(this->name,
                        (errno == ENOENT || errno == ESTALE) ? GF_LOG_DEBUG
@@ -243,7 +243,7 @@ posix_make_ancestryfromgfid(xlator_t *this, char *path, int pathsize,
         ret = posix_make_ancestral_node(priv_base_path, path, pathsize, head,
                                         dir_stack[top], &iabuf, inode, type,
                                         xdata);
-        if (ret < 0) {
+        if (IS_ERROR(ret)) {
             *op_errno = ENOMEM;
             goto out;
         }
@@ -348,7 +348,7 @@ posix_handle_pump(xlator_t *this, char *buf, int len, int maxlen,
 
     /* is a directory's symlink-handle */
     ret = readlinkat(dirfd, tmpstr, linkname, 512);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_READLINK_FAILED,
                "internal readlink failed on %s ", base_str);
         goto err;
@@ -458,10 +458,10 @@ posix_handle_path(xlator_t *this, uuid_t gfid, const char *basename, char *ubuf,
                                 pfx_len);
         len = ret;
 
-        if (ret == -1)
+        if (IS_ERROR(ret))
             break;
         ret = sys_lstat(buf, &stat);
-    } while ((ret == -1) && errno == ELOOP);
+    } while (IS_ERROR(ret) && (errno == ELOOP));
 
 out:
     return len + 1;
@@ -608,7 +608,7 @@ posix_does_old_trash_exists(char *old_trash)
     ret = sys_lstat(old_trash, &stbuf);
     if ((ret == 0) && S_ISDIR(stbuf.st_mode)) {
         ret = sys_lgetxattr(old_trash, "trusted.gfid", gfid, 16);
-        if ((ret < 0) && (errno == ENODATA || errno == ENOATTR))
+        if (IS_ERROR(ret) && (errno == ENODATA || errno == ENOATTR))
             exists = _gf_true;
     }
     return exists;
@@ -661,7 +661,7 @@ posix_mv_old_trash_into_new_trash(xlator_t *this, char *old, char *new)
     gf_uuid_generate(dest_name);
     snprintf(dest_old, sizeof(dest_old), "%s/%s", new, uuid_utoa(dest_name));
     ret = sys_rename(old, dest_old);
-    if (ret < 0) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_HANDLE_TRASH_CREATE,
                "Not able to move %s -> %s ", old, dest_old);
     }
@@ -710,7 +710,7 @@ posix_handle_mkdir_hashes(xlator_t *this, int dirfd, uuid_t gfid)
 
     snprintf(d2, sizeof(d2), "%02x", gfid[1]);
     ret = sys_mkdirat(dirfd, d2, 0700);
-    if (ret == -1 && errno != EEXIST) {
+    if (IS_ERROR(ret) && (errno != EEXIST)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_HANDLE_CREATE,
                "error mkdir hash-2 %s ", uuid_utoa(gfid));
         return -1;
@@ -736,13 +736,13 @@ posix_handle_hard(xlator_t *this, const char *oldpath, uuid_t gfid,
     MAKE_HANDLE_ABSPATH_FD(newstr, this, gfid, dfd);
     ret = sys_fstatat(dfd, newstr, &newbuf, AT_SYMLINK_NOFOLLOW);
 
-    if (ret == -1 && errno != ENOENT) {
+    if (IS_ERROR(ret) && (errno != ENOENT)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_HANDLE_CREATE, "%s",
                uuid_utoa(gfid));
         return -1;
     }
 
-    if (ret == -1 && errno == ENOENT) {
+    if (IS_ERROR(ret) && (errno == ENOENT)) {
         snprintf(d2, sizeof(d2), "%02x", gfid[1]);
         ret = sys_fstatat(dfd, d2, &hashbuf, 0);
         if (ret) {
@@ -813,14 +813,13 @@ posix_handle_soft(xlator_t *this, const char *real_path, loc_t *loc,
     MAKE_HANDLE_RELPATH(oldpath, this, loc->pargfid, loc->name);
 
     ret = sys_fstatat(dfd, newstr, &newbuf, AT_SYMLINK_NOFOLLOW);
-
-    if (ret == -1 && errno != ENOENT) {
+    if (IS_ERROR(ret) && (errno != ENOENT)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_HANDLE_CREATE, "%s",
                newstr);
         return -1;
     }
 
-    if (ret == -1 && errno == ENOENT) {
+    if (IS_ERROR(ret) && (errno == ENOENT)) {
         if (posix_is_malformed_link(this, newpath, oldpath, strlen(oldpath))) {
             GF_ASSERT(!"Malformed link");
             errno = EINVAL;
@@ -894,7 +893,7 @@ posix_handle_unset_gfid(xlator_t *this, uuid_t gfid)
     snprintf(newstr, sizeof(newstr), "%02x/%s", gfid[1], uuid_utoa(gfid));
     ret = sys_fstatat(dfd, newstr, &stat, AT_SYMLINK_NOFOLLOW);
 
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         if (errno != ENOENT) {
             gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_HANDLE_DELETE, "%s",
                    newstr);
@@ -903,7 +902,7 @@ posix_handle_unset_gfid(xlator_t *this, uuid_t gfid)
     }
 
     ret = sys_unlinkat(dfd, newstr);
-    if (ret) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_HANDLE_DELETE,
                "unlink %s is failed", newstr);
     }
@@ -936,7 +935,7 @@ posix_handle_unset(xlator_t *this, uuid_t gfid, const char *basename)
      * doesn't fetch time attributes which is fine
      */
     ret = posix_istat(this, NULL, gfid, basename, &stat);
-    if (ret == -1) {
+    if (IS_ERROR(ret)) {
         gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_HANDLE_DELETE, "%s",
                path);
         return -1;

--- a/xlators/storage/posix/src/posix-handle.h
+++ b/xlators/storage/posix/src/posix-handle.h
@@ -27,8 +27,9 @@
     do {                                                                       \
         value = hton32(value);                                                 \
         op_ret = sys_lsetxattr(path, key, &value, sizeof(value), flags);       \
-        if (op_ret == -1) {                                                    \
+        if (IS_ERROR(op_ret)) {                                                \
             op_errno = errno;                                                  \
+            op_ret = SET_ERROR(0, GF_XLATOR_EXTERNAL, P_MSG_PGFID_OP);         \
             gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_PGFID_OP,          \
                    "setting xattr failed on %s: key = %s ", path, key);        \
             goto label;                                                        \
@@ -39,8 +40,9 @@
                                   label)                                       \
     do {                                                                       \
         op_ret = sys_lgetxattr(path, key, &value, sizeof(value));              \
-        if (op_ret == -1) {                                                    \
+        if (IS_ERROR(op_ret)) {                                                \
             op_errno = errno;                                                  \
+            op_ret = SET_ERROR(0, GF_XLATOR_EXTERNAL, P_MSG_PGFID_OP);         \
             if (op_errno == ENOATTR) {                                         \
                 value = 1;                                                     \
                 SET_PGFID_XATTR(path, key, value, flags, op_ret, this, label); \
@@ -56,8 +58,9 @@
 #define REMOVE_PGFID_XATTR(path, key, op_ret, this, label)                     \
     do {                                                                       \
         op_ret = sys_lremovexattr(path, key);                                  \
-        if (op_ret == -1) {                                                    \
+        if (IS_ERROR(op_ret)) {                                                \
             op_errno = errno;                                                  \
+            op_ret = SET_ERROR(0, GF_XLATOR_EXTERNAL, P_MSG_PGFID_OP);         \
             gf_msg(this->name, GF_LOG_WARNING, op_errno, P_MSG_PGFID_OP,       \
                    "removing xattr failed"                                     \
                    "on %s: key = %s",                                          \
@@ -70,15 +73,14 @@
 #define LINK_MODIFY_PGFID_XATTR(path, key, value, flags, op_ret, this, label)  \
     do {                                                                       \
         op_ret = sys_lgetxattr(path, key, &value, sizeof(value));              \
-        if (op_ret == -1) {                                                    \
+        if (IS_ERROR(op_ret)) {                                                \
             op_errno = errno;                                                  \
+            op_ret = SET_ERROR(0, GF_XLATOR_EXTERNAL, P_MSG_PGFID_OP);         \
             if (op_errno == ENOATTR || op_errno == ENODATA) {                  \
                 value = 1;                                                     \
             } else {                                                           \
                 gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_PGFID_OP,      \
-                       "getting xattr "                                        \
-                       "failed on %s: key = %s ",                              \
-                       path, key);                                             \
+                       "getting xattr failed on %s: key = %s ", path, key);    \
                 goto label;                                                    \
             }                                                                  \
         } else {                                                               \
@@ -93,12 +95,11 @@
                                   label)                                       \
     do {                                                                       \
         op_ret = sys_lgetxattr(path, key, &value, sizeof(value));              \
-        if (op_ret == -1) {                                                    \
+        if (IS_ERROR(op_ret)) {                                                \
             op_errno = errno;                                                  \
+            op_ret = SET_ERROR(0, GF_XLATOR_EXTERNAL, P_MSG_PGFID_OP);         \
             gf_msg(this->name, GF_LOG_WARNING, errno, P_MSG_PGFID_OP,          \
-                   "getting xattr failed on "                                  \
-                   "%s: key = %s ",                                            \
-                   path, key);                                                 \
+                   "getting xattr failed on %s: key = %s ", path, key);        \
             goto label;                                                        \
         } else {                                                               \
             value = ntoh32(value);                                             \
@@ -190,7 +191,7 @@
             }                                                                  \
             break;                                                             \
         }                                                                      \
-        /* __ret == -1 && errno == ELOOP */                                    \
+        /* __ret < 0 && errno == ELOOP */                                      \
         /* expand ELOOP */                                                     \
     } while (0)
 

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -206,7 +206,7 @@ out:
 static gf_boolean_t
 posix_xattr_ignorable(char *key)
 {
-    return gf_get_index_by_elem(posix_ignore_xattrs, key) >= 0;
+    return gf_get_index_by_elem(IS_SUCCESS(posix_ignore_xattrs, key));
 }
 
 static int
@@ -918,7 +918,7 @@ _handle_list_xattr(posix_xattr_filler_t *filler)
         key = filler->list + list_offset;
         len = strlen(key);
 
-        if (gf_get_index_by_elem(list_xattr_ignore_xattrs, key) >= 0)
+        if (IS_SUCCESS(gf_get_index_by_elem(list_xattr_ignore_xattrs, key)))
             goto next;
 
         if (posix_special_xattr(marker_xattrs, key))
@@ -1723,7 +1723,7 @@ posix_acl_xattr_set(xlator_t *this, const char *path, dict_t *xattr_req)
         ret = sys_lsetxattr(path, POSIX_ACL_ACCESS_XATTR, data->data, data->len,
                             0);
 #ifdef __FreeBSD__
-        if (ret >= 0) {
+        if (IS_SUCCESS(ret)) {
             ret = 0;
         }
 #endif /* __FreeBSD__ */
@@ -1736,7 +1736,7 @@ posix_acl_xattr_set(xlator_t *this, const char *path, dict_t *xattr_req)
         ret = sys_lsetxattr(path, POSIX_ACL_DEFAULT_XATTR, data->data,
                             data->len, 0);
 #ifdef __FreeBSD__
-        if (ret >= 0) {
+        if (IS_SUCCESS(ret)) {
             ret = 0;
         }
 #endif /* __FreeBSD__ */
@@ -2480,7 +2480,7 @@ posix_fetch_signature_xattr(char *real_path, const char *key, dict_t *xattr,
     gf_boolean_t have_val = _gf_false;
 
     xattrsize = sys_lgetxattr(real_path, key, val_buf, sizeof(val_buf) - 1);
-    if (xattrsize >= 0) {
+    if (IS_SUCCESS(xattrsize)) {
         have_val = _gf_true;
     } else {
         if (errno == ERANGE)
@@ -3521,7 +3521,7 @@ posix_is_layout_stale(dict_t *xdata, char *par_path, xlator_t *this)
     size = sys_lgetxattr(par_path, xattr_name, value_buf,
                          sizeof(value_buf) - 1);
 
-    if (size >= 0) {
+    if (IS_SUCCESS(size)) {
         have_val = _gf_true;
     } else {
         if (errno == ERANGE) {

--- a/xlators/storage/posix/src/posix-helpers.c
+++ b/xlators/storage/posix/src/posix-helpers.c
@@ -206,7 +206,7 @@ out:
 static gf_boolean_t
 posix_xattr_ignorable(char *key)
 {
-    return gf_get_index_by_elem(IS_SUCCESS(posix_ignore_xattrs, key));
+    return IS_SUCCESS(gf_get_index_by_elem(posix_ignore_xattrs, key));
 }
 
 static int
@@ -1083,7 +1083,7 @@ posix_pacl_set(const char *path, int fdnum, const char *key, const char *acl_s)
     acl_t acl = NULL;
     acl_type_t type = 0;
 
-    if (IS_ERROR((!path) && (fdnum))) {
+    if (!path && IS_ERROR(fdnum)) {
         errno = -EINVAL;
         return -1;
     }
@@ -1122,7 +1122,7 @@ posix_pacl_get(const char *path, int fdnum, const char *key, char **acl_s)
     acl_type_t type = 0;
     char *acl_tmp = NULL;
 
-    if (IS_ERROR((!path) && (fdnum))) {
+    if (!path && IS_ERROR(fdnum)) {
         errno = -EINVAL;
         return -1;
     }

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -3933,7 +3933,7 @@ posix_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 done:
     op_ret = size;
 
-    if (IS_SUCCESS(xdata && (op_ret))) {
+    if (xdata && IS_SUCCESS(op_ret)) {
         xattr_rsp = posix_xattr_fill(this, real_path, loc, NULL, -1, xdata,
                                      &buf);
     }
@@ -4235,7 +4235,7 @@ posix_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
 done:
     op_ret = size;
 
-    if (IS_SUCCESS(xdata && (op_ret))) {
+    if (xdata && IS_SUCCESS(op_ret)) {
         xattr_rsp = posix_xattr_fill(this, NULL, NULL, fd, pfd->fd, xdata,
                                      &buf);
     }

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -3727,7 +3727,7 @@ posix_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         }
 #endif
         size = sys_lgetxattr(real_path, key, value_buf, XATTR_VAL_BUF_SIZE - 1);
-        if (size >= 0) {
+        if (IS_SUCCESS(size)) {
             have_val = _gf_true;
         } else {
             if (errno == ERANGE) {
@@ -3866,7 +3866,7 @@ posix_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         have_val = _gf_false;
         size = sys_lgetxattr(real_path, keybuffer, value_buf,
                              XATTR_VAL_BUF_SIZE - 1);
-        if (size >= 0) {
+        if (IS_SUCCESS(size)) {
             have_val = _gf_true;
         } else {
             if (errno == ERANGE) {
@@ -3933,7 +3933,7 @@ posix_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 done:
     op_ret = size;
 
-    if (xdata && (op_ret >= 0)) {
+    if (IS_SUCCESS(xdata && (op_ret))) {
         xattr_rsp = posix_xattr_fill(this, real_path, loc, NULL, -1, xdata,
                                      &buf);
     }
@@ -4059,7 +4059,7 @@ posix_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
         }
 #endif
         size = sys_fgetxattr(_fd, key, value_buf, XATTR_VAL_BUF_SIZE - 1);
-        if (size >= 0) {
+        if (IS_SUCCESS(size)) {
             have_val = _gf_true;
         } else {
             if (errno == ERANGE) {
@@ -4174,7 +4174,7 @@ posix_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
         key_len = snprintf(key, sizeof(key), "%s", list + list_offset);
         have_val = _gf_false;
         size = sys_fgetxattr(_fd, key, value_buf, XATTR_VAL_BUF_SIZE - 1);
-        if (size >= 0) {
+        if (IS_SUCCESS(size)) {
             have_val = _gf_true;
         } else {
             if (errno == ERANGE) {
@@ -4235,7 +4235,7 @@ posix_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
 done:
     op_ret = size;
 
-    if (xdata && (op_ret >= 0)) {
+    if (IS_SUCCESS(xdata && (op_ret))) {
         xattr_rsp = posix_xattr_fill(this, NULL, NULL, fd, pfd->fd, xdata,
                                      &buf);
     }
@@ -4496,7 +4496,7 @@ posix_common_removexattr(call_frame_t *frame, loc_t *loc, fd_t *fd,
         }
     }
 
-    if (gf_get_index_by_elem(disallow_removexattrs, (char *)name) >= 0) {
+    if (IS_SUCCESS(gf_get_index_by_elem(disallow_removexattrs, (char *)name))) {
         gf_msg(this->name, GF_LOG_WARNING, 0, P_MSG_XATTR_NOT_REMOVED,
                "Remove xattr called on %s for file/dir %s with gfid: "
                "%s",
@@ -5733,7 +5733,7 @@ posix_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
         op_ret = posix_get_ancestry(this, fd->inode, &entries, NULL,
                                     POSIX_ANCESTRY_DENTRY, &op_errno, dict);
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             op_ret = 0;
 
             list_for_each_entry(entry, &entries.list, list) { op_ret++; }

--- a/xlators/storage/posix/src/posix-inode-handle.h
+++ b/xlators/storage/posix/src/posix-inode-handle.h
@@ -89,7 +89,7 @@
                        (loc)->path);                                           \
             }                                                                  \
             break;                                                             \
-        } /* __ret == -1 && errno == ELOOP */                                  \
+        } /* __ret < 0 && errno == ELOOP */                                    \
         else {                                                                 \
             op_ret = -1;                                                       \
         }                                                                      \

--- a/xlators/storage/posix/src/posix-metadata.c
+++ b/xlators/storage/posix/src/posix-metadata.c
@@ -114,7 +114,7 @@ posix_fetch_mdata_xattr(xlator_t *this, const char *real_path_arg, int _fd,
         size = sys_lgetxattr(real_path, GF_XATTR_MDATA_KEY, value, size);
     }
 
-    if (size == -1) {
+    if (IS_ERROR(size)) {
         *op_errno = errno;
         if (value) {
             GF_FREE(value);
@@ -144,7 +144,7 @@ posix_fetch_mdata_xattr(xlator_t *this, const char *real_path_arg, int _fd,
             size = sys_lgetxattr(real_path, GF_XATTR_MDATA_KEY, NULL, 0);
         }
 
-        if (size == -1) { /* give up now and exist with an error */
+        if (IS_ERROR(size)) { /* give up now and exist with an error */
             *op_errno = errno;
             gf_msg(this->name, GF_LOG_ERROR, *op_errno, P_MSG_XATTR_FAILED,
                    "getxattr failed on %s gfid: %s key: %s ",
@@ -168,7 +168,7 @@ posix_fetch_mdata_xattr(xlator_t *this, const char *real_path_arg, int _fd,
         } else if (real_path) {
             size = sys_lgetxattr(real_path, GF_XATTR_MDATA_KEY, value, size);
         }
-        if (size == -1) {
+        if (IS_ERROR(size)) {
             *op_errno = errno;
             gf_msg(this->name, GF_LOG_ERROR, *op_errno, P_MSG_XATTR_FAILED,
                    "getxattr failed on %s gfid: %s key: %s ",
@@ -240,7 +240,7 @@ posix_store_mdata_xattr(xlator_t *this, const char *real_path_arg, int fd,
     }
 #endif
 out:
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, errno, P_MSG_XATTR_FAILED,
                "file: %s: gfid: %s key:%s ",
                real_path ? real_path : (real_path_arg ? real_path_arg : "null"),
@@ -272,7 +272,7 @@ __posix_get_mdata_xattr(xlator_t *this, const char *real_path, int _fd,
         ret = -1;
     }
 
-    if (ret == -1 || !mdata) {
+    if (IS_ERROR(ret) || !mdata) {
         mdata = GF_CALLOC(1, sizeof(posix_mdata_t), gf_posix_mt_mdata_attr);
         if (!mdata) {
             gf_msg(this->name, GF_LOG_ERROR, ENOMEM, P_MSG_NOMEM,
@@ -493,7 +493,7 @@ posix_set_mdata_xattr(xlator_t *this, const char *real_path, int fd,
         if (ret == 0) {
             mdata = (posix_mdata_t *)(uintptr_t)ctx;
         }
-        if (ret == -1 || !mdata) {
+        if (IS_ERROR(ret) || !mdata) {
             /*
              * Do we need to fetch the data from xattr
              * If we does we can compare the value and store

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -29,6 +29,7 @@
 #endif
 
 #include <glusterfs/compat.h>
+#include <glusterfs/compat-errno.h>
 #include <glusterfs/timer.h>
 #include "posix-mem-types.h"
 #include <glusterfs/call-stub.h>
@@ -62,7 +63,8 @@
     do {                                                                       \
         if (frame->root->pid >= 0 && priv->disk_space_full &&                  \
             !dict_get_sizen(xdata, GLUSTERFS_INTERNAL_FOP_KEY)) {              \
-            op_ret = -1;                                                       \
+            op_ret = SET_ERROR(0, GF_XLATOR_POSIX,                             \
+                               P_MSG_DISK_SPACE_CHECK_FAILED);                 \
             op_errno = ENOSPC;                                                 \
             gf_msg_debug("posix", ENOSPC,                                      \
                          "disk space utilization reached limits"               \
@@ -101,15 +103,15 @@
         if (_ret) {                                                            \
             gf_msg(this->name, GF_LOG_ERROR, EINVAL, P_MSG_NULL_GFID,          \
                    "failed to get the gfid from dict for %s", loc->path);      \
-            op_ret = -1;                                                       \
             op_errno = EINVAL;                                                 \
+            op_ret = SET_ERROR(0, GF_XLATOR_POSIX, P_MSG_NULL_GFID);           \
             goto out;                                                          \
         }                                                                      \
         if (gf_uuid_is_null(_uuid_req)) {                                      \
             gf_msg(this->name, GF_LOG_ERROR, EINVAL, P_MSG_NULL_GFID,          \
                    "gfid is null for %s", loc->path);                          \
-            op_ret = -1;                                                       \
             op_errno = EINVAL;                                                 \
+            op_ret = SET_ERROR(0, GF_XLATOR_POSIX, P_MSG_NULL_GFID);           \
             goto out;                                                          \
         }                                                                      \
     } while (0)

--- a/xlators/storage/posix/src/posix.h
+++ b/xlators/storage/posix/src/posix.h
@@ -61,7 +61,7 @@
 
 #define DISK_SPACE_CHECK_AND_GOTO(frame, priv, xdata, op_ret, op_errno, out)   \
     do {                                                                       \
-        if (frame->root->pid >= 0 && priv->disk_space_full &&                  \
+        if (IS_SUCCESS(frame->root->pid) && priv->disk_space_full &&                  \
             !dict_get_sizen(xdata, GLUSTERFS_INTERNAL_FOP_KEY)) {              \
             op_ret = SET_ERROR(0, GF_XLATOR_POSIX,                             \
                                P_MSG_DISK_SPACE_CHECK_FAILED);                 \

--- a/xlators/system/posix-acl/src/posix-acl.c
+++ b/xlators/system/posix-acl/src/posix-acl.c
@@ -1966,7 +1966,6 @@ posix_acl_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     int op_errno = 0;
 
     op_errno = setxattr_scrutiny(frame, loc->inode, xattr);
-
     if (op_errno != 0)
         goto red;
 


### PR DESCRIPTION
The details of how to achieve this is described in the issue, please
refer. Idea is, utilze those unused 31bits in 'op_ret' (ie, return
value) field for identifying the exact error (or as close as possible).

Plan is to handle fop by fop for this change. Best way to see the result
is by changing the lookup() fop, as that actually is expected to return
failure most times than success.

use 'IS_ERROR(ret)' instead of (ret < 0) or (ret == -1) cases.

Updates: #280

Change-Id: If6e22e7aa170f3800c0f29156c4bfc700f790fef
Signed-off-by: Amar Tumballi <amar@kadalu.io>

