### PR TITLE
inode: don't take lock on whole table during ref/unref

### DIFF
--- a/libglusterfs/src/glusterfs/inode.h
+++ b/libglusterfs/src/glusterfs/inode.h
@@ -101,9 +101,9 @@ struct _inode {
     uuid_t gfid;
     gf_lock_t lock;
     gf_atomic_t nlookup;
+    gf_atomic_t ref;              /* reference count on this inode */
     uint32_t fd_count;            /* Open fd count */
     uint32_t active_fd_count;     /* Active open fd count */
-    uint32_t ref;                 /* reference count on this inode */
     ia_type_t ia_type;            /* what kind of file */
     struct list_head fd_list;     /* list of open files on this inode */
     struct list_head dentry_list; /* list of directory entries for this inode */


### PR DESCRIPTION
inode_ref/inode_unref are very common operation, and taking
a table->lock makes no complete sense. By making 'ref' as atomic,
we can make most part of the inode_ref/inode_unref as lock-free.

also as a side effect, removed the check for root_inode from
ref/unref functions, thus making them even leaner.

also work on making critical section smaller

 * do all the 'static' tasks outside of locked region.
 * In this patch, considering hash_dentry() and hash_gfid().
 * Also remove extra __dentry_hash exported in libglusterfs.sym

Credits: Mohit Agarwal

updates: #1000
Change-Id: I78f0d77f28ed48cdd0dc7c3489fc8ca32c36e263
Signed-off-by: Amar Tumballi <amar@kadalu.io>

