### PR TITLE
all: return value signature changes

### DIFF
--- a/api/src/glfs-fops.c
+++ b/api/src/glfs-fops.c
@@ -1172,9 +1172,9 @@ struct glfs_io {
 };
 
 static int
-glfs_io_async_cbk(int op_ret, int op_errno, call_frame_t *frame, void *cookie,
-                  struct iovec *iovec, int count, struct iatt *prebuf,
-                  struct iatt *postbuf)
+glfs_io_async_cbk(gf_return_t op_ret, int op_errno, call_frame_t *frame,
+                  void *cookie, struct iovec *iovec, int count,
+                  struct iatt *prebuf, struct iatt *postbuf)
 {
     struct glfs_io *gio = NULL;
     xlator_t *subvol = NULL;
@@ -1192,21 +1192,22 @@ glfs_io_async_cbk(int op_ret, int op_errno, call_frame_t *frame, void *cookie,
     subvol = cookie;
     glfd = gio->glfd;
     fs = glfd->fs;
+    ret = GET_RET(op_ret);
 
     if (!glfs_is_glfd_still_valid(glfd))
         goto err;
 
-    if (op_ret <= 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     } else if (gio->op == GF_FOP_READ) {
         if (!iovec) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = EINVAL;
             goto out;
         }
 
-        op_ret = iov_copy(gio->iov, gio->count, iovec, count);
-        glfd->offset = gio->offset + op_ret;
+        ret = iov_copy(gio->iov, gio->count, iovec, count);
+        glfd->offset = gio->offset + ret;
     } else if (gio->op == GF_FOP_WRITE) {
         glfd->offset = gio->offset + gio->iov->iov_len;
     }
@@ -1214,7 +1215,7 @@ glfs_io_async_cbk(int op_ret, int op_errno, call_frame_t *frame, void *cookie,
 out:
     errno = op_errno;
     if (gio->oldcb) {
-        gio->fn34(gio->glfd, op_ret, gio->data);
+        gio->fn34(gio->glfd, ret, gio->data);
     } else {
         if (prebuf) {
             prestatp = &prestat;
@@ -1226,7 +1227,7 @@ out:
             glfs_iatt_to_statx(fs, postbuf, poststatp);
         }
 
-        gio->fn(gio->glfd, op_ret, prestatp, poststatp, gio->data);
+        gio->fn(gio->glfd, ret, prestatp, poststatp, gio->data);
     }
 err:
     fd_unref(glfd->fd);
@@ -1248,8 +1249,9 @@ inval:
 
 static int
 glfs_preadv_async_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, struct iovec *iovec, int count,
-                      struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
+                      gf_return_t op_ret, int op_errno, struct iovec *iovec,
+                      int count, struct iatt *stbuf, struct iobref *iobref,
+                      dict_t *xdata)
 {
     glfs_io_async_cbk(op_ret, op_errno, frame, cookie, iovec, count, NULL,
                       stbuf);
@@ -1795,7 +1797,7 @@ pub_glfs_from_glfd(glfs_fd_t *);
 
 static int
 glfs_pwritev_async_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, struct iatt *prebuf,
+                       gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                        struct iatt *postbuf, dict_t *xdata)
 {
     glfs_io_async_cbk(op_ret, op_errno, frame, cookie, NULL, 0, prebuf,
@@ -2109,7 +2111,7 @@ pub_glfs_fsync(struct glfs_fd *glfd, struct glfs_stat *prestat,
 
 static int
 glfs_fsync_async_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     glfs_io_async_cbk(op_ret, op_errno, frame, cookie, NULL, 0, prebuf,
@@ -2462,8 +2464,9 @@ invalid_fs:
 
 static int
 glfs_ftruncate_async_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                         struct iatt *postbuf, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno,
+                         struct iatt *prebuf, struct iatt *postbuf,
+                         dict_t *xdata)
 {
     glfs_io_async_cbk(op_ret, op_errno, frame, cookie, NULL, 0, prebuf,
                       postbuf);
@@ -3368,7 +3371,7 @@ pub_glfs_seekdir(struct glfs_fd *fd, long offset)
 
 static int
 glfs_discard_async_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno,
+                       gf_return_t op_ret, int32_t op_errno,
                        struct iatt *preop_stbuf, struct iatt *postop_stbuf,
                        dict_t *xdata)
 {
@@ -3475,7 +3478,7 @@ pub_glfs_discard_async(struct glfs_fd *glfd, off_t offset, size_t len,
 
 static int
 glfs_zerofill_async_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno,
+                        gf_return_t op_ret, int32_t op_errno,
                         struct iatt *preop_stbuf, struct iatt *postop_stbuf,
                         dict_t *xdata)
 {

--- a/doc/developer-guide/coding-standard.md
+++ b/doc/developer-guide/coding-standard.md
@@ -643,7 +643,7 @@ int32_t
 sample_fop (call_frame_t *frame, xlator_t *this, ...)
 {
         char *            var1     = NULL;
-        int32_t           op_ret   = -1;
+        gf_return_t           op_ret   = -1;
         int32_t           op_errno = 0;
         DIR *             dir      = NULL;
         struct posix_fd * pfd      = NULL;

--- a/extras/create_new_xlator/new-xlator.c.tmpl
+++ b/extras/create_new_xlator/new-xlator.c.tmpl
@@ -1,5 +1,5 @@
 #pragma fragment CBK_TEMPLATE
-int32_t @FOP_PREFIX@_@NAME@_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
+int32_t @FOP_PREFIX@_@NAME@_cbk(call_frame_t *frame, void *cookie, xlator_t *this, gf_return_t op_ret,
              int32_t op_errno, @UNWIND_PARAMS@)
 {
     STACK_UNWIND_STRICT(@NAME@, frame, op_ret, op_errno, @UNWIND_ARGS@);
@@ -17,7 +17,7 @@ If you are generating the leaf xlators, remove the STACK_WIND and replace the
                FIRST_CHILD(this)->fops->@NAME@, @WIND_ARGS@);
     return 0;
 err:
-    STACK_UNWIND_STRICT(@NAME@, frame, -1, errno, @ERROR_ARGS@);
+    STACK_UNWIND_STRICT(@NAME@, frame, gf_error, errno, @ERROR_ARGS@);
     return 0;
 }
 

--- a/glusterfsd/src/glusterfsd-mgmt.c
+++ b/glusterfsd/src/glusterfsd-mgmt.c
@@ -715,7 +715,7 @@ int
 glusterfs_handle_translator_op(rpcsvc_request_t *req)
 {
     int32_t ret = -1;
-    int32_t op_ret = 0;
+    int op_ret = 0;
     gd1_mgmt_brick_op_req xlator_req = {
         0,
     };

--- a/heal/src/glfs-heal.c
+++ b/heal/src/glfs-heal.c
@@ -62,7 +62,7 @@ typedef struct glfs_info {
     int (*print_heal_op_summary)(int ret, num_entries_t *num_entries);
     int (*print_heal_status)(char *path, uuid_t gfid, char *status);
     int (*print_spb_status)(char *path, uuid_t gfid, char *status);
-    int (*end)(int op_ret, char *op_errstr);
+    int (*end)(int ret, char *op_errstr);
 } glfsh_info_t;
 
 glfsh_info_t *glfsh_output = NULL;
@@ -88,19 +88,18 @@ glfsh_init()
 }
 
 int
-glfsh_end_op_granular_entry_heal(int op_ret, char *op_errstr)
+glfsh_end_op_granular_entry_heal(int ret, char *op_errstr)
 {
     /* If error string is available, give it higher precedence.*/
-
     if (op_errstr) {
         printf("%s\n", op_errstr);
-    } else if (op_ret < 0) {
-        if (op_ret == -EAGAIN)
+    } else if (ret < 0) {
+        if (ret == -EAGAIN)
             printf(
                 "One or more entries need heal. Please execute "
                 "the command again after there are no entries "
                 "to be healed\n");
-        else if (op_ret == -ENOTCONN)
+        else if (ret == -ENOTCONN)
             printf(
                 "One or more bricks could be down. Please "
                 "execute the command again after bringing all "
@@ -110,13 +109,13 @@ glfsh_end_op_granular_entry_heal(int op_ret, char *op_errstr)
             printf(
                 "Command failed - %s. Please check the logs for"
                 " more details\n",
-                strerror(-op_ret));
+                strerror(-ret));
     }
     return 0;
 }
 
 int
-glfsh_end(int op_ret, char *op_errstr)
+glfsh_end(int ret, char *op_errstr)
 {
     if (op_errstr)
         printf("%s\n", op_errstr);
@@ -183,7 +182,6 @@ glfsh_xml_end(int op_ret, char *op_errstr)
 
     if (op_ret < 0) {
         op_errno = -op_ret;
-        op_ret = -1;
         if (op_errstr == NULL) {
             op_errstr = gf_strdup(strerror(op_errno));
             alloc = _gf_true;

--- a/libglusterfs/src/call-stub.c
+++ b/libglusterfs/src/call-stub.c
@@ -53,9 +53,9 @@ out:
 }
 
 call_stub_t *
-fop_lookup_cbk_stub(call_frame_t *frame, fop_lookup_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, inode_t *inode, struct iatt *buf,
-                    dict_t *xdata, struct iatt *postparent)
+fop_lookup_cbk_stub(call_frame_t *frame, fop_lookup_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+                    struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     call_stub_t *stub = NULL;
 
@@ -86,7 +86,7 @@ out:
 }
 
 call_stub_t *
-fop_stat_cbk_stub(call_frame_t *frame, fop_stat_cbk_t fn, int32_t op_ret,
+fop_stat_cbk_stub(call_frame_t *frame, fop_stat_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, struct iatt *buf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -115,7 +115,7 @@ out:
 }
 
 call_stub_t *
-fop_fstat_cbk_stub(call_frame_t *frame, fop_fstat_cbk_t fn, int32_t op_ret,
+fop_fstat_cbk_stub(call_frame_t *frame, fop_fstat_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iatt *buf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -148,7 +148,7 @@ out:
 
 call_stub_t *
 fop_truncate_cbk_stub(call_frame_t *frame, fop_truncate_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -181,8 +181,8 @@ out:
 
 call_stub_t *
 fop_ftruncate_cbk_stub(call_frame_t *frame, fop_ftruncate_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                       struct iatt *postbuf, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *prebuf, struct iatt *postbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -215,8 +215,8 @@ out:
 }
 
 call_stub_t *
-fop_access_cbk_stub(call_frame_t *frame, fop_access_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, dict_t *xdata)
+fop_access_cbk_stub(call_frame_t *frame, fop_access_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -248,7 +248,7 @@ out:
 
 call_stub_t *
 fop_readlink_cbk_stub(call_frame_t *frame, fop_readlink_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, const char *path,
+                      gf_return_t op_ret, int32_t op_errno, const char *path,
                       struct iatt *stbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -281,7 +281,7 @@ out:
 }
 
 call_stub_t *
-fop_mknod_cbk_stub(call_frame_t *frame, fop_mknod_cbk_t fn, int32_t op_ret,
+fop_mknod_cbk_stub(call_frame_t *frame, fop_mknod_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, inode_t *inode, struct iatt *buf,
                    struct iatt *preparent, struct iatt *postparent,
                    dict_t *xdata)
@@ -316,7 +316,7 @@ out:
 }
 
 call_stub_t *
-fop_mkdir_cbk_stub(call_frame_t *frame, fop_mkdir_cbk_t fn, int32_t op_ret,
+fop_mkdir_cbk_stub(call_frame_t *frame, fop_mkdir_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, inode_t *inode, struct iatt *buf,
                    struct iatt *preparent, struct iatt *postparent,
                    dict_t *xdata)
@@ -352,9 +352,10 @@ out:
 }
 
 call_stub_t *
-fop_unlink_cbk_stub(call_frame_t *frame, fop_unlink_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata)
+fop_unlink_cbk_stub(call_frame_t *frame, fop_unlink_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -387,7 +388,7 @@ out:
 }
 
 call_stub_t *
-fop_rmdir_cbk_stub(call_frame_t *frame, fop_rmdir_cbk_t fn, int32_t op_ret,
+fop_rmdir_cbk_stub(call_frame_t *frame, fop_rmdir_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -422,10 +423,10 @@ out:
 }
 
 call_stub_t *
-fop_symlink_cbk_stub(call_frame_t *frame, fop_symlink_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, inode_t *inode, struct iatt *buf,
-                     struct iatt *preparent, struct iatt *postparent,
-                     dict_t *xdata)
+fop_symlink_cbk_stub(call_frame_t *frame, fop_symlink_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+                     struct iatt *buf, struct iatt *preparent,
+                     struct iatt *postparent, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -458,8 +459,8 @@ out:
 }
 
 call_stub_t *
-fop_rename_cbk_stub(call_frame_t *frame, fop_rename_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct iatt *buf,
+fop_rename_cbk_stub(call_frame_t *frame, fop_rename_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                     struct iatt *preoldparent, struct iatt *postoldparent,
                     struct iatt *prenewparent, struct iatt *postnewparent,
                     dict_t *xdata)
@@ -495,7 +496,7 @@ out:
 }
 
 call_stub_t *
-fop_link_cbk_stub(call_frame_t *frame, fop_link_cbk_t fn, int32_t op_ret,
+fop_link_cbk_stub(call_frame_t *frame, fop_link_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, inode_t *inode, struct iatt *buf,
                   struct iatt *preparent, struct iatt *postparent,
                   dict_t *xdata)
@@ -530,9 +531,9 @@ out:
 }
 
 call_stub_t *
-fop_create_cbk_stub(call_frame_t *frame, fop_create_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, fd_t *fd, inode_t *inode,
-                    struct iatt *buf, struct iatt *preparent,
+fop_create_cbk_stub(call_frame_t *frame, fop_create_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    inode_t *inode, struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -565,7 +566,7 @@ out:
 }
 
 call_stub_t *
-fop_open_cbk_stub(call_frame_t *frame, fop_open_cbk_t fn, int32_t op_ret,
+fop_open_cbk_stub(call_frame_t *frame, fop_open_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -595,7 +596,7 @@ out:
 }
 
 call_stub_t *
-fop_readv_cbk_stub(call_frame_t *frame, fop_readv_cbk_t fn, int32_t op_ret,
+fop_readv_cbk_stub(call_frame_t *frame, fop_readv_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iovec *vector, int32_t count,
                    struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
 {
@@ -631,9 +632,9 @@ out:
 }
 
 call_stub_t *
-fop_writev_cbk_stub(call_frame_t *frame, fop_writev_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                    dict_t *xdata)
+fop_writev_cbk_stub(call_frame_t *frame, fop_writev_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    struct iatt *postbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -662,7 +663,7 @@ out:
 }
 
 call_stub_t *
-fop_flush_cbk_stub(call_frame_t *frame, fop_flush_cbk_t fn, int32_t op_ret,
+fop_flush_cbk_stub(call_frame_t *frame, fop_flush_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -692,7 +693,7 @@ out:
 }
 
 call_stub_t *
-fop_fsync_cbk_stub(call_frame_t *frame, fop_fsync_cbk_t fn, int32_t op_ret,
+fop_fsync_cbk_stub(call_frame_t *frame, fop_fsync_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
                    dict_t *xdata)
 {
@@ -726,8 +727,9 @@ out:
 }
 
 call_stub_t *
-fop_opendir_cbk_stub(call_frame_t *frame, fop_opendir_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, fd_t *fd, dict_t *xdata)
+fop_opendir_cbk_stub(call_frame_t *frame, fop_opendir_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                     dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -757,7 +759,7 @@ out:
 
 call_stub_t *
 fop_fsyncdir_cbk_stub(call_frame_t *frame, fop_fsyncdir_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -787,8 +789,9 @@ out:
 }
 
 call_stub_t *
-fop_statfs_cbk_stub(call_frame_t *frame, fop_statfs_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct statvfs *buf, dict_t *xdata)
+fop_statfs_cbk_stub(call_frame_t *frame, fop_statfs_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
+                    dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -820,7 +823,7 @@ out:
 
 call_stub_t *
 fop_setxattr_cbk_stub(call_frame_t *frame, fop_setxattr_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -852,7 +855,7 @@ out:
 
 call_stub_t *
 fop_getxattr_cbk_stub(call_frame_t *frame, fop_getxattr_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                       dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -885,7 +888,7 @@ out:
 
 call_stub_t *
 fop_fsetxattr_cbk_stub(call_frame_t *frame, fop_fsetxattr_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -917,7 +920,7 @@ out:
 
 call_stub_t *
 fop_fgetxattr_cbk_stub(call_frame_t *frame, fop_fgetxattr_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, dict_t *dict,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                        dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -951,7 +954,7 @@ out:
 
 call_stub_t *
 fop_removexattr_cbk_stub(call_frame_t *frame, fop_removexattr_cbk_t fn,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -984,7 +987,7 @@ out:
 
 call_stub_t *
 fop_fremovexattr_cbk_stub(call_frame_t *frame, fop_fremovexattr_cbk_t fn,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1015,7 +1018,7 @@ out:
 }
 
 call_stub_t *
-fop_lk_cbk_stub(call_frame_t *frame, fop_lk_cbk_t fn, int32_t op_ret,
+fop_lk_cbk_stub(call_frame_t *frame, fop_lk_cbk_t fn, gf_return_t op_ret,
                 int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1047,8 +1050,8 @@ out:
 }
 
 call_stub_t *
-fop_inodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, dict_t *xdata)
+fop_inodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1080,8 +1083,8 @@ out:
 }
 
 call_stub_t *
-fop_finodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn, int32_t op_ret,
-                      int32_t op_errno, dict_t *xdata)
+fop_finodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1112,8 +1115,8 @@ out:
 }
 
 call_stub_t *
-fop_entrylk_cbk_stub(call_frame_t *frame, fop_entrylk_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, dict_t *xdata)
+fop_entrylk_cbk_stub(call_frame_t *frame, fop_entrylk_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1144,7 +1147,7 @@ out:
 
 call_stub_t *
 fop_fentrylk_cbk_stub(call_frame_t *frame, fop_fentrylk_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1159,8 +1162,8 @@ out:
 
 call_stub_t *
 fop_readdirp_cbk_stub(call_frame_t *frame, fop_readdirp_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
-                      dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      gf_dirent_t *entries, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1174,8 +1177,9 @@ out:
 }
 
 call_stub_t *
-fop_readdir_cbk_stub(call_frame_t *frame, fop_readdir_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, gf_dirent_t *entries, dict_t *xdata)
+fop_readdir_cbk_stub(call_frame_t *frame, fop_readdir_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                     dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1237,8 +1241,9 @@ out:
 
 call_stub_t *
 fop_rchecksum_cbk_stub(call_frame_t *frame, fop_rchecksum_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                       uint8_t *strong_checksum, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       uint32_t weak_checksum, uint8_t *strong_checksum,
+                       dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1253,8 +1258,9 @@ out:
 }
 
 call_stub_t *
-fop_xattrop_cbk_stub(call_frame_t *frame, fop_xattrop_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, dict_t *xattr, dict_t *xdata)
+fop_xattrop_cbk_stub(call_frame_t *frame, fop_xattrop_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
+                     dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1269,7 +1275,7 @@ out:
 
 call_stub_t *
 fop_fxattrop_cbk_stub(call_frame_t *frame, fop_fxattrop_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *xattr,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
                       dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1318,8 +1324,8 @@ out:
 }
 
 call_stub_t *
-fop_setattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, struct iatt *statpre,
+fop_setattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1335,9 +1341,10 @@ out:
 }
 
 call_stub_t *
-fop_fsetattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn, int32_t op_ret,
-                      int32_t op_errno, struct iatt *statpre,
-                      struct iatt *statpost, dict_t *xdata)
+fop_fsetattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn,
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct iatt *statpre, struct iatt *statpost,
+                      dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1387,8 +1394,9 @@ out:
 
 call_stub_t *
 fop_fallocate_cbk_stub(call_frame_t *frame, fop_fallocate_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, struct iatt *statpre,
-                       struct iatt *statpost, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *statpre, struct iatt *statpost,
+                       dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1421,8 +1429,8 @@ out:
 }
 
 call_stub_t *
-fop_discard_cbk_stub(call_frame_t *frame, fop_discard_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, struct iatt *statpre,
+fop_discard_cbk_stub(call_frame_t *frame, fop_discard_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1457,8 +1465,9 @@ out:
 
 call_stub_t *
 fop_zerofill_cbk_stub(call_frame_t *frame, fop_zerofill_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, struct iatt *statpre,
-                      struct iatt *statpost, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct iatt *statpre, struct iatt *statpost,
+                      dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1491,7 +1500,7 @@ out:
 }
 
 call_stub_t *
-fop_ipc_cbk_stub(call_frame_t *frame, fop_ipc_cbk_t fn, int32_t op_ret,
+fop_ipc_cbk_stub(call_frame_t *frame, fop_ipc_cbk_t fn, gf_return_t op_ret,
                  int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1523,7 +1532,7 @@ out:
 }
 
 call_stub_t *
-fop_lease_cbk_stub(call_frame_t *frame, fop_lease_cbk_t fn, int32_t op_ret,
+fop_lease_cbk_stub(call_frame_t *frame, fop_lease_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct gf_lease *lease, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1556,7 +1565,7 @@ out:
 }
 
 call_stub_t *
-fop_seek_cbk_stub(call_frame_t *frame, fop_seek_cbk_t fn, int32_t op_ret,
+fop_seek_cbk_stub(call_frame_t *frame, fop_seek_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, off_t offset, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1590,7 +1599,7 @@ out:
 
 call_stub_t *
 fop_getactivelk_cbk_stub(call_frame_t *frame, fop_getactivelk_cbk_t fn,
-                         int32_t op_ret, int32_t op_errno,
+                         gf_return_t op_ret, int32_t op_errno,
                          lock_migration_info_t *lmi, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -1628,7 +1637,7 @@ out:
 
 call_stub_t *
 fop_setactivelk_cbk_stub(call_frame_t *frame, fop_setactivelk_cbk_t fn,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1689,7 +1698,7 @@ out:
 
 call_stub_t *
 fop_copy_file_range_cbk_stub(call_frame_t *frame, fop_copy_file_range_cbk_t fn,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              struct iatt *stbuf, struct iatt *prebuf_dst,
                              struct iatt *postbuf_dst, dict_t *xdata)
 {
@@ -1728,7 +1737,7 @@ out:
 }
 
 call_stub_t *
-fop_put_cbk_stub(call_frame_t *frame, fop_put_cbk_t fn, int32_t op_ret,
+fop_put_cbk_stub(call_frame_t *frame, fop_put_cbk_t fn, gf_return_t op_ret,
                  int32_t op_errno, inode_t *inode, struct iatt *buf,
                  struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
 {
@@ -1768,7 +1777,7 @@ out:
 }
 
 static void
-args_icreate_store_cbk(default_args_cbk_t *args, int32_t op_ret,
+args_icreate_store_cbk(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, inode_t *inode, struct iatt *buf,
                        dict_t *xdata)
 {
@@ -1783,9 +1792,9 @@ args_icreate_store_cbk(default_args_cbk_t *args, int32_t op_ret,
 }
 
 call_stub_t *
-fop_icreate_cbk_stub(call_frame_t *frame, fop_icreate_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, inode_t *inode, struct iatt *buf,
-                     dict_t *xdata)
+fop_icreate_cbk_stub(call_frame_t *frame, fop_icreate_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+                     struct iatt *buf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
@@ -1823,7 +1832,7 @@ out:
 }
 
 static void
-args_namelink_store_cbk(default_args_cbk_t *args, int32_t op_ret,
+args_namelink_store_cbk(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *prebuf,
                         struct iatt *postbuf, dict_t *xdata)
 {
@@ -1840,7 +1849,7 @@ args_namelink_store_cbk(default_args_cbk_t *args, int32_t op_ret,
 
 call_stub_t *
 fop_namelink_cbk_stub(call_frame_t *frame, fop_namelink_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -2401,7 +2410,7 @@ out:
 }
 
 void
-call_unwind_error(call_stub_t *stub, int op_ret, int op_errno)
+call_unwind_error(call_stub_t *stub, gf_return_t op_ret, int op_errno)
 {
     xlator_t *old_THIS = NULL;
 
@@ -2422,7 +2431,7 @@ call_unwind_error(call_stub_t *stub, int op_ret, int op_errno)
 }
 
 void
-call_unwind_error_keep_stub(call_stub_t *stub, int op_ret, int op_errno)
+call_unwind_error_keep_stub(call_stub_t *stub, gf_return_t op_ret, int op_errno)
 {
     xlator_t *old_THIS = NULL;
 

--- a/libglusterfs/src/cluster-syncop.c
+++ b/libglusterfs/src/cluster-syncop.c
@@ -98,7 +98,7 @@ cluster_fop_success_fill(default_args_cbk_t *replies, int numsubvols,
     int count = 0;
 
     for (i = 0; i < numsubvols; i++) {
-        if (replies[i].valid && replies[i].op_ret >= 0) {
+        if (replies[i].valid && IS_SUCCESS(replies[i].op_ret)) {
             success[i] = 1;
             count++;
         } else {
@@ -124,7 +124,7 @@ cluster_replies_wipe(default_args_cbk_t *replies, int numsubvols)
 
 int32_t
 cluster_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     FOP_CBK(lookup, frame, cookie, op_ret, op_errno, inode, buf, xdata,
@@ -134,7 +134,7 @@ cluster_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                  dict_t *xdata)
 {
     FOP_CBK(stat, frame, cookie, op_ret, op_errno, buf, xdata);
@@ -143,7 +143,7 @@ cluster_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     FOP_CBK(truncate, frame, cookie, op_ret, op_errno, prebuf, postbuf, xdata);
@@ -152,7 +152,7 @@ cluster_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     FOP_CBK(ftruncate, frame, cookie, op_ret, op_errno, prebuf, postbuf, xdata);
@@ -161,7 +161,7 @@ cluster_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(access, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -169,7 +169,7 @@ cluster_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, const char *path,
+                     gf_return_t op_ret, int32_t op_errno, const char *path,
                      struct iatt *buf, dict_t *xdata)
 {
     FOP_CBK(readlink, frame, cookie, op_ret, op_errno, path, buf, xdata);
@@ -178,7 +178,7 @@ cluster_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
@@ -189,7 +189,7 @@ cluster_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
@@ -200,7 +200,7 @@ cluster_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     FOP_CBK(unlink, frame, cookie, op_ret, op_errno, preparent, postparent,
@@ -210,7 +210,7 @@ cluster_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     FOP_CBK(rmdir, frame, cookie, op_ret, op_errno, preparent, postparent,
@@ -220,7 +220,7 @@ cluster_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -231,7 +231,7 @@ cluster_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                    struct iatt *preoldparent, struct iatt *postoldparent,
                    struct iatt *prenewparent, struct iatt *postnewparent,
                    dict_t *xdata)
@@ -243,7 +243,7 @@ cluster_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -254,8 +254,8 @@ cluster_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                   struct iatt *buf, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   inode_t *inode, struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     FOP_CBK(create, frame, cookie, op_ret, op_errno, fd, inode, buf, preparent,
@@ -265,7 +265,7 @@ cluster_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     FOP_CBK(open, frame, cookie, op_ret, op_errno, fd, xdata);
     return 0;
@@ -273,7 +273,7 @@ cluster_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                  gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                   int32_t count, struct iatt *stbuf, struct iobref *iobref,
                   dict_t *xdata)
 {
@@ -284,7 +284,7 @@ cluster_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     FOP_CBK(writev, frame, cookie, op_ret, op_errno, prebuf, postbuf, xdata);
@@ -293,7 +293,7 @@ cluster_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_put_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -304,7 +304,7 @@ cluster_put_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(flush, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -312,7 +312,7 @@ cluster_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     FOP_CBK(fsync, frame, cookie, op_ret, op_errno, prebuf, postbuf, xdata);
@@ -321,7 +321,7 @@ cluster_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   dict_t *xdata)
 {
     FOP_CBK(fstat, frame, cookie, op_ret, op_errno, buf, xdata);
@@ -330,7 +330,8 @@ cluster_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    dict_t *xdata)
 {
     FOP_CBK(opendir, frame, cookie, op_ret, op_errno, fd, xdata);
     return 0;
@@ -338,7 +339,7 @@ cluster_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(fsyncdir, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -346,7 +347,7 @@ cluster_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                    dict_t *xdata)
 {
     FOP_CBK(statfs, frame, cookie, op_ret, op_errno, buf, xdata);
@@ -355,7 +356,7 @@ cluster_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(setxattr, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -363,7 +364,7 @@ cluster_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(fsetxattr, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -371,7 +372,7 @@ cluster_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                       dict_t *xdata)
 {
     FOP_CBK(fgetxattr, frame, cookie, op_ret, op_errno, dict, xdata);
@@ -380,7 +381,7 @@ cluster_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     FOP_CBK(getxattr, frame, cookie, op_ret, op_errno, dict, xdata);
@@ -389,7 +390,7 @@ cluster_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata)
 {
     FOP_CBK(xattrop, frame, cookie, op_ret, op_errno, dict, xdata);
@@ -398,7 +399,7 @@ cluster_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     FOP_CBK(fxattrop, frame, cookie, op_ret, op_errno, dict, xdata);
@@ -407,7 +408,7 @@ cluster_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(removexattr, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -415,7 +416,7 @@ cluster_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(fremovexattr, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -423,7 +424,7 @@ cluster_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+               gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                dict_t *xdata)
 {
     FOP_CBK(lk, frame, cookie, op_ret, op_errno, lock, xdata);
@@ -432,7 +433,7 @@ cluster_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(inodelk, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -440,7 +441,7 @@ cluster_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(finodelk, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -448,7 +449,7 @@ cluster_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(entrylk, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -456,7 +457,7 @@ cluster_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(fentrylk, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -464,8 +465,9 @@ cluster_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                      uint8_t *strong_checksum, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      uint32_t weak_checksum, uint8_t *strong_checksum,
+                      dict_t *xdata)
 {
     FOP_CBK(rchecksum, frame, cookie, op_ret, op_errno, weak_checksum,
             strong_checksum, xdata);
@@ -474,7 +476,7 @@ cluster_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                     dict_t *xdata)
 {
     FOP_CBK(readdir, frame, cookie, op_ret, op_errno, entries, xdata);
@@ -483,7 +485,7 @@ cluster_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                      dict_t *xdata)
 {
     FOP_CBK(readdirp, frame, cookie, op_ret, op_errno, entries, xdata);
@@ -492,7 +494,7 @@ cluster_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata)
 {
     FOP_CBK(setattr, frame, cookie, op_ret, op_errno, statpre, statpost, xdata);
@@ -501,7 +503,7 @@ cluster_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
     FOP_CBK(fsetattr, frame, cookie, op_ret, op_errno, statpre, statpost,
@@ -511,7 +513,7 @@ cluster_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                       struct iatt *post, dict_t *xdata)
 {
     FOP_CBK(fallocate, frame, cookie, op_ret, op_errno, pre, post, xdata);
@@ -520,7 +522,7 @@ cluster_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                     struct iatt *post, dict_t *xdata)
 {
     FOP_CBK(discard, frame, cookie, op_ret, op_errno, pre, post, xdata);
@@ -529,7 +531,7 @@ cluster_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                      struct iatt *post, dict_t *xdata)
 {
     FOP_CBK(zerofill, frame, cookie, op_ret, op_errno, pre, post, xdata);
@@ -538,7 +540,7 @@ cluster_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 cluster_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     FOP_CBK(ipc, frame, cookie, op_ret, op_errno, xdata);
     return 0;
@@ -1077,7 +1079,7 @@ cluster_inodelk(xlator_t **subvols, unsigned char *on, int numsubvols,
                &loc, F_SETLK, &flock, NULL);
 
     for (i = 0; i < numsubvols; i++) {
-        if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == EAGAIN) {
             cluster_fop_success_fill(replies, numsubvols, locked_on);
             cluster_uninodelk(subvols, locked_on, numsubvols, replies, output,
                               frame, this, dom, inode, off, size);
@@ -1147,7 +1149,7 @@ cluster_entrylk(xlator_t **subvols, unsigned char *on, int numsubvols,
                &loc, name, ENTRYLK_LOCK_NB, ENTRYLK_WRLCK, NULL);
 
     for (i = 0; i < numsubvols; i++) {
-        if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == EAGAIN) {
             cluster_fop_success_fill(replies, numsubvols, locked_on);
             cluster_unentrylk(subvols, locked_on, numsubvols, replies, output,
                               frame, this, dom, inode, name);
@@ -1187,7 +1189,7 @@ cluster_tiebreaker_inodelk(xlator_t **subvols, unsigned char *on,
                &loc, F_SETLK, &flock, NULL);
 
     for (i = 0; i < numsubvols; i++) {
-        if (replies[i].valid && replies[i].op_ret == 0) {
+        if (replies[i].valid && IS_SUCCESS(replies[i].op_ret)) {
             num_success++;
             continue;
         }
@@ -1195,7 +1197,7 @@ cluster_tiebreaker_inodelk(xlator_t **subvols, unsigned char *on,
         /* TODO: If earlier subvols fail with an error other
          * than EAGAIN, we could still have 2 clients competing
          * for the lock*/
-        if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == EAGAIN) {
             cluster_fop_success_fill(replies, numsubvols, locked_on);
             cluster_uninodelk(subvols, locked_on, numsubvols, replies, output,
                               frame, this, dom, inode, off, size);
@@ -1235,11 +1237,11 @@ cluster_tiebreaker_entrylk(xlator_t **subvols, unsigned char *on,
                &loc, name, ENTRYLK_LOCK_NB, ENTRYLK_WRLCK, NULL);
 
     for (i = 0; i < numsubvols; i++) {
-        if (replies[i].valid && replies[i].op_ret == 0) {
+        if (replies[i].valid && IS_SUCCESS(replies[i].op_ret)) {
             num_success++;
             continue;
         }
-        if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == EAGAIN) {
             cluster_fop_success_fill(replies, numsubvols, locked_on);
             cluster_unentrylk(subvols, locked_on, numsubvols, replies, output,
                               frame, this, dom, inode, name);

--- a/libglusterfs/src/default-args.c
+++ b/libglusterfs/src/default-args.c
@@ -26,7 +26,7 @@ args_lookup_store(default_args_t *args, loc_t *loc, dict_t *xdata)
 }
 
 int
-args_lookup_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_lookup_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, inode_t *inode, struct iatt *buf,
                       dict_t *xdata, struct iatt *postparent)
 {
@@ -55,12 +55,12 @@ args_stat_store(default_args_t *args, loc_t *loc, dict_t *xdata)
 }
 
 int
-args_stat_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    struct iatt *buf, dict_t *xdata)
+args_stat_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, struct iatt *buf, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         args->stat = *buf;
     if (xdata)
         args->xdata = dict_ref(xdata);
@@ -80,8 +80,8 @@ args_fstat_store(default_args_t *args, fd_t *fd, dict_t *xdata)
 }
 
 int
-args_fstat_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iatt *buf, dict_t *xdata)
+args_fstat_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iatt *buf, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -105,7 +105,7 @@ args_truncate_store(default_args_t *args, loc_t *loc, off_t off, dict_t *xdata)
 }
 
 int
-args_truncate_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_truncate_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *prebuf,
                         struct iatt *postbuf, dict_t *xdata)
 {
@@ -135,7 +135,7 @@ args_ftruncate_store(default_args_t *args, fd_t *fd, off_t off, dict_t *xdata)
 }
 
 int
-args_ftruncate_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_ftruncate_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, struct iatt *prebuf,
                          struct iatt *postbuf, dict_t *xdata)
 {
@@ -163,7 +163,7 @@ args_access_store(default_args_t *args, loc_t *loc, int32_t mask, dict_t *xdata)
 }
 
 int
-args_access_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_access_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -187,7 +187,7 @@ args_readlink_store(default_args_t *args, loc_t *loc, size_t size,
 }
 
 int
-args_readlink_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_readlink_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, const char *path, struct iatt *stbuf,
                         dict_t *xdata)
 {
@@ -218,9 +218,10 @@ args_mknod_store(default_args_t *args, loc_t *loc, mode_t mode, dev_t rdev,
 }
 
 int
-args_mknod_cbk_store(default_args_cbk_t *args, int op_ret, int32_t op_errno,
-                     inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                     struct iatt *postparent, dict_t *xdata)
+args_mknod_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, inode_t *inode, struct iatt *buf,
+                     struct iatt *preparent, struct iatt *postparent,
+                     dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -253,9 +254,10 @@ args_mkdir_store(default_args_t *args, loc_t *loc, mode_t mode, mode_t umask,
 }
 
 int
-args_mkdir_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                     struct iatt *postparent, dict_t *xdata)
+args_mkdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, inode_t *inode, struct iatt *buf,
+                     struct iatt *preparent, struct iatt *postparent,
+                     dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -285,7 +287,7 @@ args_unlink_store(default_args_t *args, loc_t *loc, int xflag, dict_t *xdata)
 }
 
 int
-args_unlink_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_unlink_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata)
 {
@@ -312,9 +314,9 @@ args_rmdir_store(default_args_t *args, loc_t *loc, int flags, dict_t *xdata)
 }
 
 int
-args_rmdir_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iatt *preparent, struct iatt *postparent,
-                     dict_t *xdata)
+args_rmdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iatt *preparent,
+                     struct iatt *postparent, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -342,7 +344,7 @@ args_symlink_store(default_args_t *args, const char *linkname, loc_t *loc,
 }
 
 int
-args_symlink_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_symlink_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, inode_t *inode, struct iatt *buf,
                        struct iatt *preparent, struct iatt *postparent,
                        dict_t *xdata)
@@ -376,7 +378,7 @@ args_rename_store(default_args_t *args, loc_t *oldloc, loc_t *newloc,
 }
 
 int
-args_rename_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_rename_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct iatt *buf,
                       struct iatt *preoldparent, struct iatt *postoldparent,
                       struct iatt *prenewparent, struct iatt *postnewparent,
@@ -414,9 +416,10 @@ args_link_store(default_args_t *args, loc_t *oldloc, loc_t *newloc,
 }
 
 int
-args_link_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata)
+args_link_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, inode_t *inode, struct iatt *buf,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -450,7 +453,7 @@ args_create_store(default_args_t *args, loc_t *loc, int32_t flags, mode_t mode,
 }
 
 int
-args_create_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_create_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, fd_t *fd, inode_t *inode,
                       struct iatt *buf, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata)
@@ -488,8 +491,8 @@ args_open_store(default_args_t *args, loc_t *loc, int32_t flags, fd_t *fd,
 }
 
 int
-args_open_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    fd_t *fd, dict_t *xdata)
+args_open_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -518,13 +521,13 @@ args_readv_store(default_args_t *args, fd_t *fd, size_t size, off_t off,
 }
 
 int
-args_readv_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iovec *vector, int32_t count, struct iatt *stbuf,
-                     struct iobref *iobref, dict_t *xdata)
+args_readv_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iovec *vector, int32_t count,
+                     struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->vector = iov_dup(vector, count);
         args->count = count;
         args->stat = *stbuf;
@@ -554,13 +557,13 @@ args_writev_store(default_args_t *args, fd_t *fd, struct iovec *vector,
 }
 
 int
-args_writev_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_writev_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         args->poststat = *postbuf;
     if (prebuf)
         args->prestat = *prebuf;
@@ -591,13 +594,14 @@ args_put_store(default_args_t *args, loc_t *loc, mode_t mode, mode_t umask,
 }
 
 int
-args_put_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                   inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                   struct iatt *postparent, dict_t *xdata)
+args_put_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                   int32_t op_errno, inode_t *inode, struct iatt *buf,
+                   struct iatt *preparent, struct iatt *postparent,
+                   dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         args->stat = *buf;
     if (inode)
         args->inode = inode_ref(inode);
@@ -621,8 +625,8 @@ args_flush_store(default_args_t *args, fd_t *fd, dict_t *xdata)
 }
 
 int
-args_flush_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     dict_t *xdata)
+args_flush_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -645,8 +649,9 @@ args_fsync_store(default_args_t *args, fd_t *fd, int32_t datasync,
 }
 
 int
-args_fsync_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iatt *prebuf, struct iatt *postbuf, dict_t *xdata)
+args_fsync_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iatt *prebuf,
+                     struct iatt *postbuf, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -673,7 +678,7 @@ args_opendir_store(default_args_t *args, loc_t *loc, fd_t *fd, dict_t *xdata)
 }
 
 int
-args_opendir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_opendir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -698,7 +703,7 @@ args_fsyncdir_store(default_args_t *args, fd_t *fd, int32_t datasync,
     return 0;
 }
 int
-args_fsyncdir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fsyncdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -719,12 +724,12 @@ args_statfs_store(default_args_t *args, loc_t *loc, dict_t *xdata)
 }
 
 int
-args_statfs_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_statfs_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct statvfs *buf, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         args->statvfs = *buf;
     if (xdata)
         args->xdata = dict_ref(xdata);
@@ -747,7 +752,7 @@ args_setxattr_store(default_args_t *args, loc_t *loc, dict_t *dict,
 }
 
 int
-args_setxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_setxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -772,7 +777,7 @@ args_getxattr_store(default_args_t *args, loc_t *loc, const char *name,
 }
 
 int
-args_getxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_getxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -800,7 +805,7 @@ args_fsetxattr_store(default_args_t *args, fd_t *fd, dict_t *dict,
 }
 
 int
-args_fsetxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fsetxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -825,7 +830,7 @@ args_fgetxattr_store(default_args_t *args, fd_t *fd, const char *name,
 }
 
 int
-args_fgetxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fgetxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -850,7 +855,7 @@ args_removexattr_store(default_args_t *args, loc_t *loc, const char *name,
 }
 
 int
-args_removexattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_removexattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                            int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -873,7 +878,7 @@ args_fremovexattr_store(default_args_t *args, fd_t *fd, const char *name,
 }
 
 int
-args_fremovexattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fremovexattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                             int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -898,12 +903,12 @@ args_lk_store(default_args_t *args, fd_t *fd, int32_t cmd,
 }
 
 int
-args_lk_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                  struct gf_flock *lock, dict_t *xdata)
+args_lk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                  int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         args->lock = *lock;
     if (xdata)
         args->xdata = dict_ref(xdata);
@@ -927,7 +932,7 @@ args_inodelk_store(default_args_t *args, const char *volume, loc_t *loc,
 }
 
 int
-args_inodelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_inodelk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -957,7 +962,7 @@ args_finodelk_store(default_args_t *args, const char *volume, fd_t *fd,
 }
 
 int
-args_finodelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_finodelk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -990,7 +995,7 @@ args_entrylk_store(default_args_t *args, const char *volume, loc_t *loc,
 }
 
 int
-args_entrylk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_entrylk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -1022,7 +1027,7 @@ args_fentrylk_store(default_args_t *args, const char *volume, fd_t *fd,
 }
 
 int
-args_fentrylk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fentrylk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -1046,14 +1051,14 @@ args_readdirp_store(default_args_t *args, fd_t *fd, size_t size, off_t off,
 }
 
 int
-args_readdirp_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_readdirp_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, gf_dirent_t *entries, dict_t *xdata)
 {
     gf_dirent_t *stub_entry = NULL, *entry = NULL;
 
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret > 0) {
+    if (IS_SUCCESS(op_ret)) {
         list_for_each_entry(entry, &entries->list, list)
         {
             stub_entry = gf_dirent_for_name(entry->d_name);
@@ -1090,14 +1095,14 @@ args_readdir_store(default_args_t *args, fd_t *fd, size_t size, off_t off,
 }
 
 int
-args_readdir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_readdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, gf_dirent_t *entries, dict_t *xdata)
 {
     gf_dirent_t *stub_entry = NULL, *entry = NULL;
 
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret > 0) {
+    if (IS_SUCCESS(op_ret)) {
         list_for_each_entry(entry, &entries->list, list)
         {
             stub_entry = gf_dirent_for_name(entry->d_name);
@@ -1128,13 +1133,13 @@ args_rchecksum_store(default_args_t *args, fd_t *fd, off_t offset, int32_t len,
 }
 
 int
-args_rchecksum_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_rchecksum_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, uint32_t weak_checksum,
                          uint8_t *strong_checksum, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->weak_checksum = weak_checksum;
         args->strong_checksum = gf_memdup(strong_checksum,
                                           SHA256_DIGEST_LENGTH);
@@ -1160,7 +1165,7 @@ args_xattrop_store(default_args_t *args, loc_t *loc, gf_xattrop_flags_t optype,
 }
 
 int
-args_xattrop_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_xattrop_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, dict_t *xattr, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -1188,7 +1193,7 @@ args_fxattrop_store(default_args_t *args, fd_t *fd, gf_xattrop_flags_t optype,
 }
 
 int
-args_fxattrop_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fxattrop_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xattr, dict_t *xdata)
 {
     args->op_ret = op_ret;
@@ -1218,7 +1223,7 @@ args_setattr_store(default_args_t *args, loc_t *loc, struct iatt *stbuf,
 }
 
 int
-args_setattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_setattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, struct iatt *statpre,
                        struct iatt *statpost, dict_t *xdata)
 {
@@ -1251,7 +1256,7 @@ args_fsetattr_store(default_args_t *args, fd_t *fd, struct iatt *stbuf,
     return 0;
 }
 int
-args_fsetattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fsetattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *statpre,
                         struct iatt *statpost, dict_t *xdata)
 {
@@ -1284,7 +1289,7 @@ args_fallocate_store(default_args_t *args, fd_t *fd, int32_t mode, off_t offset,
 }
 
 int
-args_fallocate_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fallocate_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, struct iatt *statpre,
                          struct iatt *statpost, dict_t *xdata)
 {
@@ -1316,7 +1321,7 @@ args_discard_store(default_args_t *args, fd_t *fd, off_t offset, size_t len,
 }
 
 int
-args_discard_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_discard_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, struct iatt *statpre,
                        struct iatt *statpost, dict_t *xdata)
 {
@@ -1348,7 +1353,7 @@ args_zerofill_store(default_args_t *args, fd_t *fd, off_t offset, off_t len,
 }
 
 int
-args_zerofill_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_zerofill_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *statpre,
                         struct iatt *statpost, dict_t *xdata)
 {
@@ -1375,8 +1380,8 @@ args_ipc_store(default_args_t *args, int32_t op, dict_t *xdata)
 }
 
 int
-args_ipc_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                   dict_t *xdata)
+args_ipc_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                   int32_t op_errno, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -1402,8 +1407,8 @@ args_seek_store(default_args_t *args, fd_t *fd, off_t offset,
 }
 
 int
-args_seek_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    off_t offset, dict_t *xdata)
+args_seek_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, off_t offset, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
@@ -1415,7 +1420,7 @@ args_seek_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
 }
 
 int
-args_getactivelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_getactivelk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                            int32_t op_errno, lock_migration_info_t *locklist,
                            dict_t *xdata)
 {
@@ -1425,7 +1430,7 @@ args_getactivelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
     args->op_ret = op_ret;
     args->op_errno = op_errno;
     /*op_ret needs to carry the number of locks present in the list*/
-    if (op_ret > 0) {
+    if (IS_SUCCESS(op_ret)) {
         list_for_each_entry(entry, &locklist->list, list)
         {
             stub_entry = GF_CALLOC(1, sizeof(*stub_entry), gf_common_mt_char);
@@ -1509,12 +1514,12 @@ args_lease_store(default_args_t *args, loc_t *loc, struct gf_lease *lease,
 }
 
 void
-args_lease_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct gf_lease *lease, dict_t *xdata)
+args_lease_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct gf_lease *lease, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         args->lease = *lease;
     if (xdata)
         args->xdata = dict_ref(xdata);
@@ -1562,14 +1567,14 @@ args_copy_file_range_store(default_args_t *args, fd_t *fd_in, off64_t off_in,
 }
 
 int
-args_copy_file_range_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_copy_file_range_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                                int32_t op_errno, struct iatt *stbuf,
                                struct iatt *prebuf_dst,
                                struct iatt *postbuf_dst, dict_t *xdata)
 {
     args->op_ret = op_ret;
     args->op_errno = op_errno;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         if (postbuf_dst)
             args->poststat = *postbuf_dst;
         if (prebuf_dst)

--- a/libglusterfs/src/gen-defaults.py
+++ b/libglusterfs/src/gen-defaults.py
@@ -8,15 +8,15 @@ FAILURE_CBK_TEMPLATE = """
 int32_t
 default_@NAME@_failure_cbk (call_frame_t *frame, int32_t op_errno)
 {
-	STACK_UNWIND_STRICT (@NAME@, frame, -1, op_errno, @ERROR_ARGS@);
-	return 0;
+    STACK_UNWIND_STRICT (@NAME@, frame, gf_error, op_errno, @ERROR_ARGS@);
+    return 0;
 }
 """
 
 CBK_RESUME_TEMPLATE = """
 int32_t
 default_@NAME@_cbk_resume (call_frame_t *frame, void *cookie, xlator_t *this,
-			   int32_t op_ret, int32_t op_errno, @LONG_ARGS@)
+			   gf_return_t op_ret, int32_t op_errno, @LONG_ARGS@)
 {
 	STACK_UNWIND_STRICT (@NAME@, frame, op_ret, op_errno,
 			     @SHORT_ARGS@);
@@ -27,7 +27,7 @@ default_@NAME@_cbk_resume (call_frame_t *frame, void *cookie, xlator_t *this,
 CBK_TEMPLATE = """
 int32_t
 default_@NAME@_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-		    int32_t op_ret, int32_t op_errno, @LONG_ARGS@)
+		    gf_return_t op_ret, int32_t op_errno, @LONG_ARGS@)
 {
 	STACK_UNWIND_STRICT (@NAME@, frame, op_ret, op_errno,
 			     @SHORT_ARGS@);

--- a/libglusterfs/src/globals.c
+++ b/libglusterfs/src/globals.c
@@ -86,6 +86,16 @@ const char *gf_upcall_list[GF_UPCALL_FLAGS_MAXVALUE] = {
     [GF_UPCALL_LEASE_RECALL] = "LEASE_RECALL",
 };
 
+const char *gf_xlator_list[GF_XLATOR_MAXVALUE] = {
+    [GF_XLATOR_BACKEND] = "backend-filesystem",
+    [GF_XLATOR_POSIX] = "storage/posix",
+    [GF_XLATOR_DHT] = "cluster/distribute",
+    [GF_XLATOR_AFR] = "cluster/replicate",
+};
+
+const gf_return_t gf_error = {-1};
+const gf_return_t gf_success = {0};
+
 /* THIS */
 
 /* This global ctx is a bad hack to prevent some of the libgfapi crashes.
@@ -106,6 +116,9 @@ static __thread struct syncopctx thread_syncopctx = {};
 static __thread char thread_uuid_buf[GF_UUID_BUF_SIZE] = {};
 static __thread char thread_lkowner_buf[GF_LKOWNER_BUF_SIZE] = {};
 static __thread char thread_leaseid_buf[GF_LEASE_ID_BUF_SIZE] = {};
+
+/* TODO: add macro for size */
+static __thread char thread_errorcode_buf[1024] = {};
 
 int
 gf_global_mem_acct_enable_get(void)
@@ -299,6 +312,14 @@ glusterfs_leaseid_buf_get()
     }
 
     return buf;
+}
+
+// ERRORCODE_BUFFER
+
+char *
+glusterfs_errorcode_buf_get()
+{
+    return thread_errorcode_buf;
 }
 
 char *

--- a/libglusterfs/src/glusterfs/call-stub.h
+++ b/libglusterfs/src/glusterfs/call-stub.h
@@ -147,18 +147,18 @@ fop_lookup_stub(call_frame_t *frame, fop_lookup_t fn, loc_t *loc,
                 dict_t *xdata);
 
 call_stub_t *
-fop_lookup_cbk_stub(call_frame_t *frame, fop_lookup_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, inode_t *inode, struct iatt *buf,
-                    dict_t *xdata, struct iatt *postparent);
+fop_lookup_cbk_stub(call_frame_t *frame, fop_lookup_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+                    struct iatt *buf, dict_t *xdata, struct iatt *postparent);
 call_stub_t *
 fop_stat_stub(call_frame_t *frame, fop_stat_t fn, loc_t *loc, dict_t *xdata);
 call_stub_t *
-fop_stat_cbk_stub(call_frame_t *frame, fop_stat_cbk_t fn, int32_t op_ret,
+fop_stat_cbk_stub(call_frame_t *frame, fop_stat_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, struct iatt *buf, dict_t *xdata);
 call_stub_t *
 fop_fstat_stub(call_frame_t *frame, fop_fstat_t fn, fd_t *fd, dict_t *xdata);
 call_stub_t *
-fop_fstat_cbk_stub(call_frame_t *frame, fop_fstat_cbk_t fn, int32_t op_ret,
+fop_fstat_cbk_stub(call_frame_t *frame, fop_fstat_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iatt *buf, dict_t *xdata);
 
 call_stub_t *
@@ -167,7 +167,7 @@ fop_truncate_stub(call_frame_t *frame, fop_truncate_t fn, loc_t *loc, off_t off,
 
 call_stub_t *
 fop_truncate_cbk_stub(call_frame_t *frame, fop_truncate_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata);
 
 call_stub_t *
@@ -176,16 +176,17 @@ fop_ftruncate_stub(call_frame_t *frame, fop_ftruncate_t fn, fd_t *fd, off_t off,
 
 call_stub_t *
 fop_ftruncate_cbk_stub(call_frame_t *frame, fop_ftruncate_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                       struct iatt *postbuf, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *prebuf, struct iatt *postbuf,
+                       dict_t *xdata);
 
 call_stub_t *
 fop_access_stub(call_frame_t *frame, fop_access_t fn, loc_t *loc, int32_t mask,
                 dict_t *xdata);
 
 call_stub_t *
-fop_access_cbk_stub(call_frame_t *frame, fop_access_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, dict_t *xdata);
+fop_access_cbk_stub(call_frame_t *frame, fop_access_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_readlink_stub(call_frame_t *frame, fop_readlink_t fn, loc_t *loc,
@@ -193,7 +194,7 @@ fop_readlink_stub(call_frame_t *frame, fop_readlink_t fn, loc_t *loc,
 
 call_stub_t *
 fop_readlink_cbk_stub(call_frame_t *frame, fop_readlink_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, const char *path,
+                      gf_return_t op_ret, int32_t op_errno, const char *path,
                       struct iatt *buf, dict_t *xdata);
 
 call_stub_t *
@@ -201,7 +202,7 @@ fop_mknod_stub(call_frame_t *frame, fop_mknod_t fn, loc_t *loc, mode_t mode,
                dev_t rdev, mode_t umask, dict_t *xdata);
 
 call_stub_t *
-fop_mknod_cbk_stub(call_frame_t *frame, fop_mknod_cbk_t fn, int32_t op_ret,
+fop_mknod_cbk_stub(call_frame_t *frame, fop_mknod_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, inode_t *inode, struct iatt *buf,
                    struct iatt *preparent, struct iatt *postparent,
                    dict_t *xdata);
@@ -211,7 +212,7 @@ fop_mkdir_stub(call_frame_t *frame, fop_mkdir_t fn, loc_t *loc, mode_t mode,
                mode_t umask, dict_t *xdata);
 
 call_stub_t *
-fop_mkdir_cbk_stub(call_frame_t *frame, fop_mkdir_cbk_t fn, int32_t op_ret,
+fop_mkdir_cbk_stub(call_frame_t *frame, fop_mkdir_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, inode_t *inode, struct iatt *buf,
                    struct iatt *preparent, struct iatt *postparent,
                    dict_t *xdata);
@@ -221,16 +222,17 @@ fop_unlink_stub(call_frame_t *frame, fop_unlink_t fn, loc_t *loc, int xflag,
                 dict_t *xdata);
 
 call_stub_t *
-fop_unlink_cbk_stub(call_frame_t *frame, fop_unlink_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata);
+fop_unlink_cbk_stub(call_frame_t *frame, fop_unlink_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata);
 
 call_stub_t *
 fop_rmdir_stub(call_frame_t *frame, fop_rmdir_t fn, loc_t *loc, int flags,
                dict_t *xdata);
 
 call_stub_t *
-fop_rmdir_cbk_stub(call_frame_t *frame, fop_rmdir_cbk_t fn, int32_t op_ret,
+fop_rmdir_cbk_stub(call_frame_t *frame, fop_rmdir_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata);
 
@@ -239,18 +241,18 @@ fop_symlink_stub(call_frame_t *frame, fop_symlink_t fn, const char *linkname,
                  loc_t *loc, mode_t umask, dict_t *xdata);
 
 call_stub_t *
-fop_symlink_cbk_stub(call_frame_t *frame, fop_symlink_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, inode_t *inode, struct iatt *buf,
-                     struct iatt *preparent, struct iatt *postparent,
-                     dict_t *xdata);
+fop_symlink_cbk_stub(call_frame_t *frame, fop_symlink_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+                     struct iatt *buf, struct iatt *preparent,
+                     struct iatt *postparent, dict_t *xdata);
 
 call_stub_t *
 fop_rename_stub(call_frame_t *frame, fop_rename_t fn, loc_t *oldloc,
                 loc_t *newloc, dict_t *xdata);
 
 call_stub_t *
-fop_rename_cbk_stub(call_frame_t *frame, fop_rename_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct iatt *buf,
+fop_rename_cbk_stub(call_frame_t *frame, fop_rename_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                     struct iatt *preoldparent, struct iatt *postoldparent,
                     struct iatt *prenewparent, struct iatt *postnewparent,
                     dict_t *xdata);
@@ -260,7 +262,7 @@ fop_link_stub(call_frame_t *frame, fop_link_t fn, loc_t *oldloc, loc_t *newloc,
               dict_t *xdata);
 
 call_stub_t *
-fop_link_cbk_stub(call_frame_t *frame, fop_link_cbk_t fn, int32_t op_ret,
+fop_link_cbk_stub(call_frame_t *frame, fop_link_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, inode_t *inode, struct iatt *buf,
                   struct iatt *preparent, struct iatt *postparent,
                   dict_t *xdata);
@@ -270,9 +272,9 @@ fop_create_stub(call_frame_t *frame, fop_create_t fn, loc_t *loc, int32_t flags,
                 mode_t mode, mode_t umask, fd_t *fd, dict_t *xdata);
 
 call_stub_t *
-fop_create_cbk_stub(call_frame_t *frame, fop_create_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, fd_t *fd, inode_t *inode,
-                    struct iatt *buf, struct iatt *preparent,
+fop_create_cbk_stub(call_frame_t *frame, fop_create_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    inode_t *inode, struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata);
 
 call_stub_t *
@@ -280,7 +282,7 @@ fop_open_stub(call_frame_t *frame, fop_open_t fn, loc_t *loc, int32_t flags,
               fd_t *fd, dict_t *xdata);
 
 call_stub_t *
-fop_open_cbk_stub(call_frame_t *frame, fop_open_cbk_t fn, int32_t op_ret,
+fop_open_cbk_stub(call_frame_t *frame, fop_open_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, fd_t *fd, dict_t *xdata);
 
 call_stub_t *
@@ -288,7 +290,7 @@ fop_readv_stub(call_frame_t *frame, fop_readv_t fn, fd_t *fd, size_t size,
                off_t off, uint32_t flags, dict_t *xdata);
 
 call_stub_t *
-fop_readv_cbk_stub(call_frame_t *frame, fop_readv_cbk_t fn, int32_t op_ret,
+fop_readv_cbk_stub(call_frame_t *frame, fop_readv_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iovec *vector, int32_t count,
                    struct iatt *stbuf, struct iobref *iobref, dict_t *xdata);
 
@@ -298,15 +300,15 @@ fop_writev_stub(call_frame_t *frame, fop_writev_t fn, fd_t *fd,
                 struct iobref *iobref, dict_t *xdata);
 
 call_stub_t *
-fop_writev_cbk_stub(call_frame_t *frame, fop_writev_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                    dict_t *xdata);
+fop_writev_cbk_stub(call_frame_t *frame, fop_writev_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    struct iatt *postbuf, dict_t *xdata);
 
 call_stub_t *
 fop_flush_stub(call_frame_t *frame, fop_flush_t fn, fd_t *fd, dict_t *xdata);
 
 call_stub_t *
-fop_flush_cbk_stub(call_frame_t *frame, fop_flush_cbk_t fn, int32_t op_ret,
+fop_flush_cbk_stub(call_frame_t *frame, fop_flush_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
@@ -314,7 +316,7 @@ fop_fsync_stub(call_frame_t *frame, fop_fsync_t fn, fd_t *fd, int32_t datasync,
                dict_t *xdata);
 
 call_stub_t *
-fop_fsync_cbk_stub(call_frame_t *frame, fop_fsync_cbk_t fn, int32_t op_ret,
+fop_fsync_cbk_stub(call_frame_t *frame, fop_fsync_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
                    dict_t *xdata);
 
@@ -323,8 +325,9 @@ fop_opendir_stub(call_frame_t *frame, fop_opendir_t fn, loc_t *loc, fd_t *fd,
                  dict_t *xdata);
 
 call_stub_t *
-fop_opendir_cbk_stub(call_frame_t *frame, fop_opendir_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, fd_t *fd, dict_t *xdata);
+fop_opendir_cbk_stub(call_frame_t *frame, fop_opendir_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                     dict_t *xdata);
 
 call_stub_t *
 fop_fsyncdir_stub(call_frame_t *frame, fop_fsyncdir_t fn, fd_t *fd,
@@ -332,15 +335,16 @@ fop_fsyncdir_stub(call_frame_t *frame, fop_fsyncdir_t fn, fd_t *fd,
 
 call_stub_t *
 fop_fsyncdir_cbk_stub(call_frame_t *frame, fop_fsyncdir_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_statfs_stub(call_frame_t *frame, fop_statfs_t fn, loc_t *loc,
                 dict_t *xdata);
 
 call_stub_t *
-fop_statfs_cbk_stub(call_frame_t *frame, fop_statfs_cbk_t fn, int32_t op_ret,
-                    int32_t op_errno, struct statvfs *buf, dict_t *xdata);
+fop_statfs_cbk_stub(call_frame_t *frame, fop_statfs_cbk_t fn,
+                    gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
+                    dict_t *xdata);
 
 call_stub_t *
 fop_setxattr_stub(call_frame_t *frame, fop_setxattr_t fn, loc_t *loc,
@@ -348,7 +352,7 @@ fop_setxattr_stub(call_frame_t *frame, fop_setxattr_t fn, loc_t *loc,
 
 call_stub_t *
 fop_setxattr_cbk_stub(call_frame_t *frame, fop_setxattr_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_getxattr_stub(call_frame_t *frame, fop_getxattr_t fn, loc_t *loc,
@@ -356,7 +360,7 @@ fop_getxattr_stub(call_frame_t *frame, fop_getxattr_t fn, loc_t *loc,
 
 call_stub_t *
 fop_getxattr_cbk_stub(call_frame_t *frame, fop_getxattr_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, dict_t *value,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *value,
                       dict_t *xdata);
 
 call_stub_t *
@@ -365,7 +369,7 @@ fop_fsetxattr_stub(call_frame_t *frame, fop_fsetxattr_t fn, fd_t *fd,
 
 call_stub_t *
 fop_fsetxattr_cbk_stub(call_frame_t *frame, fop_fsetxattr_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_fgetxattr_stub(call_frame_t *frame, fop_fgetxattr_t fn, fd_t *fd,
@@ -373,7 +377,7 @@ fop_fgetxattr_stub(call_frame_t *frame, fop_fgetxattr_t fn, fd_t *fd,
 
 call_stub_t *
 fop_fgetxattr_cbk_stub(call_frame_t *frame, fop_fgetxattr_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, dict_t *value,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *value,
                        dict_t *xdata);
 
 call_stub_t *
@@ -382,7 +386,7 @@ fop_removexattr_stub(call_frame_t *frame, fop_removexattr_t fn, loc_t *loc,
 
 call_stub_t *
 fop_removexattr_cbk_stub(call_frame_t *frame, fop_removexattr_cbk_t fn,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_fremovexattr_stub(call_frame_t *frame, fop_fremovexattr_t fn, fd_t *fd,
@@ -390,14 +394,14 @@ fop_fremovexattr_stub(call_frame_t *frame, fop_fremovexattr_t fn, fd_t *fd,
 
 call_stub_t *
 fop_fremovexattr_cbk_stub(call_frame_t *frame, fop_fremovexattr_cbk_t fn,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_lk_stub(call_frame_t *frame, fop_lk_t fn, fd_t *fd, int32_t cmd,
             struct gf_flock *lock, dict_t *xdata);
 
 call_stub_t *
-fop_lk_cbk_stub(call_frame_t *frame, fop_lk_cbk_t fn, int32_t op_ret,
+fop_lk_cbk_stub(call_frame_t *frame, fop_lk_cbk_t fn, gf_return_t op_ret,
                 int32_t op_errno, struct gf_flock *lock, dict_t *xdata);
 
 call_stub_t *
@@ -419,20 +423,20 @@ fop_fentrylk_stub(call_frame_t *frame, fop_fentrylk_t fn, const char *volume,
                   entrylk_type type, dict_t *xdata);
 
 call_stub_t *
-fop_inodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, dict_t *xdata);
+fop_inodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
-fop_finodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn, int32_t op_ret,
-                      int32_t op_errno, dict_t *xdata);
+fop_finodelk_cbk_stub(call_frame_t *frame, fop_inodelk_cbk_t fn,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
-fop_entrylk_cbk_stub(call_frame_t *frame, fop_entrylk_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, dict_t *xdata);
+fop_entrylk_cbk_stub(call_frame_t *frame, fop_entrylk_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
-fop_fentrylk_cbk_stub(call_frame_t *frame, fop_entrylk_cbk_t fn, int32_t op_ret,
-                      int32_t op_errno, dict_t *xdata);
+fop_fentrylk_cbk_stub(call_frame_t *frame, fop_entrylk_cbk_t fn,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_readdir_stub(call_frame_t *frame, fop_readdir_t fn, fd_t *fd, size_t size,
@@ -443,12 +447,14 @@ fop_readdirp_stub(call_frame_t *frame, fop_readdirp_t fn, fd_t *fd, size_t size,
                   off_t off, dict_t *xdata);
 
 call_stub_t *
-fop_readdirp_cbk_stub(call_frame_t *frame, fop_readdir_cbk_t fn, int32_t op_ret,
-                      int32_t op_errno, gf_dirent_t *entries, dict_t *xdata);
+fop_readdirp_cbk_stub(call_frame_t *frame, fop_readdir_cbk_t fn,
+                      gf_return_t op_ret, int32_t op_errno,
+                      gf_dirent_t *entries, dict_t *xdata);
 
 call_stub_t *
-fop_readdir_cbk_stub(call_frame_t *frame, fop_readdir_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, gf_dirent_t *entries, dict_t *xdata);
+fop_readdir_cbk_stub(call_frame_t *frame, fop_readdir_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                     dict_t *xdata);
 
 call_stub_t *
 fop_rchecksum_stub(call_frame_t *frame, fop_rchecksum_t fn, fd_t *fd,
@@ -456,8 +462,9 @@ fop_rchecksum_stub(call_frame_t *frame, fop_rchecksum_t fn, fd_t *fd,
 
 call_stub_t *
 fop_rchecksum_cbk_stub(call_frame_t *frame, fop_rchecksum_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                       uint8_t *strong_checksum, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno,
+                       uint32_t weak_checksum, uint8_t *strong_checksum,
+                       dict_t *xdata);
 
 call_stub_t *
 fop_xattrop_stub(call_frame_t *frame, fop_xattrop_t fn, loc_t *loc,
@@ -465,7 +472,7 @@ fop_xattrop_stub(call_frame_t *frame, fop_xattrop_t fn, loc_t *loc,
 
 call_stub_t *
 fop_xattrop_stub_cbk_stub(call_frame_t *frame, fop_xattrop_cbk_t fn,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_fxattrop_stub(call_frame_t *frame, fop_fxattrop_t fn, fd_t *fd,
@@ -473,15 +480,15 @@ fop_fxattrop_stub(call_frame_t *frame, fop_fxattrop_t fn, fd_t *fd,
 
 call_stub_t *
 fop_fxattrop_stub_cbk_stub(call_frame_t *frame, fop_xattrop_cbk_t fn,
-                           int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                           gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_setattr_stub(call_frame_t *frame, fop_setattr_t fn, loc_t *loc,
                  struct iatt *stbuf, int32_t valid, dict_t *xdata);
 
 call_stub_t *
-fop_setattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, struct iatt *statpre,
+fop_setattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata);
 
 call_stub_t *
@@ -489,9 +496,10 @@ fop_fsetattr_stub(call_frame_t *frame, fop_fsetattr_t fn, fd_t *fd,
                   struct iatt *stbuf, int32_t valid, dict_t *xdata);
 
 call_stub_t *
-fop_fsetattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn, int32_t op_ret,
-                      int32_t op_errno, struct iatt *statpre,
-                      struct iatt *statpost, dict_t *xdata);
+fop_fsetattr_cbk_stub(call_frame_t *frame, fop_setattr_cbk_t fn,
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct iatt *statpre, struct iatt *statpost,
+                      dict_t *xdata);
 
 call_stub_t *
 fop_fallocate_stub(call_frame_t *frame, fop_fallocate_t fn, fd_t *fd,
@@ -499,16 +507,17 @@ fop_fallocate_stub(call_frame_t *frame, fop_fallocate_t fn, fd_t *fd,
 
 call_stub_t *
 fop_fallocate_cbk_stub(call_frame_t *frame, fop_fallocate_cbk_t fn,
-                       int32_t op_ret, int32_t op_errno, struct iatt *statpre,
-                       struct iatt *statpost, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *statpre, struct iatt *statpost,
+                       dict_t *xdata);
 
 call_stub_t *
 fop_discard_stub(call_frame_t *frame, fop_discard_t fn, fd_t *fd, off_t offset,
                  size_t len, dict_t *xdata);
 
 call_stub_t *
-fop_discard_cbk_stub(call_frame_t *frame, fop_discard_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, struct iatt *statpre,
+fop_discard_cbk_stub(call_frame_t *frame, fop_discard_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata);
 
 call_stub_t *
@@ -517,14 +526,15 @@ fop_zerofill_stub(call_frame_t *frame, fop_zerofill_t fn, fd_t *fd,
 
 call_stub_t *
 fop_zerofill_cbk_stub(call_frame_t *frame, fop_zerofill_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, struct iatt *statpre,
-                      struct iatt *statpost, dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct iatt *statpre, struct iatt *statpost,
+                      dict_t *xdata);
 
 call_stub_t *
 fop_ipc_stub(call_frame_t *frame, fop_ipc_t fn, int32_t op, dict_t *xdata);
 
 call_stub_t *
-fop_ipc_cbk_stub(call_frame_t *frame, fop_ipc_cbk_t fn, int32_t op_ret,
+fop_ipc_cbk_stub(call_frame_t *frame, fop_ipc_cbk_t fn, gf_return_t op_ret,
                  int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
@@ -532,7 +542,7 @@ fop_seek_stub(call_frame_t *frame, fop_seek_t fn, fd_t *fd, off_t offset,
               gf_seek_what_t what, dict_t *xdata);
 
 call_stub_t *
-fop_seek_cbk_stub(call_frame_t *frame, fop_seek_cbk_t fn, int32_t op_ret,
+fop_seek_cbk_stub(call_frame_t *frame, fop_seek_cbk_t fn, gf_return_t op_ret,
                   int32_t op_errno, off_t offset, dict_t *xdata);
 
 call_stub_t *
@@ -540,7 +550,7 @@ fop_lease_stub(call_frame_t *frame, fop_lease_t fn, loc_t *loc,
                struct gf_lease *lease, dict_t *xdata);
 
 call_stub_t *
-fop_lease_cbk_stub(call_frame_t *frame, fop_lease_cbk_t fn, int32_t op_ret,
+fop_lease_cbk_stub(call_frame_t *frame, fop_lease_cbk_t fn, gf_return_t op_ret,
                    int32_t op_errno, struct gf_lease *lease, dict_t *xdata);
 
 call_stub_t *
@@ -549,7 +559,7 @@ fop_getactivelk_stub(call_frame_t *frame, fop_getactivelk_t fn, loc_t *loc,
 
 call_stub_t *
 fop_getactivelk_cbk_stub(call_frame_t *frame, fop_getactivelk_cbk_t fn,
-                         int32_t op_ret, int32_t op_errno,
+                         gf_return_t op_ret, int32_t op_errno,
                          lock_migration_info_t *lmi, dict_t *xdata);
 
 call_stub_t *
@@ -558,7 +568,7 @@ fop_setactivelk_stub(call_frame_t *frame, fop_setactivelk_t fn, loc_t *loc,
 
 call_stub_t *
 fop_setactivelk_cbk_stub(call_frame_t *frame, fop_setactivelk_cbk_t fn,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 call_stub_t *
 fop_put_stub(call_frame_t *frame, fop_put_t fn, loc_t *loc, mode_t mode,
@@ -566,7 +576,7 @@ fop_put_stub(call_frame_t *frame, fop_put_t fn, loc_t *loc, mode_t mode,
              off_t offset, struct iobref *iobref, dict_t *xattr, dict_t *xdata);
 
 call_stub_t *
-fop_put_cbk_stub(call_frame_t *frame, fop_put_cbk_t fn, int32_t op_ret,
+fop_put_cbk_stub(call_frame_t *frame, fop_put_cbk_t fn, gf_return_t op_ret,
                  int32_t op_errno, inode_t *inode, struct iatt *buf,
                  struct iatt *preparent, struct iatt *postparent,
                  dict_t *xdata);
@@ -580,13 +590,13 @@ fop_namelink_stub(call_frame_t *frame, fop_namelink_t fn, loc_t *loc,
                   dict_t *xdata);
 
 call_stub_t *
-fop_icreate_cbk_stub(call_frame_t *frame, fop_icreate_cbk_t fn, int32_t op_ret,
-                     int32_t op_errno, inode_t *inode, struct iatt *buf,
-                     dict_t *xdata);
+fop_icreate_cbk_stub(call_frame_t *frame, fop_icreate_cbk_t fn,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+                     struct iatt *buf, dict_t *xdata);
 
 call_stub_t *
 fop_namelink_cbk_stub(call_frame_t *frame, fop_namelink_cbk_t fn,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata);
 
 call_stub_t *
@@ -597,7 +607,7 @@ fop_copy_file_range_stub(call_frame_t *frame, fop_copy_file_range_t fn,
 
 call_stub_t *
 fop_copy_file_range_cbk_stub(call_frame_t *frame, fop_copy_file_range_cbk_t fn,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              struct iatt *stbuf, struct iatt *prebuf_dst,
                              struct iatt *postbuf_dst, dict_t *xdata);
 
@@ -608,9 +618,10 @@ call_resume_keep_stub(call_stub_t *stub);
 void
 call_stub_destroy(call_stub_t *stub);
 void
-call_unwind_error(call_stub_t *stub, int op_ret, int op_errno);
+call_unwind_error(call_stub_t *stub, gf_return_t op_ret, int op_errno);
 void
-call_unwind_error_keep_stub(call_stub_t *stub, int op_ret, int op_errno);
+call_unwind_error_keep_stub(call_stub_t *stub, gf_return_t op_ret,
+                            int op_errno);
 
 /*
  * Sometimes we might want to call just this, perhaps repeatedly, without

--- a/libglusterfs/src/glusterfs/cluster-syncop.h
+++ b/libglusterfs/src/glusterfs/cluster-syncop.h
@@ -215,7 +215,7 @@ cluster_fop_success_fill(default_args_cbk_t *replies, int numsubvols,
 
 int32_t
 cluster_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata);
 
 int

--- a/libglusterfs/src/glusterfs/common-utils.h
+++ b/libglusterfs/src/glusterfs/common-utils.h
@@ -1253,4 +1253,9 @@ gf_tsdiff(struct timespec *start, struct timespec *end)
            (double)(t.tv_nsec - start->tv_nsec);
 }
 
+char *
+gf_strerror_r(gf_return_t code, char *str, size_t size);
+char *
+gf_strerror(gf_return_t code);
+
 #endif /* _COMMON_UTILS_H */

--- a/libglusterfs/src/glusterfs/default-args.h
+++ b/libglusterfs/src/glusterfs/default-args.h
@@ -18,224 +18,229 @@
 #include "glusterfs/xlator.h"
 
 int
-args_lookup_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_lookup_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, inode_t *inode, struct iatt *buf,
                       dict_t *xdata, struct iatt *postparent);
 
 int
-args_stat_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    struct iatt *buf, dict_t *xdata);
+args_stat_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, struct iatt *buf, dict_t *xdata);
 
 int
-args_fstat_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iatt *buf, dict_t *xdata);
+args_fstat_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iatt *buf, dict_t *xdata);
 
 int
-args_truncate_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_truncate_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *prebuf,
                         struct iatt *postbuf, dict_t *xdata);
 
 int
-args_ftruncate_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_ftruncate_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, struct iatt *prebuf,
                          struct iatt *postbuf, dict_t *xdata);
 
 int
-args_access_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_access_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, dict_t *xdata);
 
 int
-args_readlink_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_readlink_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, const char *path, struct iatt *stbuf,
                         dict_t *xdata);
 
 int
-args_mknod_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                     struct iatt *postparent, dict_t *xdata);
-
-int
-args_mkdir_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                     struct iatt *postparent, dict_t *xdata);
-
-int
-args_unlink_cbk_store(default_args_cbk_t *args, int32_t op_ret,
-                      int32_t op_errno, struct iatt *preparent,
-                      struct iatt *postparent, dict_t *xdata);
-
-int
-args_rmdir_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
+args_mknod_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, inode_t *inode, struct iatt *buf,
                      struct iatt *preparent, struct iatt *postparent,
                      dict_t *xdata);
 
 int
-args_symlink_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_mkdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, inode_t *inode, struct iatt *buf,
+                     struct iatt *preparent, struct iatt *postparent,
+                     dict_t *xdata);
+
+int
+args_unlink_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                      int32_t op_errno, struct iatt *preparent,
+                      struct iatt *postparent, dict_t *xdata);
+
+int
+args_rmdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iatt *preparent,
+                     struct iatt *postparent, dict_t *xdata);
+
+int
+args_symlink_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, inode_t *inode, struct iatt *buf,
                        struct iatt *preparent, struct iatt *postparent,
                        dict_t *xdata);
 
 int
-args_rename_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_rename_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct iatt *buf,
                       struct iatt *preoldparent, struct iatt *postoldparent,
                       struct iatt *prenewparent, struct iatt *postnewparent,
                       dict_t *xdata);
 
 int
-args_link_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata);
+args_link_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, inode_t *inode, struct iatt *buf,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata);
 
 int
-args_create_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_create_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, fd_t *fd, inode_t *inode,
                       struct iatt *buf, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata);
 
 int
-args_open_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    fd_t *fd, dict_t *xdata);
+args_open_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, fd_t *fd, dict_t *xdata);
 
 int
-args_readv_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iovec *vector, int32_t count, struct iatt *stbuf,
-                     struct iobref *iobref, dict_t *xdata);
+args_readv_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iovec *vector, int32_t count,
+                     struct iatt *stbuf, struct iobref *iobref, dict_t *xdata);
 
 int
-args_writev_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_writev_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata);
 
 int
-args_put_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                   inode_t *inode, struct iatt *buf, struct iatt *preparent,
-                   struct iatt *postparent, dict_t *xdata);
+args_put_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                   int32_t op_errno, inode_t *inode, struct iatt *buf,
+                   struct iatt *preparent, struct iatt *postparent,
+                   dict_t *xdata);
 
 int
-args_flush_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     dict_t *xdata);
+args_flush_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, dict_t *xdata);
 
 int
-args_fsync_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct iatt *prebuf, struct iatt *postbuf, dict_t *xdata);
+args_fsync_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct iatt *prebuf,
+                     struct iatt *postbuf, dict_t *xdata);
 
 int
-args_opendir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_opendir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, fd_t *fd, dict_t *xdata);
 
 int
-args_fsyncdir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fsyncdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata);
 
 int
-args_statfs_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_statfs_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                       int32_t op_errno, struct statvfs *buf, dict_t *xdata);
 
 int
-args_setxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_setxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata);
 
 int
-args_getxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_getxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *dict, dict_t *xdata);
 
 int
-args_fsetxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fsetxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, dict_t *xdata);
 
 int
-args_fgetxattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fgetxattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, dict_t *dict, dict_t *xdata);
 
 int
-args_removexattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_removexattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                            int32_t op_errno, dict_t *xdata);
 
 int
-args_fremovexattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fremovexattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                             int32_t op_errno, dict_t *xdata);
 
 int
-args_lk_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                  struct gf_flock *lock, dict_t *xdata);
+args_lk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                  int32_t op_errno, struct gf_flock *lock, dict_t *xdata);
 
 int
-args_inodelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_inodelk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, dict_t *xdata);
 
 int
-args_finodelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_finodelk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata);
 
 int
-args_entrylk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_entrylk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, dict_t *xdata);
 
 int
-args_fentrylk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fentrylk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xdata);
 
 int
-args_readdirp_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_readdirp_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, gf_dirent_t *entries, dict_t *xdata);
 
 int
-args_readdir_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_readdir_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, gf_dirent_t *entries, dict_t *xdata);
 
 int
-args_rchecksum_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_rchecksum_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, uint32_t weak_checksum,
                          uint8_t *strong_checksum, dict_t *xdata);
 
 int
-args_xattrop_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_xattrop_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, dict_t *xattr, dict_t *xdata);
 
 int
-args_fxattrop_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fxattrop_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, dict_t *xattr, dict_t *xdata);
 
 int
-args_setattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_setattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, struct iatt *statpre,
                        struct iatt *statpost, dict_t *xdata);
 
 int
-args_fsetattr_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fsetattr_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *statpre,
                         struct iatt *statpost, dict_t *xdata);
 
 int
-args_fallocate_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_fallocate_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                          int32_t op_errno, struct iatt *statpre,
                          struct iatt *statpost, dict_t *xdata);
 
 int
-args_discard_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_discard_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                        int32_t op_errno, struct iatt *statpre,
                        struct iatt *statpost, dict_t *xdata);
 
 int
-args_zerofill_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_zerofill_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                         int32_t op_errno, struct iatt *statpre,
                         struct iatt *statpost, dict_t *xdata);
 
 int
-args_ipc_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                   dict_t *xdata);
+args_ipc_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                   int32_t op_errno, dict_t *xdata);
 
 int
-args_seek_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                    off_t offset, dict_t *xdata);
+args_seek_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                    int32_t op_errno, off_t offset, dict_t *xdata);
 
 void
-args_lease_cbk_store(default_args_cbk_t *args, int32_t op_ret, int32_t op_errno,
-                     struct gf_lease *lease, dict_t *xdata);
+args_lease_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
+                     int32_t op_errno, struct gf_lease *lease, dict_t *xdata);
 
 int
-args_copy_file_range_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_copy_file_range_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                                int32_t op_errno, struct iatt *stbuf,
                                struct iatt *prebuf_dst,
                                struct iatt *postbuf_dst, dict_t *xdata);
@@ -430,7 +435,7 @@ args_lease_store(default_args_t *args, loc_t *loc, struct gf_lease *lease,
                  dict_t *xdata);
 
 int
-args_getactivelk_cbk_store(default_args_cbk_t *args, int32_t op_ret,
+args_getactivelk_cbk_store(default_args_cbk_t *args, gf_return_t op_ret,
                            int32_t op_errno, lock_migration_info_t *locklist,
                            dict_t *xdata);
 

--- a/libglusterfs/src/glusterfs/defaults.h
+++ b/libglusterfs/src/glusterfs/defaults.h
@@ -18,8 +18,8 @@
 #include "glusterfs/xlator.h"
 
 typedef struct {
-    int op_ret;
-    int op_errno;
+    gf_return_t op_ret;
+    int32_t op_errno;
     inode_t *inode;
     struct iatt stat;
     struct iatt prestat;
@@ -566,262 +566,273 @@ default_copy_file_range_resume(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
 
 int32_t
 default_lookup_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, inode_t *inode,
+                          gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                           struct iatt *buf, dict_t *xdata,
                           struct iatt *postparent);
 
 int32_t
 default_stat_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                        gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                         dict_t *xdata);
 
 int32_t
 default_truncate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             struct iatt *prebuf, struct iatt *postbuf,
                             dict_t *xdata);
 
 int32_t
 default_ftruncate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              struct iatt *prebuf, struct iatt *postbuf,
                              dict_t *xdata);
 
 int32_t
 default_access_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_readlink_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, const char *path,
-                            struct iatt *buf, dict_t *xdata);
+                            gf_return_t op_ret, int32_t op_errno,
+                            const char *path, struct iatt *buf, dict_t *xdata);
 
 int32_t
 default_mknod_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, inode_t *inode,
+                         gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                          struct iatt *buf, struct iatt *preparent,
                          struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_mkdir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, inode_t *inode,
+                         gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                          struct iatt *buf, struct iatt *preparent,
                          struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_unlink_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno,
+                          gf_return_t op_ret, int32_t op_errno,
                           struct iatt *preparent, struct iatt *postparent,
                           dict_t *xdata);
 
 int32_t
 default_rmdir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno,
+                         gf_return_t op_ret, int32_t op_errno,
                          struct iatt *preparent, struct iatt *postparent,
                          dict_t *xdata);
 
 int32_t
 default_symlink_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, inode_t *inode,
+                           gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                            struct iatt *buf, struct iatt *preparent,
                            struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_rename_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *buf,
-                          struct iatt *preoldparent, struct iatt *postoldparent,
-                          struct iatt *prenewparent, struct iatt *postnewparent,
-                          dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *buf, struct iatt *preoldparent,
+                          struct iatt *postoldparent, struct iatt *prenewparent,
+                          struct iatt *postnewparent, dict_t *xdata);
 
 int32_t
 default_link_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, inode_t *inode,
+                        gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                         struct iatt *buf, struct iatt *preparent,
                         struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_create_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, fd_t *fd,
+                          gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                           inode_t *inode, struct iatt *buf,
                           struct iatt *preparent, struct iatt *postparent,
                           dict_t *xdata);
 
 int32_t
 default_open_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, fd_t *fd,
+                        gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                         dict_t *xdata);
 
 int32_t
 default_readv_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, struct iovec *vector,
-                         int32_t count, struct iatt *stbuf,
-                         struct iobref *iobref, dict_t *xdata);
+                         gf_return_t op_ret, int32_t op_errno,
+                         struct iovec *vector, int32_t count,
+                         struct iatt *stbuf, struct iobref *iobref,
+                         dict_t *xdata);
 
 int32_t
 default_writev_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                          struct iatt *postbuf, dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *prebuf, struct iatt *postbuf,
+                          dict_t *xdata);
 
 int32_t
 default_flush_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fsync_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                         struct iatt *postbuf, dict_t *xdata);
+                         gf_return_t op_ret, int32_t op_errno,
+                         struct iatt *prebuf, struct iatt *postbuf,
+                         dict_t *xdata);
 
 int32_t
 default_fstat_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                         gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                          dict_t *xdata);
 
 int32_t
 default_opendir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, fd_t *fd,
+                           gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                            dict_t *xdata);
 
 int32_t
 default_fsyncdir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                            gf_return_t op_ret, int32_t op_errno,
+                            dict_t *xdata);
 
 int32_t
 default_statfs_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct statvfs *buf,
-                          dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct statvfs *buf, dict_t *xdata);
 
 int32_t
 default_setxattr_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                            gf_return_t op_ret, int32_t op_errno,
+                            dict_t *xdata);
 
 int32_t
 default_fsetxattr_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                             gf_return_t op_ret, int32_t op_errno,
+                             dict_t *xdata);
 
 int32_t
 default_fgetxattr_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno, dict_t *dict,
+                             gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                              dict_t *xdata);
 
 int32_t
 default_getxattr_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *dict,
+                            gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                             dict_t *xdata);
 
 int32_t
 default_xattrop_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, dict_t *dict,
+                           gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                            dict_t *xdata);
 
 int32_t
 default_fxattrop_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *dict,
+                            gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                             dict_t *xdata);
 
 int32_t
 default_removexattr_cbk_resume(call_frame_t *frame, void *cookie,
-                               xlator_t *this, int32_t op_ret, int32_t op_errno,
-                               dict_t *xdata);
+                               xlator_t *this, gf_return_t op_ret,
+                               int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fremovexattr_cbk_resume(call_frame_t *frame, void *cookie,
-                                xlator_t *this, int32_t op_ret,
+                                xlator_t *this, gf_return_t op_ret,
                                 int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_lk_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
-                      dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct gf_flock *lock, dict_t *xdata);
 
 int32_t
 default_inodelk_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                           gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_finodelk_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                            gf_return_t op_ret, int32_t op_errno,
+                            dict_t *xdata);
 
 int32_t
 default_entrylk_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                           gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fentrylk_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                            gf_return_t op_ret, int32_t op_errno,
+                            dict_t *xdata);
 
 int32_t
 default_rchecksum_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              uint32_t weak_checksum, uint8_t *strong_checksum,
                              dict_t *xdata);
 
 int32_t
 default_readdir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno,
+                           gf_return_t op_ret, int32_t op_errno,
                            gf_dirent_t *entries, dict_t *xdata);
 
 int32_t
 default_readdirp_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             gf_dirent_t *entries, dict_t *xdata);
 
 int32_t
 default_setattr_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno,
+                           gf_return_t op_ret, int32_t op_errno,
                            struct iatt *statpre, struct iatt *statpost,
                            dict_t *xdata);
 
 int32_t
 default_fsetattr_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             struct iatt *statpre, struct iatt *statpost,
                             dict_t *xdata);
 
 int32_t
 default_fallocate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno, struct iatt *pre,
-                             struct iatt *post, dict_t *xdata);
+                             gf_return_t op_ret, int32_t op_errno,
+                             struct iatt *pre, struct iatt *post,
+                             dict_t *xdata);
 
 int32_t
 default_discard_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, struct iatt *pre,
-                           struct iatt *post, dict_t *xdata);
+                           gf_return_t op_ret, int32_t op_errno,
+                           struct iatt *pre, struct iatt *post, dict_t *xdata);
 
 int32_t
 default_zerofill_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, struct iatt *pre,
-                            struct iatt *post, dict_t *xdata);
+                            gf_return_t op_ret, int32_t op_errno,
+                            struct iatt *pre, struct iatt *post, dict_t *xdata);
 int32_t
 default_ipc_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_seek_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, off_t offset,
+                        gf_return_t op_ret, int32_t op_errno, off_t offset,
                         dict_t *xdata);
 
 int32_t
 default_getspec_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, char *spec_data);
+                           gf_return_t op_ret, int32_t op_errno,
+                           char *spec_data);
 
 int32_t
 default_lease_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno,
+                         gf_return_t op_ret, int32_t op_errno,
                          struct gf_lease *lease, dict_t *xdata);
 
 int32_t
 default_getactivelk_cbk_resume(call_frame_t *frame, void *cookie,
-                               xlator_t *this, int32_t op_ret, int32_t op_errno,
+                               xlator_t *this, gf_return_t op_ret,
+                               int32_t op_errno,
                                lock_migration_info_t *locklist, dict_t *xdata);
 
 int32_t
 default_setactivelk_cbk_resume(call_frame_t *frame, void *cookie,
-                               xlator_t *this, int32_t op_ret, int32_t op_errno,
-                               dict_t *xdata);
+                               xlator_t *this, gf_return_t op_ret,
+                               int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_put_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, inode_t *inode,
+                       gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                        struct iatt *buf, struct iatt *preparent,
                        struct iatt *postparent, dict_t *xdata);
 
@@ -835,7 +846,7 @@ default_namelink_resume(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 int32_t
 default_copy_file_range_cbk_resume(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, struct iatt *stbuf,
                                    struct iatt *prebuf_dst,
                                    struct iatt *postbuf_dst, dict_t *xdata);
@@ -843,264 +854,267 @@ default_copy_file_range_cbk_resume(call_frame_t *frame, void *cookie,
 /* _CBK */
 int32_t
 default_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, dict_t *xdata, struct iatt *postparent);
 
 int32_t
 default_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                  dict_t *xdata);
 
 int32_t
 default_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata);
 
 int32_t
 default_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata);
 
 int32_t
 default_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, const char *path,
+                     gf_return_t op_ret, int32_t op_errno, const char *path,
                      struct iatt *buf, dict_t *xdata);
 
 int32_t
 default_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                    struct iatt *preoldparent, struct iatt *postoldparent,
                    struct iatt *prenewparent, struct iatt *postnewparent,
                    dict_t *xdata);
 
 int32_t
 default_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                   struct iatt *buf, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   inode_t *inode, struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata);
+                 gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata);
 
 int32_t
 default_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                  gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                   int32_t count, struct iatt *stbuf, struct iobref *iobref,
                   dict_t *xdata);
 
 int32_t
 default_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata);
 
 int32_t
 default_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata);
 
 int32_t
 default_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   dict_t *xdata);
 
 int32_t
 default_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata);
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    dict_t *xdata);
 
 int32_t
 default_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                    dict_t *xdata);
 
 int32_t
 default_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                       dict_t *xdata);
 
 int32_t
 default_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata);
 
 int32_t
 default_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata);
 
 int32_t
 default_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata);
 
 int32_t
 default_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+               gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                dict_t *xdata);
 
 int32_t
 default_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                      uint8_t *strong_checksum, dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno,
+                      uint32_t weak_checksum, uint8_t *strong_checksum,
+                      dict_t *xdata);
 
 int32_t
 default_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                     dict_t *xdata);
 
 int32_t
 default_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                      dict_t *xdata);
 
 int32_t
 default_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata);
 
 int32_t
 default_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata);
 
 int32_t
 default_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                       struct iatt *post, dict_t *xdata);
 
 int32_t
 default_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                     struct iatt *post, dict_t *xdata);
 
 int32_t
 default_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                      struct iatt *post, dict_t *xdata);
 
 int32_t
 default_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata);
+                 gf_return_t op_ret, int32_t op_errno, off_t offset,
+                 dict_t *xdata);
 
 int32_t
 default_getspec_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, char *spec_data);
+                    gf_return_t op_ret, int32_t op_errno, char *spec_data);
 
 int32_t
 default_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct gf_lease *lease,
+                  gf_return_t op_ret, int32_t op_errno, struct gf_lease *lease,
                   dict_t *xdata);
 
 int32_t
 default_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno,
+                        gf_return_t op_ret, int32_t op_errno,
                         lock_migration_info_t *locklist, dict_t *xdata);
 
 int32_t
 default_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int32_t
 default_put_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata);
 
 int32_t
 default_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, dict_t *xdata);
 
 int32_t
 default_namelink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata);
 
 int32_t
 default_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             struct iatt *stbuf, struct iatt *prebuf_dst,
                             struct iatt *postbuf_dst, dict_t *xdata);
 

--- a/libglusterfs/src/glusterfs/globals.h
+++ b/libglusterfs/src/glusterfs/globals.h
@@ -142,6 +142,8 @@ glusterfs_this_set(xlator_t *);
 
 extern xlator_t global_xlator;
 extern struct volume_options global_xl_options[];
+extern const gf_return_t gf_error;
+extern const gf_return_t gf_success;
 
 /* syncopctx */
 void *
@@ -164,6 +166,9 @@ char *
 glusterfs_leaseid_buf_get(void);
 char *
 glusterfs_leaseid_exist(void);
+/* errorcode_buf */
+char *
+glusterfs_errorcode_buf_get(void);
 
 /* init */
 int
@@ -179,6 +184,7 @@ glusterfs_ctx_tw_put(glusterfs_ctx_t *ctx);
 
 extern const char *gf_fop_list[];
 extern const char *gf_upcall_list[];
+extern const char *gf_xlator_list[];
 
 /* mem acct enable/disable */
 int

--- a/libglusterfs/src/glusterfs/glusterfs.h
+++ b/libglusterfs/src/glusterfs/glusterfs.h
@@ -43,8 +43,14 @@
 #define GF_YES 1
 #define GF_NO 0
 
-#define IS_ERROR(ret) ((ret) < 0)
-#define IS_SUCCESS(ret) ((ret) >= 0)
+typedef struct _gf_return {
+    int32_t op_ret;
+} gf_return_t;
+
+#define IS_ERROR(ret) (((ret).op_ret) < 0)
+#define IS_SUCCESS(ret) (((ret).op_ret) >= 0)
+#define GET_RET(ret) ((ret).op_ret)
+#define SET_RET(ret, val) ((ret).op_ret = (val))
 
 #ifndef O_LARGEFILE
 /* savannah bug #20053, patch for compiling on darwin */
@@ -425,7 +431,7 @@ static const char *const FOP_PRI_STRINGS[] = {"HIGH", "NORMAL", "LOW", "LEAST"};
 static inline const char *
 fop_pri_to_string(gf_fop_pri_t pri)
 {
-    if (IS_ERROR(pri))
+    if (pri < 0)
         return "UNSPEC";
 
     if (pri >= GF_FOP_PRI_MAX)

--- a/libglusterfs/src/glusterfs/syncop.h
+++ b/libglusterfs/src/glusterfs/syncop.h
@@ -170,8 +170,8 @@ struct syncbarrier {
 typedef struct syncbarrier syncbarrier_t;
 
 struct syncargs {
-    int op_ret;
     int op_errno;
+    gf_return_t op_ret;
 
     /*
      * The below 3 iatt structures are used in the fops
@@ -280,7 +280,7 @@ struct syncopctx {
             frame = syncop_create_frame(THIS);                                 \
                                                                                \
         if (!frame) {                                                          \
-            stb->op_ret = -1;                                                  \
+            stb->op_ret = gf_error;                                            \
             stb->op_errno = errno;                                             \
             break;                                                             \
         }                                                                      \
@@ -677,7 +677,7 @@ syncop_getactivelk(xlator_t *subvol, loc_t *loc,
 
 int
 syncop_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int
 syncop_setactivelk(xlator_t *subvol, loc_t *loc,
@@ -692,7 +692,7 @@ syncop_put(xlator_t *subvol, loc_t *loc, mode_t mode, mode_t umask,
 
 int
 syncop_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int
 syncop_icreate(xlator_t *subvol, loc_t *loc, mode_t mode, dict_t *xdata_out);
@@ -711,7 +711,7 @@ syncop_copy_file_range(xlator_t *subvol, fd_t *fd_in, off64_t off_in,
 
 int
 syncop_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int op_ret, int op_errno, struct iatt *stbuf,
+                           gf_return_t op_ret, int op_errno, struct iatt *stbuf,
                            struct iatt *prebuf_dst, struct iatt *postbuf_dst,
                            dict_t *xdata);
 

--- a/libglusterfs/src/glusterfs/xlator.h
+++ b/libglusterfs/src/glusterfs/xlator.h
@@ -54,6 +54,28 @@ typedef struct _loc loc_t;
 typedef int32_t (*event_notify_fn_t)(xlator_t *this, int32_t event, void *data,
                                      ...);
 
+enum _gf_xlator_list {
+    GF_XLATOR_NONE = 0,
+    GF_XLATOR_POSIX = 1,
+    GF_XLATOR_AFR,
+    GF_XLATOR_DHT,
+    GF_XLATOR_EC,
+    GF_XLATOR_ACL,
+    GF_XLATOR_SELINUX,
+    GF_XLATOR_LOCKS,
+    GF_XLATOR_LEASES,
+    GF_XLATOR_INDEX,
+    GF_XLATOR_FUSE,
+    GF_XLATOR_IOT,
+    GF_XLATOR_MARKER,
+    GF_XLATOR_IO_STATS,
+    GF_XLATOR_SERVER,
+    GF_XLATOR_BACKEND = 125,
+    GF_XLATOR_EXTERNAL = 126,
+    GF_XLATOR_MAXVALUE = 127,
+};
+typedef enum _gf_xlator_list gf_xlator_list_t;
+
 #include "glusterfs/list.h"
 #include "glusterfs/gf-dirent.h"
 #include "glusterfs/stack.h"
@@ -79,11 +101,11 @@ struct _loc {
 };
 
 typedef int32_t (*fop_getspec_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, char *spec_data);
 
 typedef int32_t (*fop_rchecksum_cbk_t)(call_frame_t *frame, void *cookie,
-                                       xlator_t *this, int32_t op_ret,
+                                       xlator_t *this, gf_return_t op_ret,
                                        int32_t op_errno, uint32_t weak_checksum,
                                        uint8_t *strong_checksum, dict_t *xdata);
 
@@ -95,70 +117,70 @@ typedef int32_t (*fop_rchecksum_t)(call_frame_t *frame, xlator_t *this,
                                    dict_t *xdata);
 
 typedef int32_t (*fop_lookup_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, inode_t *inode,
                                     struct iatt *buf, dict_t *xdata,
                                     struct iatt *postparent);
 
 typedef int32_t (*fop_stat_cbk_t)(call_frame_t *frame, void *cookie,
-                                  xlator_t *this, int32_t op_ret,
+                                  xlator_t *this, gf_return_t op_ret,
                                   int32_t op_errno, struct iatt *buf,
                                   dict_t *xdata);
 
 typedef int32_t (*fop_fstat_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, struct iatt *buf,
                                    dict_t *xdata);
 
 typedef int32_t (*fop_truncate_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, struct iatt *prebuf,
                                       struct iatt *postbuf, dict_t *xdata);
 
 typedef int32_t (*fop_ftruncate_cbk_t)(call_frame_t *frame, void *cookie,
-                                       xlator_t *this, int32_t op_ret,
+                                       xlator_t *this, gf_return_t op_ret,
                                        int32_t op_errno, struct iatt *prebuf,
                                        struct iatt *postbuf, dict_t *xdata);
 
 typedef int32_t (*fop_access_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_readlink_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, const char *path,
                                       struct iatt *buf, dict_t *xdata);
 
 typedef int32_t (*fop_mknod_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, inode_t *inode,
                                    struct iatt *buf, struct iatt *preparent,
                                    struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_mkdir_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, inode_t *inode,
                                    struct iatt *buf, struct iatt *preparent,
                                    struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_unlink_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, struct iatt *preparent,
                                     struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_rmdir_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, struct iatt *preparent,
                                    struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_symlink_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, inode_t *inode,
                                      struct iatt *buf, struct iatt *preparent,
                                      struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_rename_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, struct iatt *buf,
                                     struct iatt *preoldparent,
                                     struct iatt *postoldparent,
@@ -166,196 +188,196 @@ typedef int32_t (*fop_rename_cbk_t)(call_frame_t *frame, void *cookie,
                                     struct iatt *postnewparent, dict_t *xdata);
 
 typedef int32_t (*fop_link_cbk_t)(call_frame_t *frame, void *cookie,
-                                  xlator_t *this, int32_t op_ret,
+                                  xlator_t *this, gf_return_t op_ret,
                                   int32_t op_errno, inode_t *inode,
                                   struct iatt *buf, struct iatt *preparent,
                                   struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_create_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, fd_t *fd, inode_t *inode,
                                     struct iatt *buf, struct iatt *preparent,
                                     struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_open_cbk_t)(call_frame_t *frame, void *cookie,
-                                  xlator_t *this, int32_t op_ret,
+                                  xlator_t *this, gf_return_t op_ret,
                                   int32_t op_errno, fd_t *fd, dict_t *xdata);
 
 typedef int32_t (*fop_readv_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, struct iovec *vector,
                                    int32_t count, struct iatt *stbuf,
                                    struct iobref *iobref, dict_t *xdata);
 
 typedef int32_t (*fop_writev_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, struct iatt *prebuf,
                                     struct iatt *postbuf, dict_t *xdata);
 
 typedef int32_t (*fop_flush_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_fsync_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, struct iatt *prebuf,
                                    struct iatt *postbuf, dict_t *xdata);
 
 typedef int32_t (*fop_opendir_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, fd_t *fd, dict_t *xdata);
 
 typedef int32_t (*fop_fsyncdir_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_statfs_cbk_t)(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, struct statvfs *buf,
                                     dict_t *xdata);
 
 typedef int32_t (*fop_setxattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_getxattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *dict,
                                       dict_t *xdata);
 
 typedef int32_t (*fop_fsetxattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                       xlator_t *this, int32_t op_ret,
+                                       xlator_t *this, gf_return_t op_ret,
                                        int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_fgetxattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                       xlator_t *this, int32_t op_ret,
+                                       xlator_t *this, gf_return_t op_ret,
                                        int32_t op_errno, dict_t *dict,
                                        dict_t *xdata);
 
 typedef int32_t (*fop_removexattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                         xlator_t *this, int32_t op_ret,
+                                         xlator_t *this, gf_return_t op_ret,
                                          int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_fremovexattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                          xlator_t *this, int32_t op_ret,
+                                          xlator_t *this, gf_return_t op_ret,
                                           int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_lk_cbk_t)(call_frame_t *frame, void *cookie,
-                                xlator_t *this, int32_t op_ret,
+                                xlator_t *this, gf_return_t op_ret,
                                 int32_t op_errno, struct gf_flock *flock,
                                 dict_t *xdata);
 
 typedef int32_t (*fop_inodelk_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_finodelk_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_entrylk_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_fentrylk_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_readdir_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, gf_dirent_t *entries,
                                      dict_t *xdata);
 
 typedef int32_t (*fop_readdirp_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, gf_dirent_t *entries,
                                       dict_t *xdata);
 
 typedef int32_t (*fop_xattrop_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, dict_t *xattr,
                                      dict_t *xdata);
 
 typedef int32_t (*fop_fxattrop_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *xattr,
                                       dict_t *xdata);
 
 typedef int32_t (*fop_setattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, struct iatt *preop_stbuf,
                                      struct iatt *postop_stbuf, dict_t *xdata);
 
 typedef int32_t (*fop_fsetattr_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno,
                                       struct iatt *preop_stbuf,
                                       struct iatt *postop_stbuf, dict_t *xdata);
 
 typedef int32_t (*fop_fallocate_cbk_t)(call_frame_t *frame, void *cookie,
-                                       xlator_t *this, int32_t op_ret,
+                                       xlator_t *this, gf_return_t op_ret,
                                        int32_t op_errno,
                                        struct iatt *preop_stbuf,
                                        struct iatt *postop_stbuf,
                                        dict_t *xdata);
 
 typedef int32_t (*fop_discard_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, struct iatt *preop_stbuf,
                                      struct iatt *postop_stbuf, dict_t *xdata);
 
 typedef int32_t (*fop_zerofill_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno,
                                       struct iatt *preop_stbuf,
                                       struct iatt *postop_stbuf, dict_t *xdata);
 
 typedef int32_t (*fop_ipc_cbk_t)(call_frame_t *frame, void *cookie,
-                                 xlator_t *this, int32_t op_ret,
+                                 xlator_t *this, gf_return_t op_ret,
                                  int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_seek_cbk_t)(call_frame_t *frame, void *cookie,
-                                  xlator_t *this, int32_t op_ret,
+                                  xlator_t *this, gf_return_t op_ret,
                                   int32_t op_errno, off_t offset,
                                   dict_t *xdata);
 
 typedef int32_t (*fop_lease_cbk_t)(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, struct gf_lease *lease,
                                    dict_t *xdata);
 typedef int32_t (*fop_compound_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, void *data,
                                       dict_t *xdata);
 
 typedef int32_t (*fop_getactivelk_cbk_t)(call_frame_t *frame, void *cookie,
-                                         xlator_t *this, int32_t op_ret,
+                                         xlator_t *this, gf_return_t op_ret,
                                          int32_t op_errno,
                                          lock_migration_info_t *locklist,
                                          dict_t *xdata);
 
 typedef int32_t (*fop_setactivelk_cbk_t)(call_frame_t *frame, void *cookie,
-                                         xlator_t *this, int32_t op_ret,
+                                         xlator_t *this, gf_return_t op_ret,
                                          int32_t op_errno, dict_t *xdata);
 
 typedef int32_t (*fop_put_cbk_t)(call_frame_t *frame, void *cookie,
-                                 xlator_t *this, int32_t op_ret,
+                                 xlator_t *this, gf_return_t op_ret,
                                  int32_t op_errno, inode_t *inode,
                                  struct iatt *buf, struct iatt *preparent,
                                  struct iatt *postparent, dict_t *xdata);
 
 typedef int32_t (*fop_icreate_cbk_t)(call_frame_t *frame, void *cookie,
-                                     xlator_t *this, int32_t op_ret,
+                                     xlator_t *this, gf_return_t op_ret,
                                      int32_t op_errno, inode_t *inode,
                                      struct iatt *buf, dict_t *xdata);
 
 typedef int32_t (*fop_namelink_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, struct iatt *prebuf,
                                       struct iatt *postbuf, dict_t *xdata);
 
 typedef int32_t (*fop_copy_file_range_cbk_t)(
-    call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
+    call_frame_t *frame, void *cookie, xlator_t *this, gf_return_t op_ret,
     int32_t op_errno, struct iatt *stbuf, struct iatt *prebuf_dst,
     struct iatt *postbuf_dst, dict_t *xdata);
 

--- a/libglusterfs/src/inode.c
+++ b/libglusterfs/src/inode.c
@@ -2024,13 +2024,13 @@ inode_needs_lookup(inode_t *inode, xlator_t *this)
 {
     uint64_t need_lookup = 0;
     gf_boolean_t ret = _gf_false;
-    int op_ret = -1;
+    int op_ret;
 
     if (!inode || !this)
         return ret;
 
     op_ret = inode_ctx_get(inode, this, &need_lookup);
-    if (op_ret == -1) {
+    if (op_ret < 0) {
         ret = _gf_true;
     } else if (need_lookup == LOOKUP_NEEDED) {
         ret = _gf_true;

--- a/libglusterfs/src/libglusterfs.sym
+++ b/libglusterfs/src/libglusterfs.sym
@@ -589,6 +589,7 @@ gf_dnscache_deinit
 gf_errno_to_error
 gf_error_to_errno
 _gf_event
+gf_error
 gf_fd_fdptr_get
 gf_fd_fdtable_alloc
 gf_fd_fdtable_copy_all_fds
@@ -697,6 +698,8 @@ gf_store_save_value
 gf_store_save_items
 gf_store_unlink_tmppath
 gf_store_unlock
+gf_strerror
+gf_strerror_r
 gf_string2boolean
 gf_string2bytesize_int64
 gf_string2bytesize_uint64
@@ -743,6 +746,7 @@ gf_vasprintf
 gf_volfile_reconfigure
 gf_xxh64_wrapper
 gf_zero_fill_stat
+gf_success
 gid_cache_add
 gid_cache_init
 gid_cache_lookup

--- a/libglusterfs/src/syncop.c
+++ b/libglusterfs/src/syncop.c
@@ -1310,9 +1310,9 @@ syncbarrier_wake(struct syncbarrier *barrier)
 /* FOPS */
 
 int
-syncop_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, inode_t *inode, struct iatt *iatt,
-                  dict_t *xdata, struct iatt *parent)
+syncop_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, inode_t *inode,
+                  struct iatt *iatt, dict_t *xdata, struct iatt *parent)
 {
     struct syncargs *args = NULL;
 
@@ -1323,7 +1323,7 @@ syncop_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *iatt;
         args->iatt2 = *parent;
     }
@@ -1353,14 +1353,14 @@ syncop_lookup(xlator_t *subvol, loc_t *loc, struct iatt *iatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                     dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -1378,12 +1378,12 @@ syncop_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         list_for_each_entry(entry, &entries->list, list)
         {
             tmp = entry_copy(entry);
             if (!tmp) {
-                args->op_ret = -1;
+                args->op_ret = gf_error;
                 args->op_errno = ENOMEM;
                 gf_dirent_free(&(args->entries));
                 break;
@@ -1423,14 +1423,14 @@ syncop_readdirp(xlator_t *subvol, fd_t *fd, size_t size, off_t off,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                   gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                    dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -1448,12 +1448,12 @@ syncop_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         list_for_each_entry(entry, &entries->list, list)
         {
             tmp = entry_copy(entry);
             if (!tmp) {
-                args->op_ret = -1;
+                args->op_ret = gf_error;
                 args->op_errno = ENOMEM;
                 gf_dirent_free(&(args->entries));
                 break;
@@ -1493,14 +1493,15 @@ syncop_readdir(xlator_t *subvol, fd_t *fd, size_t size, off_t off,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1532,14 +1533,14 @@ syncop_opendir(xlator_t *subvol, loc_t *loc, fd_t *fd, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1571,14 +1572,14 @@ syncop_fsyncdir(xlator_t *subvol, fd_t *fd, int datasync, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1610,14 +1611,14 @@ syncop_removexattr(xlator_t *subvol, loc_t *loc, const char *name,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1649,14 +1650,14 @@ syncop_fremovexattr(xlator_t *subvol, fd_t *fd, const char *name,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1688,14 +1689,14 @@ syncop_setxattr(xlator_t *subvol, loc_t *loc, dict_t *dict, int32_t flags,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1727,14 +1728,15 @@ syncop_fsetxattr(xlator_t *subvol, fd_t *fd, dict_t *dict, int32_t flags,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, dict_t *dict, dict_t *xdata)
+                    gf_return_t op_ret, int op_errno, dict_t *dict,
+                    dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1745,7 +1747,7 @@ syncop_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         args->xattr = dict_ref(dict);
 
     __wake(args);
@@ -1774,9 +1776,9 @@ syncop_listxattr(xlator_t *subvol, loc_t *loc, dict_t **dict, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -1800,9 +1802,9 @@ syncop_getxattr(xlator_t *subvol, loc_t *loc, dict_t **dict, const char *key,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -1826,14 +1828,14 @@ syncop_fgetxattr(xlator_t *subvol, fd_t *fd, dict_t **dict, const char *key,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                   dict_t *xdata)
 
 {
@@ -1846,7 +1848,7 @@ syncop_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->statvfs_buf = *buf;
     }
 
@@ -1874,14 +1876,14 @@ syncop_statfs(xlator_t *subvol, loc_t *loc, struct statvfs *buf,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, struct iatt *preop,
+                   gf_return_t op_ret, int op_errno, struct iatt *preop,
                    struct iatt *postop, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -1893,7 +1895,7 @@ syncop_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *preop;
         args->iatt2 = *postop;
     }
@@ -1925,9 +1927,9 @@ syncop_setattr(xlator_t *subvol, loc_t *loc, struct iatt *iatt, int valid,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -1952,14 +1954,14 @@ syncop_fsetattr(xlator_t *subvol, fd_t *fd, struct iatt *iatt, int valid,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -1991,14 +1993,14 @@ syncop_open(xlator_t *subvol, loc_t *loc, int32_t flags, fd_t *fd,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                 gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                  int32_t count, struct iatt *stbuf, struct iobref *iobref,
                  dict_t *xdata)
 {
@@ -2013,7 +2015,7 @@ syncop_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (args->op_ret >= 0) {
+    if (IS_SUCCESS(args->op_ret)) {
         if (iobref)
             args->iobref = iobref_ref(iobref);
         args->vector = iov_dup(vector, count);
@@ -2046,7 +2048,7 @@ syncop_readv(xlator_t *subvol, fd_t *fd, size_t size, off_t off, uint32_t flags,
     if (iatt)
         *iatt = args.iatt1;
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         goto out;
 
     if (vector)
@@ -2064,15 +2066,15 @@ syncop_readv(xlator_t *subvol, fd_t *fd, size_t size, off_t off, uint32_t flags,
         iobref_unref(args.iobref);
 
 out:
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
-syncop_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                  dict_t *xdata)
+syncop_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                  struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -2083,7 +2085,7 @@ syncop_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *prebuf;
         args->iatt2 = *postbuf;
     }
@@ -2116,9 +2118,9 @@ syncop_writev(xlator_t *subvol, fd_t *fd, const struct iovec *vector,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -2144,9 +2146,9 @@ syncop_write(xlator_t *subvol, fd_t *fd, const char *buf, int size,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -2159,8 +2161,8 @@ syncop_close(fd_t *fd)
 
 int32_t
 syncop_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                  struct iatt *buf, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                  inode_t *inode, struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2199,14 +2201,14 @@ syncop_create(xlator_t *subvol, loc_t *loc, int32_t flags, mode_t mode,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_put_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *buf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -2249,15 +2251,15 @@ syncop_put(xlator_t *subvol, loc_t *loc, mode_t mode, mode_t umask,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
-syncop_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, struct iatt *preparent, struct iatt *postparent,
-                  dict_t *xdata)
+syncop_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, struct iatt *preparent,
+                  struct iatt *postparent, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -2289,15 +2291,15 @@ syncop_unlink(xlator_t *subvol, loc_t *loc, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
-syncop_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iatt *preparent, struct iatt *postparent,
-                 dict_t *xdata)
+syncop_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iatt *preparent,
+                 struct iatt *postparent, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -2329,14 +2331,14 @@ syncop_rmdir(xlator_t *subvol, loc_t *loc, int flags, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -2376,15 +2378,15 @@ syncop_link(xlator_t *subvol, loc_t *oldloc, loc_t *newloc, struct iatt *iatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   struct iatt *preoldparent, struct iatt *postoldparent,
                   struct iatt *prenewparent, struct iatt *postnewparent,
                   dict_t *xdata)
@@ -2419,15 +2421,15 @@ syncop_rename(xlator_t *subvol, loc_t *oldloc, loc_t *newloc, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2439,7 +2441,7 @@ syncop_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *prebuf;
         args->iatt2 = *postbuf;
     }
@@ -2470,9 +2472,9 @@ syncop_ftruncate(xlator_t *subvol, fd_t *fd, off_t offset, struct iatt *preiatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -2491,14 +2493,14 @@ syncop_truncate(xlator_t *subvol, loc_t *loc, off_t offset, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2510,7 +2512,7 @@ syncop_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *prebuf;
         args->iatt2 = *postbuf;
     }
@@ -2541,14 +2543,14 @@ syncop_fsync(xlator_t *subvol, fd_t *fd, int dataonly, struct iatt *preiatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -2577,14 +2579,14 @@ syncop_flush(xlator_t *subvol, fd_t *fd, dict_t *xdata_in, dict_t **xdata_out)
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                  dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2596,7 +2598,7 @@ syncop_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         args->iatt1 = *stbuf;
 
     __wake(args);
@@ -2623,9 +2625,9 @@ syncop_fstat(xlator_t *subvol, fd_t *fd, struct iatt *stbuf, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -2647,14 +2649,14 @@ syncop_stat(xlator_t *subvol, loc_t *loc, struct iatt *stbuf, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -2694,14 +2696,14 @@ syncop_symlink(xlator_t *subvol, loc_t *loc, const char *newpath,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, const char *path,
+                    gf_return_t op_ret, int op_errno, const char *path,
                     struct iatt *stbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2713,7 +2715,7 @@ syncop_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if ((op_ret != -1) && path)
+    if (IS_SUCCESS(op_ret) && path)
         args->buffer = gf_strdup(path);
 
     __wake(args);
@@ -2742,14 +2744,14 @@ syncop_readlink(xlator_t *subvol, loc_t *loc, char **buffer, size_t size,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -2789,14 +2791,14 @@ syncop_mknod(xlator_t *subvol, loc_t *loc, mode_t mode, dev_t rdev,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -2836,14 +2838,14 @@ syncop_mkdir(xlator_t *subvol, loc_t *loc, mode_t mode, struct iatt *iatt,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -2890,14 +2892,14 @@ syncop_access(xlator_t *subvol, loc_t *loc, int32_t mask, dict_t *xdata_in,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
     return args.op_errno;
 }
 
 int
 syncop_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2930,14 +2932,14 @@ syncop_fallocate(xlator_t *subvol, fd_t *fd, int32_t keep_size, off_t offset,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -2970,14 +2972,14 @@ syncop_discard(xlator_t *subvol, fd_t *fd, off_t offset, size_t len,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -3010,14 +3012,14 @@ syncop_zerofill(xlator_t *subvol, fd_t *fd, off_t offset, off_t len,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
-syncop_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, dict_t *xdata)
+syncop_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3055,14 +3057,14 @@ syncop_ipc(xlator_t *subvol, int32_t op, dict_t *xdata_in, dict_t **xdata_out)
         }
     }
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
-syncop_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, off_t offset, dict_t *xdata)
+syncop_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, off_t offset, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3090,18 +3092,19 @@ syncop_seek(xlator_t *subvol, fd_t *fd, off_t offset, gf_seek_what_t what,
     SYNCOP(subvol, (&args), syncop_seek_cbk, subvol->fops->seek, fd, offset,
            what, xdata_in);
 
-    if (args.op_ret < 0) {
+    if (IS_ERROR(args.op_ret)) {
         return -args.op_errno;
     } else {
         if (off)
             *off = args.offset;
-        return args.op_ret;
+        return GET_RET(args.op_ret);
     }
 }
 
 int
-syncop_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct gf_lease *lease, dict_t *xdata)
+syncop_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct gf_lease *lease,
+                 dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3145,14 +3148,15 @@ syncop_lease(xlator_t *subvol, loc_t *loc, struct gf_lease *lease,
         }
     }
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
-syncop_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, struct gf_flock *flock, dict_t *xdata)
+syncop_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, struct gf_flock *flock,
+              dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3188,14 +3192,14 @@ syncop_lk(xlator_t *subvol, fd_t *fd, int cmd, struct gf_flock *flock,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3227,15 +3231,15 @@ syncop_inodelk(xlator_t *subvol, const char *volume, loc_t *loc, int32_t cmd,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3266,15 +3270,15 @@ syncop_entrylk(xlator_t *subvol, const char *volume, loc_t *loc,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *dict,
+                   gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                    dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -3315,10 +3319,10 @@ syncop_xattrop(xlator_t *subvol, loc_t *loc, gf_xattrop_flags_t flags,
     else if (args.dict_out)
         dict_unref(args.dict_out);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
@@ -3343,15 +3347,15 @@ syncop_fxattrop(xlator_t *subvol, fd_t *fd, gf_xattrop_flags_t flags,
     else if (args.dict_out)
         dict_unref(args.dict_out);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int32_t
 syncop_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno,
+                       gf_return_t op_ret, int32_t op_errno,
                        lock_migration_info_t *locklist, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -3367,7 +3371,7 @@ syncop_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret > 0) {
+    if (IS_SUCCESS(op_ret)) {
         list_for_each_entry(tmp, &locklist->list, list)
         {
             entry = GF_CALLOC(1, sizeof(lock_migration_info_t),
@@ -3420,15 +3424,15 @@ syncop_getactivelk(xlator_t *subvol, loc_t *loc,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct syncargs *args = NULL;
 
@@ -3462,15 +3466,15 @@ syncop_setactivelk(xlator_t *subvol, loc_t *loc,
     else if (args.xdata)
         dict_unref(args.xdata);
 
-    if (args.op_ret < 0)
+    if (IS_ERROR(args.op_ret))
         return -args.op_errno;
 
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -3492,7 +3496,7 @@ syncop_icreate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 syncop_namelink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     struct syncargs *args = NULL;
@@ -3542,12 +3546,12 @@ syncop_copy_file_range(xlator_t *subvol, fd_t *fd_in, off64_t off_in,
     }
 
     errno = args.op_errno;
-    return args.op_ret;
+    return GET_RET(args.op_ret);
 }
 
 int
 syncop_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int op_ret, int op_errno, struct iatt *stbuf,
+                           gf_return_t op_ret, int op_errno, struct iatt *stbuf,
                            struct iatt *prebuf_dst, struct iatt *postbuf_dst,
                            dict_t *xdata)
 {
@@ -3560,7 +3564,7 @@ syncop_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (xdata)
         args->xdata = dict_ref(xdata);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         args->iatt1 = *stbuf;
         args->iatt2 = *prebuf_dst;
         args->iatt3 = *postbuf_dst;

--- a/xlators/cluster/afr/src/afr-common.c
+++ b/xlators/cluster/afr/src/afr-common.c
@@ -52,7 +52,7 @@ afr_fill_success_replies(afr_local_t *local, afr_private_t *priv,
     int i = 0;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (local->replies[i].valid && local->replies[i].op_ret == 0) {
+        if (local->replies[i].valid && IS_SUCCESS(local->replies[i].op_ret)) {
             replies[i] = 1;
         } else {
             replies[i] = 0;
@@ -71,15 +71,15 @@ afr_discover_done(call_frame_t *frame, xlator_t *this);
 
 int
 afr_dom_lock_acquire_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int op_ret, int op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     afr_local_t *local = frame->local;
     afr_private_t *priv = this->private;
     int i = (long)cookie;
 
-    local->cont.lk.dom_lock_op_ret[i] = op_ret;
+    local->cont.lk.dom_lock_op_ret[i] = GET_RET(op_ret);
     local->cont.lk.dom_lock_op_errno[i] = op_errno;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_LK_HEAL_DOM,
                "%s: Failed to acquire %s on %s",
                uuid_utoa(local->fd->inode->gfid), AFR_LK_HEAL_DOM,
@@ -157,13 +157,13 @@ blocking_lock:
 
 int
 afr_dom_lock_release_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int op_ret, int op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     afr_local_t *local = frame->local;
     afr_private_t *priv = this->private;
     int i = (long)cookie;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_LK_HEAL_DOM,
                "%s: Failed to release %s on %s", local->loc.path,
                AFR_LK_HEAL_DOM, priv->children[i]->name);
@@ -331,7 +331,7 @@ out:
 
 int
 afr_lock_heal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+                  gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                   dict_t *xdata)
 {
     afr_local_t *local = frame->local;
@@ -340,7 +340,7 @@ afr_lock_heal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local->replies[i].valid = 1;
     local->replies[i].op_ret = op_ret;
     local->replies[i].op_errno = op_errno;
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_LK_HEAL_DOM,
                "Failed to heal lock on child %d for %s", i,
                uuid_utoa(local->fd->inode->gfid));
@@ -350,8 +350,9 @@ afr_lock_heal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 }
 
 int
-afr_getlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
+afr_getlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
+              dict_t *xdata)
 {
     afr_local_t *local = frame->local;
     int i = (long)cookie;
@@ -359,7 +360,7 @@ afr_getlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     local->replies[i].valid = 1;
     local->replies[i].op_ret = op_ret;
     local->replies[i].op_errno = op_errno;
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_LK_HEAL_DOM,
                "Failed getlk for %s", uuid_utoa(local->fd->inode->gfid));
     } else {
@@ -401,7 +402,7 @@ afr_does_lk_owner_match(call_frame_t *frame, afr_private_t *priv,
     }
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!local->replies[i].valid || local->replies[i].op_ret != 0)
+        if (!local->replies[i].valid || IS_ERROR(local->replies[i].op_ret))
             continue;
         if (local->cont.lk.getlk_rsp[i].l_type == F_UNLCK)
             continue;
@@ -493,7 +494,8 @@ afr_lock_heal_do(call_frame_t *frame, afr_private_t *priv,
         for (i = 0; i < priv->child_count; i++) {
             if (!wind_on[i])
                 continue;
-            if ((!local->replies[i].valid) || (local->replies[i].op_ret != 0)) {
+            if ((!local->replies[i].valid) ||
+                IS_ERROR(local->replies[i].op_ret)) {
                 continue;
             }
 
@@ -931,7 +933,7 @@ afr_is_symmetric_error(call_frame_t *frame, xlator_t *this)
     for (i = 0; i < priv->child_count; i++) {
         if (!local->replies[i].valid)
             continue;
-        if (local->replies[i].op_ret != -1) {
+        if (IS_SUCCESS(local->replies[i].op_ret)) {
             /* Operation succeeded on at least one subvol,
                so it is not a failed-everywhere situation.
             */
@@ -1529,7 +1531,9 @@ post_unlock:
     inode_invalidate(inode);
 out:
     GF_FREE(data);
-    AFR_STACK_UNWIND(setxattr, frame, ret, op_errno, NULL);
+    gf_return_t op_ret;
+    SET_RET(op_ret, ret);
+    AFR_STACK_UNWIND(setxattr, frame, op_ret, op_errno, NULL);
     return 0;
 }
 
@@ -1618,7 +1622,7 @@ afr_readables_fill(call_frame_t *frame, xlator_t *this, inode_t *inode,
 
     for (i = 0; i < priv->child_count; i++) {
         if (replies) { /* Lookup */
-            if (!replies[i].valid || replies[i].op_ret == -1 ||
+            if (!replies[i].valid || IS_ERROR(replies[i].op_ret) ||
                 (replies[i].xdata &&
                  dict_get_sizen(replies[i].xdata, GLUSTERFS_BAD_INODE))) {
                 data_readable[i] = 0;
@@ -1726,7 +1730,7 @@ afr_inode_refresh_err(call_frame_t *frame, xlator_t *this)
     priv = this->private;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (local->replies[i].valid && !local->replies[i].op_ret) {
+        if (local->replies[i].valid && IS_SUCCESS(local->replies[i].op_ret)) {
             err = 0;
             goto ret;
         }
@@ -1872,7 +1876,7 @@ refresh_done:
 
 void
 afr_inode_refresh_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int op_ret, int op_errno, struct iatt *buf,
+                             gf_return_t op_ret, int op_errno, struct iatt *buf,
                              dict_t *xdata, struct iatt *par)
 {
     afr_local_t *local = NULL;
@@ -1885,7 +1889,7 @@ afr_inode_refresh_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local->replies[call_child].valid = 1;
     local->replies[call_child].op_ret = op_ret;
     local->replies[call_child].op_errno = op_errno;
-    if (op_ret != -1) {
+    if (IS_SUCCESS(op_ret)) {
         local->replies[call_child].poststat = *buf;
         if (par)
             local->replies[call_child].postparent = *par;
@@ -1914,7 +1918,7 @@ afr_inode_refresh_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 afr_inode_refresh_subvol_with_lookup_cbk(call_frame_t *frame, void *cookie,
-                                         xlator_t *this, int op_ret,
+                                         xlator_t *this, gf_return_t op_ret,
                                          int op_errno, inode_t *inode,
                                          struct iatt *buf, dict_t *xdata,
                                          struct iatt *par)
@@ -1952,7 +1956,7 @@ afr_inode_refresh_subvol_with_lookup(call_frame_t *frame, xlator_t *this, int i,
 
 int
 afr_inode_refresh_subvol_with_fstat_cbk(call_frame_t *frame, void *cookie,
-                                        xlator_t *this, int32_t op_ret,
+                                        xlator_t *this, gf_return_t op_ret,
                                         int32_t op_errno, struct iatt *buf,
                                         dict_t *xdata)
 {
@@ -2531,7 +2535,7 @@ afr_handle_inconsistent_fop(call_frame_t *frame, int32_t *op_ret,
     if (!frame || !frame->this || !frame->local || !frame->this->private)
         return;
 
-    if (*op_ret < 0)
+    if (*op_ret < -1)
         return;
 
     /* Failing inodelk/entrylk/lk here is not a good idea because we
@@ -2783,7 +2787,7 @@ afr_get_parent_read_subvol(xlator_t *this, inode_t *parent,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret < 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         if (par_read_subvol_iter == -1) {
@@ -2844,7 +2848,7 @@ afr_first_up_child(call_frame_t *frame, xlator_t *this)
     priv = this->private;
 
     for (i = 0; i < priv->child_count; i++)
-        if (local->replies[i].valid && local->replies[i].op_ret == 0)
+        if (local->replies[i].valid && IS_SUCCESS(local->replies[i].op_ret))
             return i;
     return -1;
 }
@@ -2881,7 +2885,7 @@ afr_attempt_readsubvol_set(call_frame_t *frame, xlator_t *this,
         /* If quorum is enabled and we do not have a
            readable yet, it means all good copies are down.
         */
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOTCONN;
         gf_msg(this->name, GF_LOG_WARNING, 0, AFR_MSG_READ_SUBVOL_ERROR,
                "no read "
@@ -2939,7 +2943,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
        issued
     */
     if (local->cont.lookup.needs_fresh_lookup) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ESTALE;
         goto error;
     }
@@ -2954,7 +2958,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret == -1) {
+        if (IS_ERROR(replies[i].op_ret)) {
             if (locked_entry && replies[i].op_errno == ENOENT) {
                 in_flight_create = _gf_true;
             }
@@ -2965,12 +2969,12 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
             read_subvol = i;
             gf_uuid_copy(read_gfid, replies[i].poststat.ia_gfid);
             ia_type = replies[i].poststat.ia_type;
-            local->op_ret = 0;
+            local->op_ret = gf_success;
         }
     }
 
     if (in_flight_create && !afr_has_quorum(success_replies, this, NULL)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOENT;
         goto error;
     }
@@ -2983,7 +2987,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
        readable[] but the mismatching GFID subvol is not.
     */
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1) {
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret)) {
             continue;
         }
 
@@ -3008,7 +3012,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
             goto cant_interpret;
 
         /* LOG ERROR */
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = EIO;
         goto error;
     }
@@ -3048,8 +3052,8 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
     afr_handle_quota_size(frame, this);
 
     afr_set_need_heal(this, local);
-    if (AFR_IS_ARBITER_BRICK(priv, read_subvol) && local->op_ret == 0) {
-        local->op_ret = -1;
+    if (AFR_IS_ARBITER_BRICK(priv, read_subvol) && IS_SUCCESS(local->op_ret)) {
+        local->op_ret = gf_error;
         local->op_errno = ENOTCONN;
         gf_msg_debug(this->name, 0,
                      "Arbiter cannot be a read subvol "
@@ -3065,7 +3069,7 @@ afr_lookup_done(call_frame_t *frame, xlator_t *this)
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, 0, AFR_MSG_DICT_SET_FAILED,
                    "Error setting gfid-heal-msg dict");
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = ENOMEM;
         }
     }
@@ -3114,7 +3118,7 @@ afr_final_errno(afr_local_t *local, afr_private_t *priv)
     for (i = 0; i < priv->child_count; i++) {
         if (!local->replies[i].valid)
             continue;
-        if (local->replies[i].op_ret >= 0)
+        if (IS_SUCCESS(local->replies[i].op_ret))
             continue;
         tmp_errno = local->replies[i].op_errno;
         op_errno = afr_higher_errno(op_errno, tmp_errno);
@@ -3125,7 +3129,7 @@ afr_final_errno(afr_local_t *local, afr_private_t *priv)
 
 static int32_t
 afr_local_discovery_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *dict,
+                        gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                         dict_t *xdata)
 {
     int ret = 0;
@@ -3134,7 +3138,7 @@ afr_local_discovery_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     afr_private_t *priv = NULL;
     int32_t child_index = -1;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3213,7 +3217,7 @@ afr_lookup_sh_metadata_wrap(void *opaque)
     replies = local->replies;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         first = i;
         break;
@@ -3316,7 +3320,7 @@ afr_can_start_metadata_self_heal(call_frame_t *frame, xlator_t *this)
         return _gf_false;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         if (first == -1) {
             first = i;
@@ -3423,7 +3427,7 @@ afr_lookup_selfheal_wrap(void *opaque)
     return 0;
 
 unwind:
-    AFR_STACK_UNWIND(lookup, frame, -1, EIO, NULL, NULL, NULL, NULL);
+    AFR_STACK_UNWIND(lookup, frame, gf_error, EIO, NULL, NULL, NULL, NULL);
     return 0;
 }
 
@@ -3461,7 +3465,7 @@ afr_lookup_entry_heal(call_frame_t *frame, xlator_t *this)
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret == 0) {
+        if (IS_SUCCESS(replies[i].op_ret)) {
             if (gf_uuid_is_null(gfid)) {
                 gf_uuid_copy(gfid, replies[i].poststat.ia_gfid);
             }
@@ -3475,7 +3479,7 @@ afr_lookup_entry_heal(call_frame_t *frame, xlator_t *this)
         }
 
         /*gfid is missing, needs heal*/
-        if ((replies[i].op_ret == -1) && (replies[i].op_errno == ENODATA)) {
+        if (IS_ERROR(replies[i].op_ret) && (replies[i].op_errno == ENODATA)) {
             goto name_heal;
         }
 
@@ -3484,11 +3488,11 @@ afr_lookup_entry_heal(call_frame_t *frame, xlator_t *this)
             continue;
         }
 
-        if (replies[i].op_ret != replies[first].op_ret) {
+        if (GET_RET(replies[i].op_ret) != GET_RET(replies[first].op_ret)) {
             name_state_mismatch = _gf_true;
         }
 
-        if (replies[i].op_ret == 0) {
+        if (GET_RET(replies[i].op_ret) == 0) {
             /* Rename after this lookup may succeed if we don't do
              * a name-heal and the destination may not have pending xattrs
              * to indicate which name is good and which is bad so always do
@@ -3509,7 +3513,7 @@ afr_lookup_entry_heal(call_frame_t *frame, xlator_t *this)
         for (i = 0; i < priv->child_count; i++) {
             if (!replies[i].valid)
                 continue;
-            if (par_readables[i] && replies[i].op_ret < 0 &&
+            if (par_readables[i] && IS_ERROR(replies[i].op_ret) &&
                 replies[i].op_errno != ENOTCONN) {
                 goto name_heal;
             }
@@ -3538,9 +3542,9 @@ metadata_heal:
 }
 
 int
-afr_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, inode_t *inode, struct iatt *buf, dict_t *xdata,
-               struct iatt *postparent)
+afr_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, inode_t *inode,
+               struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     afr_local_t *local = NULL;
     int call_count = -1;
@@ -3569,7 +3573,7 @@ afr_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     } else {
         local->replies[child_index].need_heal = need_heal;
     }
-    if (op_ret != -1) {
+    if (IS_SUCCESS(op_ret)) {
         local->replies[child_index].poststat = *buf;
         local->replies[child_index].postparent = *postparent;
         if (xdata)
@@ -3602,10 +3606,10 @@ afr_discover_unwind(call_frame_t *frame, xlator_t *this)
 
     afr_fill_success_replies(local, priv, success_replies);
     if (AFR_COUNT(success_replies, priv->child_count) > 0)
-        local->op_ret = 0;
+        local->op_ret = gf_success;
 
-    if (local->op_ret < 0) {
-        local->op_ret = -1;
+    if (IS_ERROR(local->op_ret)) {
+        local->op_ret = gf_error;
         local->op_errno = afr_final_errno(frame->local, this->private);
         goto error;
     }
@@ -3627,8 +3631,8 @@ unwind:
     if (read_subvol == -1)
         goto error;
 
-    if (AFR_IS_ARBITER_BRICK(priv, read_subvol) && local->op_ret == 0) {
-        local->op_ret = -1;
+    if (AFR_IS_ARBITER_BRICK(priv, read_subvol) && IS_SUCCESS(local->op_ret)) {
+        local->op_ret = gf_error;
         local->op_errno = ENOTCONN;
         gf_msg_debug(this->name, 0,
                      "Arbiter cannot be a read subvol "
@@ -3735,9 +3739,9 @@ unwind:
 }
 
 int
-afr_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, inode_t *inode, struct iatt *buf, dict_t *xdata,
-                 struct iatt *postparent)
+afr_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, inode_t *inode,
+                 struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     afr_local_t *local = NULL;
     int call_count = -1;
@@ -3752,14 +3756,14 @@ afr_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     local->replies[child_index].valid = 1;
     local->replies[child_index].op_ret = op_ret;
     local->replies[child_index].op_errno = op_errno;
-    if (op_ret != -1) {
+    if (IS_SUCCESS(op_ret)) {
         local->replies[child_index].poststat = *buf;
         local->replies[child_index].postparent = *postparent;
         if (xdata)
             local->replies[child_index].xdata = dict_ref(xdata);
     }
 
-    if (local->do_discovery && (op_ret == 0))
+    if (local->do_discovery && IS_SUCCESS(op_ret))
         afr_attempt_local_discovery(this, child_index);
 
     if (xdata) {
@@ -3817,7 +3821,7 @@ afr_discover_do(call_frame_t *frame, xlator_t *this, int err)
 
     return 0;
 out:
-    AFR_STACK_UNWIND(lookup, frame, -1, local->op_errno, 0, 0, 0, 0);
+    AFR_STACK_UNWIND(lookup, frame, gf_error, local->op_errno, 0, 0, 0, 0);
     return 0;
 }
 
@@ -3881,7 +3885,7 @@ afr_discover(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
 
     return 0;
 out:
-    AFR_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    AFR_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL, NULL);
     return 0;
 }
 
@@ -3923,7 +3927,7 @@ afr_lookup_do(call_frame_t *frame, xlator_t *this, int err)
     }
     return 0;
 out:
-    AFR_STACK_UNWIND(lookup, frame, -1, local->op_errno, 0, 0, 0, 0);
+    AFR_STACK_UNWIND(lookup, frame, gf_error, local->op_errno, 0, 0, 0, 0);
     return 0;
 }
 
@@ -4022,7 +4026,7 @@ afr_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
 
     return 0;
 out:
-    AFR_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    AFR_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL, NULL);
 
     return 0;
 }
@@ -4166,8 +4170,8 @@ out:
 /* {{{ flush */
 
 int
-afr_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, dict_t *xdata)
+afr_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int call_count = -1;
@@ -4176,7 +4180,7 @@ afr_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret != -1) {
+        if (IS_SUCCESS(op_ret)) {
             local->op_ret = op_ret;
             if (!local->xdata_rsp && xdata)
                 local->xdata_rsp = dict_ref(xdata);
@@ -4301,13 +4305,13 @@ afr_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 
     return 0;
 out:
-    AFR_STACK_UNWIND(flush, frame, -1, op_errno, NULL);
+    AFR_STACK_UNWIND(flush, frame, gf_error, op_errno, NULL);
     return 0;
 }
 
 int
 afr_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int call_count = -1;
@@ -4316,8 +4320,8 @@ afr_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == 0) {
-            local->op_ret = 0;
+        if (IS_SUCCESS(op_ret)) {
+            local->op_ret = gf_success;
             if (!local->xdata_rsp && xdata)
                 local->xdata_rsp = dict_ref(xdata);
         } else {
@@ -4366,7 +4370,7 @@ afr_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t datasync,
 
     return 0;
 out:
-    AFR_STACK_UNWIND(fsyncdir, frame, -1, op_errno, NULL);
+    AFR_STACK_UNWIND(fsyncdir, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
@@ -4377,15 +4381,15 @@ static int
 afr_serialized_lock_wind(call_frame_t *frame, xlator_t *this);
 
 static gf_boolean_t
-afr_is_conflicting_lock_present(int32_t op_ret, int32_t op_errno)
+afr_is_conflicting_lock_present(gf_return_t op_ret, int32_t op_errno)
 {
-    if (op_ret == -1 && op_errno == EAGAIN)
+    if (IS_ERROR(op_ret) && op_errno == EAGAIN)
         return _gf_true;
     return _gf_false;
 }
 
 static void
-afr_fop_lock_unwind(call_frame_t *frame, glusterfs_fop_t op, int32_t op_ret,
+afr_fop_lock_unwind(call_frame_t *frame, glusterfs_fop_t op, gf_return_t op_ret,
                     int32_t op_errno, dict_t *xdata)
 {
     switch (op) {
@@ -4409,7 +4413,7 @@ afr_fop_lock_unwind(call_frame_t *frame, glusterfs_fop_t op, int32_t op_ret,
 static void
 afr_fop_lock_wind(call_frame_t *frame, xlator_t *this, int child_index,
                   int32_t (*lock_cbk)(call_frame_t *, void *, xlator_t *,
-                                      int32_t, int32_t, dict_t *))
+                                      gf_return_t, int32_t, dict_t *))
 {
     afr_local_t *local = frame->local;
     afr_private_t *priv = this->private;
@@ -4479,7 +4483,7 @@ afr_fop_lock_proceed(call_frame_t *frame)
      * both the mounts only got partial locks, afr treats them as failure in
      * gaining the locks and unwinds with EAGAIN errno.
      */
-    local->op_ret = -1;
+    local->op_ret = gf_error;
     local->op_errno = EUCLEAN;
     local->fop_lock_state = AFR_FOP_LOCK_SERIAL;
     afr_local_replies_wipe(local, priv);
@@ -4514,7 +4518,7 @@ afr_fop_lock_proceed(call_frame_t *frame)
 
 static int32_t
 afr_unlock_partial_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                            gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 
 {
     afr_local_t *local = NULL;
@@ -4526,7 +4530,7 @@ afr_unlock_partial_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     priv = this->private;
 
-    if (op_ret < 0 && op_errno != ENOTCONN) {
+    if (IS_ERROR(op_ret) && op_errno != ENOTCONN) {
         if (local->fd)
             gf_uuid_copy(gfid, local->fd->inode->gfid);
         else
@@ -4586,7 +4590,7 @@ afr_unlock_locks_and_proceed(call_frame_t *frame, xlator_t *this,
         if (!local->replies[i].valid)
             continue;
 
-        if (local->replies[i].op_ret == -1)
+        if (IS_ERROR(local->replies[i].op_ret))
             continue;
 
         afr_fop_lock_wind(frame, this, i, afr_unlock_partial_lock_cbk);
@@ -4617,23 +4621,23 @@ afr_fop_lock_done(call_frame_t *frame, xlator_t *this)
         if (!local->replies[i].valid)
             continue;
 
-        if (local->replies[i].op_ret == 0) {
+        if (IS_SUCCESS(local->replies[i].op_ret)) {
             lock_count++;
             success[i] = 1;
         }
 
-        if (local->op_ret == -1 && local->op_errno == EAGAIN)
+        if (IS_ERROR(local->op_ret) && local->op_errno == EAGAIN)
             continue;
 
-        if ((local->replies[i].op_ret == -1) &&
+        if (IS_ERROR(local->replies[i].op_ret) &&
             (local->replies[i].op_errno == EAGAIN)) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = EAGAIN;
             continue;
         }
 
-        if (local->replies[i].op_ret == 0)
-            local->op_ret = 0;
+        if (IS_SUCCESS(local->replies[i].op_ret))
+            local->op_ret = gf_success;
 
         local->op_errno = local->replies[i].op_errno;
     }
@@ -4645,7 +4649,7 @@ afr_fop_lock_done(call_frame_t *frame, xlator_t *this)
         afr_unlock_locks_and_proceed(frame, this, lock_count);
     } else if (priv->quorum_count && !afr_has_quorum(success, this, NULL)) {
         local->fop_lock_state = AFR_FOP_LOCK_QUORUM_FAILED;
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = afr_final_errno(local, priv);
         if (local->op_errno == 0)
             local->op_errno = afr_quorum_errno(priv);
@@ -4663,7 +4667,7 @@ unwind:
 
 static int
 afr_common_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int child_index = (long)cookie;
@@ -4673,7 +4677,7 @@ afr_common_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local->replies[child_index].valid = 1;
     local->replies[child_index].op_ret = op_ret;
     local->replies[child_index].op_errno = op_errno;
-    if (op_ret == 0 && xdata) {
+    if (IS_SUCCESS(op_ret) && xdata) {
         local->replies[child_index].xdata = dict_ref(xdata);
         LOCK(&frame->lock);
         {
@@ -4687,7 +4691,7 @@ afr_common_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int32_t
 afr_serialized_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 
 {
     afr_local_t *local = NULL;
@@ -4737,7 +4741,7 @@ afr_serialized_lock_wind(call_frame_t *frame, xlator_t *this)
 
 static int32_t
 afr_parallel_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 
 {
     int call_count = 0;
@@ -4856,7 +4860,7 @@ afr_handle_inodelk(call_frame_t *frame, xlator_t *this, glusterfs_fop_t fop,
         goto out;
     return 0;
 out:
-    afr_fop_lock_unwind(frame, fop, -1, op_errno, NULL);
+    afr_fop_lock_unwind(frame, fop, gf_error, op_errno, NULL);
 
     return 0;
 }
@@ -4916,7 +4920,7 @@ afr_handle_entrylk(call_frame_t *frame, xlator_t *this, glusterfs_fop_t fop,
 
     return 0;
 out:
-    afr_fop_lock_unwind(frame, fop, -1, op_errno, NULL);
+    afr_fop_lock_unwind(frame, fop, gf_error, op_errno, NULL);
     return 0;
 }
 
@@ -4941,8 +4945,9 @@ afr_fentrylk(call_frame_t *frame, xlator_t *this, const char *volume, fd_t *fd,
 }
 
 int
-afr_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, struct statvfs *statvfs, dict_t *xdata)
+afr_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, struct statvfs *statvfs,
+               dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int call_count = 0;
@@ -4952,7 +4957,7 @@ afr_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret != 0) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             goto unlock;
         }
@@ -5027,14 +5032,14 @@ afr_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
     return 0;
 out:
-    AFR_STACK_UNWIND(statfs, frame, -1, op_errno, NULL, NULL);
+    AFR_STACK_UNWIND(statfs, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 int32_t
 afr_lk_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+                  gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                   dict_t *xdata)
 {
     afr_local_t *local = NULL;
@@ -5044,7 +5049,7 @@ afr_lk_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0 && op_errno != ENOTCONN && op_errno != EBADFD) {
+    if (IS_ERROR(op_ret) && op_errno != ENOTCONN && op_errno != EBADFD) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_UNLOCK_FAIL,
                "gfid=%s: unlock failed on subvolume %s "
                "with lock owner %s",
@@ -5102,8 +5107,9 @@ afr_lk_unlock(call_frame_t *frame, xlator_t *this)
 }
 
 int32_t
-afr_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-           int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
+afr_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+           gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
+           dict_t *xdata)
 {
     afr_local_t *local = NULL;
     afr_private_t *priv = NULL;
@@ -5115,16 +5121,16 @@ afr_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     child_index = (long)cookie;
 
     afr_common_lock_cbk(frame, cookie, this, op_ret, op_errno, xdata);
-    if (op_ret < 0 && op_errno == EAGAIN) {
-        local->op_ret = -1;
+    if (IS_ERROR(op_ret) && op_errno == EAGAIN) {
+        local->op_ret = gf_error;
         local->op_errno = EAGAIN;
 
         afr_lk_unlock(frame, this);
         return 0;
     }
 
-    if (op_ret == 0) {
-        local->op_ret = 0;
+    if (IS_SUCCESS(op_ret)) {
+        local->op_ret = gf_success;
         local->op_errno = 0;
         local->cont.lk.locked_nodes[child_index] = 1;
         local->cont.lk.ret_flock = *lock;
@@ -5140,12 +5146,12 @@ afr_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
                           local->xdata_req);
     } else if (priv->quorum_count &&
                !afr_has_quorum(local->cont.lk.locked_nodes, this, NULL)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = afr_final_errno(local, priv);
 
         afr_lk_unlock(frame, this);
     } else {
-        if (local->op_ret < 0)
+        if (IS_ERROR(local->op_ret))
             local->op_errno = afr_final_errno(local, priv);
 
         AFR_STACK_UNWIND(lk, frame, local->op_ret, local->op_errno,
@@ -5163,7 +5169,7 @@ afr_lk_transaction_cbk(int ret, call_frame_t *frame, void *opaque)
 
 int
 afr_lk_txn_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+                    gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                     dict_t *xdata)
 {
     afr_local_t *local = NULL;
@@ -5172,8 +5178,8 @@ afr_lk_txn_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     child_index = (long)cookie;
     afr_common_lock_cbk(frame, cookie, this, op_ret, op_errno, xdata);
-    if (op_ret == 0) {
-        local->op_ret = 0;
+    if (IS_SUCCESS(op_ret)) {
+        local->op_ret = gf_success;
         local->op_errno = 0;
         local->cont.lk.locked_nodes[child_index] = 1;
         local->cont.lk.ret_flock = *lock;
@@ -5184,14 +5190,14 @@ afr_lk_txn_wind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 afr_lk_txn_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
-                      dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct gf_flock *lock, dict_t *xdata)
 {
     afr_local_t *local = frame->local;
     afr_private_t *priv = this->private;
     int child_index = (long)cookie;
 
-    if (op_ret < 0 && op_errno != ENOTCONN && op_errno != EBADFD) {
+    if (IS_ERROR(op_ret) && op_errno != ENOTCONN && op_errno != EBADFD) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_UNLOCK_FAIL,
                "gfid=%s: unlock failed on subvolume %s "
                "with lock owner %s",
@@ -5248,7 +5254,7 @@ afr_lk_transaction(void *opaque)
 
     if (priv->quorum_count &&
         !afr_has_quorum(local->cont.lk.locked_nodes, this, NULL)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = afr_final_errno(local, priv);
         goto unlock;
     } else {
@@ -5257,7 +5263,7 @@ afr_lk_transaction(void *opaque)
         else
             ret = afr_add_lock_to_saved_locks(frame, this);
         if (ret) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = -ret;
             goto unlock;
         }
@@ -5272,7 +5278,7 @@ unlock:
     AFR_ONLIST(local->cont.lk.locked_nodes, frame, afr_lk_txn_unlock_cbk, lk,
                local->fd, F_SETLK, &local->cont.lk.user_flock, NULL);
 err:
-    AFR_STACK_UNWIND(lk, frame, -1, op_errno, NULL, NULL);
+    AFR_STACK_UNWIND(lk, frame, gf_error, op_errno, NULL, NULL);
     return -1;
 }
 
@@ -5331,15 +5337,15 @@ afr_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 
     return 0;
 out:
-    AFR_STACK_UNWIND(lk, frame, -1, op_errno, NULL, NULL);
+    AFR_STACK_UNWIND(lk, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 int32_t
 afr_lease_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct gf_lease *lease,
-                     dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno,
+                     struct gf_lease *lease, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int call_count = -1;
@@ -5393,8 +5399,9 @@ afr_lease_unlock(call_frame_t *frame, xlator_t *this)
 }
 
 int32_t
-afr_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct gf_lease *lease, dict_t *xdata)
+afr_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct gf_lease *lease,
+              dict_t *xdata)
 {
     afr_local_t *local = NULL;
     afr_private_t *priv = NULL;
@@ -5406,16 +5413,16 @@ afr_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     child_index = (long)cookie;
 
     afr_common_lock_cbk(frame, cookie, this, op_ret, op_errno, xdata);
-    if (op_ret < 0 && op_errno == EAGAIN) {
-        local->op_ret = -1;
+    if (IS_ERROR(op_ret) && op_errno == EAGAIN) {
+        local->op_ret = gf_error;
         local->op_errno = EAGAIN;
 
         afr_lease_unlock(frame, this);
         return 0;
     }
 
-    if (op_ret == 0) {
-        local->op_ret = 0;
+    if (IS_SUCCESS(op_ret)) {
+        local->op_ret = gf_success;
         local->op_errno = 0;
         local->cont.lease.locked_nodes[child_index] = 1;
         local->cont.lease.ret_lease = *lease;
@@ -5429,12 +5436,12 @@ afr_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
                           &local->cont.lease.user_lease, xdata);
     } else if (priv->quorum_count &&
                !afr_has_quorum(local->cont.lease.locked_nodes, this, NULL)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = afr_final_errno(local, priv);
 
         afr_lease_unlock(frame, this);
     } else {
-        if (local->op_ret < 0)
+        if (IS_ERROR(local->op_ret))
             local->op_errno = afr_final_errno(local, priv);
         AFR_STACK_UNWIND(lease, frame, local->op_ret, local->op_errno,
                          &local->cont.lease.ret_lease, NULL);
@@ -5476,14 +5483,14 @@ afr_lease(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     return 0;
 out:
-    AFR_STACK_UNWIND(lease, frame, -1, op_errno, NULL, NULL);
+    AFR_STACK_UNWIND(lease, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 int
-afr_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, dict_t *xdata)
+afr_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int child_index = (long)cookie;
@@ -5514,7 +5521,7 @@ afr_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     for (i = 0; i < priv->child_count; i++) {
         if (!local->replies[i].valid)
             continue;
-        if (local->replies[i].op_ret < 0 &&
+        if (IS_ERROR(local->replies[i].op_ret) &&
             local->replies[i].op_errno != ENOTCONN) {
             local->op_ret = local->replies[i].op_ret;
             local->op_errno = local->replies[i].op_errno;
@@ -5527,9 +5534,9 @@ afr_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
             failed = _gf_true;
             break;
         }
-        if (local->replies[i].op_ret == 0) {
+        if (IS_SUCCESS(local->replies[i].op_ret)) {
             succeeded = _gf_true;
-            local->op_ret = 0;
+            local->op_ret = gf_success;
             local->op_errno = 0;
             if (!local->xdata_rsp && local->replies[i].xdata) {
                 local->xdata_rsp = dict_ref(local->replies[i].xdata);
@@ -5538,7 +5545,7 @@ afr_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     }
 
     if (!succeeded && !failed) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOTCONN;
     }
 
@@ -5595,7 +5602,7 @@ afr_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
 err:
     if (op_errno == -1)
         op_errno = errno;
-    AFR_STACK_UNWIND(ipc, frame, -1, op_errno, NULL);
+    AFR_STACK_UNWIND(ipc, frame, gf_error, op_errno, NULL);
 
     return 0;
 
@@ -6434,7 +6441,7 @@ int
 afr_local_init(afr_local_t *local, afr_private_t *priv, int32_t *op_errno)
 {
     int __ret = -1;
-    local->op_ret = -1;
+    local->op_ret = gf_error;
     local->op_errno = EUCLEAN;
 
     __ret = syncbarrier_init(&local->barrier);
@@ -6525,7 +6532,7 @@ afr_internal_lock_init(afr_internal_lock_t *lk, size_t child_count)
     if (NULL == lk->lower_locked_nodes)
         goto out;
 
-    lk->lock_op_ret = -1;
+    lk->lock_op_ret = gf_error;
     lk->lock_op_errno = EUCLEAN;
 
     ret = 0;
@@ -6813,7 +6820,7 @@ afr_update_heal_status(xlator_t *this, struct afr_reply *replies,
     sprintf(key2, "%s:%s", GLUSTERFS_INODELK_DOM_PREFIX, priv->sh_domain);
 
     for (i = 0; i < priv->child_count; i++) {
-        if ((replies[i].valid != 1) || (replies[i].op_ret != 0))
+        if ((replies[i].valid != 1) || IS_ERROR(replies[i].op_ret))
             continue;
         if (!io_domain_lk_count) {
             ret1 = dict_get_int32(replies[i].xdata, key1, &io_domain_lk_count);
@@ -6874,7 +6881,7 @@ afr_lockless_inspect(call_frame_t *frame, xlator_t *this, uuid_t gfid,
     if (ret)
         goto out;
     for (i = 0; i < priv->child_count; i++) {
-        if (replies[i].valid && replies[i].op_ret == 0) {
+        if (replies[i].valid && IS_SUCCESS(replies[i].op_ret)) {
             valid_on[i] = 1;
         }
     }
@@ -7033,7 +7040,9 @@ out:
         heal_frame->local = heal_local;
         AFR_STACK_DESTROY(heal_frame);
     }
-    AFR_STACK_UNWIND(getxattr, frame, ret, op_errno, dict, NULL);
+    gf_return_t op_ret;
+    SET_RET(op_ret, ret);
+    AFR_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, NULL);
     if (dict)
         dict_unref(dict);
     if (inode)
@@ -7134,6 +7143,7 @@ afr_get_split_brain_status(void *opaque)
     xlator_t *this = NULL;
     loc_t *loc = NULL;
     afr_spb_status_t *data = NULL;
+    gf_return_t op_ret = {0};
 
     data = opaque;
     frame = data->frame;
@@ -7213,8 +7223,11 @@ afr_get_split_brain_status(void *opaque)
     }
 
     ret = 0;
+
 out:
-    AFR_STACK_UNWIND(getxattr, frame, ret, op_errno, dict, NULL);
+
+    SET_RET(op_ret, ret);
+    AFR_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, NULL);
     if (dict)
         dict_unref(dict);
     if (inode)
@@ -7275,10 +7288,13 @@ out:
         heal_frame->local = heal_local;
         AFR_STACK_DESTROY(heal_frame);
     }
+
+    gf_return_t op_ret;
+    SET_RET(op_ret, ret);
     if (local->op == GF_FOP_GETXATTR)
-        AFR_STACK_UNWIND(getxattr, frame, ret, op_errno, dict, NULL);
+        AFR_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, NULL);
     else if (local->op == GF_FOP_SETXATTR)
-        AFR_STACK_UNWIND(setxattr, frame, ret, op_errno, NULL);
+        AFR_STACK_UNWIND(setxattr, frame, op_ret, op_errno, NULL);
     if (dict)
         dict_unref(dict);
     return ret;
@@ -7470,7 +7486,7 @@ afr_serialize_xattrs_with_delimiter(call_frame_t *frame, xlator_t *this,
 
     keylen = strlen(local->cont.getxattr.name);
     for (i = 0; i < priv->child_count; i++) {
-        if (!local->replies[i].valid || local->replies[i].op_ret) {
+        if (!local->replies[i].valid || IS_ERROR(local->replies[i].op_ret)) {
             str_len = strlen(default_str);
             buf = strncat(buf, default_str, str_len);
             len += str_len;
@@ -7815,7 +7831,7 @@ afr_handle_replies_quorum(call_frame_t *frame, xlator_t *this)
         local->op_errno = afr_final_errno(local, priv);
         if (!local->op_errno)
             local->op_errno = afr_quorum_errno(priv);
-        local->op_ret = -1;
+        local->op_ret = gf_error;
     }
 }
 

--- a/xlators/cluster/afr/src/afr-dir-read.c
+++ b/xlators/cluster/afr/src/afr-dir-read.c
@@ -27,7 +27,7 @@
 
 int32_t
 afr_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int call_count = -1;
@@ -44,7 +44,7 @@ afr_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             fd_ctx->opened_on[child_index] = AFR_FD_NOT_OPENED;
         } else {
@@ -117,7 +117,7 @@ afr_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
 
     return 0;
 out:
-    AFR_STACK_UNWIND(opendir, frame, -1, op_errno, fd, NULL);
+    AFR_STACK_UNWIND(opendir, frame, gf_error, op_errno, fd, NULL);
     return 0;
 }
 
@@ -207,8 +207,8 @@ afr_readdir_transform_entries(gf_dirent_t *subvol_entries, int subvol,
 
 int32_t
 afr_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, gf_dirent_t *subvol_entries,
-                dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno,
+                gf_dirent_t *subvol_entries, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     gf_dirent_t entries;
@@ -217,7 +217,7 @@ afr_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0 && !local->cont.readdir.offset) {
+    if (IS_ERROR(op_ret) && !local->cont.readdir.offset) {
         /* failover only if this was first readdir, detected
            by offset == 0 */
         local->op_ret = op_ret;
@@ -227,7 +227,7 @@ afr_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         return 0;
     }
 
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         afr_readdir_transform_entries(subvol_entries, (long)cookie, &entries,
                                       local->fd);
 
@@ -250,7 +250,7 @@ afr_readdir_wind(call_frame_t *frame, xlator_t *this, int subvol)
     fd_ctx = afr_fd_ctx_get(local->fd, this);
     if (!fd_ctx) {
         local->op_errno = EINVAL;
-        local->op_ret = -1;
+        local->op_ret = gf_error;
     }
 
     if (subvol == -1 || !fd_ctx) {
@@ -315,7 +315,7 @@ afr_do_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     return 0;
 out:
-    AFR_STACK_UNWIND(readdir, frame, -1, op_errno, NULL, NULL);
+    AFR_STACK_UNWIND(readdir, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 

--- a/xlators/cluster/afr/src/afr-inode-read.c
+++ b/xlators/cluster/afr/src/afr-inode-read.c
@@ -68,7 +68,7 @@ afr_handle_quota_size(call_frame_t *frame, xlator_t *this)
     readable_cnt = AFR_COUNT(readable, priv->child_count);
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         if (readable_cnt && !readable[i])
             continue;
@@ -98,7 +98,7 @@ afr_handle_quota_size(call_frame_t *frame, xlator_t *this)
         return read_subvol;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         if (readable_cnt && !readable[i])
             continue;
@@ -114,14 +114,14 @@ afr_handle_quota_size(call_frame_t *frame, xlator_t *this)
 /* {{{ access */
 
 int
-afr_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, dict_t *xdata)
+afr_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     afr_local_t *local = NULL;
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
 
@@ -177,7 +177,7 @@ afr_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int mask,
 
     return 0;
 out:
-    AFR_STACK_UNWIND(access, frame, -1, op_errno, NULL);
+    AFR_STACK_UNWIND(access, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
@@ -187,14 +187,15 @@ out:
 /* {{{ stat */
 
 int
-afr_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iatt *buf, dict_t *xdata)
+afr_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+             dict_t *xdata)
 {
     afr_local_t *local = NULL;
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
 
@@ -246,7 +247,7 @@ afr_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
     return 0;
 out:
-    AFR_STACK_UNWIND(stat, frame, -1, op_errno, NULL, NULL);
+    AFR_STACK_UNWIND(stat, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -256,14 +257,15 @@ out:
 /* {{{ fstat */
 
 int
-afr_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *buf, dict_t *xdata)
+afr_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+              dict_t *xdata)
 {
     afr_local_t *local = NULL;
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
 
@@ -318,7 +320,7 @@ afr_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 
     return 0;
 out:
-    AFR_STACK_UNWIND(fstat, frame, -1, op_errno, NULL, NULL);
+    AFR_STACK_UNWIND(fstat, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -329,15 +331,15 @@ out:
 
 int
 afr_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, const char *buf,
+                 gf_return_t op_ret, int32_t op_errno, const char *buf,
                  struct iatt *sbuf, dict_t *xdata)
 {
     afr_local_t *local = NULL;
 
     local = frame->local;
 
-    if (op_ret < 0) {
-        local->op_ret = -1;
+    if (IS_ERROR(op_ret)) {
+        local->op_ret = op_ret;
         local->op_errno = op_errno;
 
         afr_read_txn_continue(frame, this, (long)cookie);
@@ -392,7 +394,7 @@ afr_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
 
     return 0;
 out:
-    AFR_STACK_UNWIND(readlink, frame, -1, op_errno, 0, 0, 0);
+    AFR_STACK_UNWIND(readlink, frame, gf_error, op_errno, 0, 0, 0);
 
     return 0;
 }
@@ -459,13 +461,14 @@ afr_getxattr_ignorable_errnos(int32_t op_errno)
 }
 int
 afr_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                 dict_t *xdata)
 {
     afr_local_t *local = NULL;
 
     local = frame->local;
 
-    if (op_ret < 0 && !afr_getxattr_ignorable_errnos(op_errno)) {
+    if (IS_ERROR(op_ret) && !afr_getxattr_ignorable_errnos(op_errno)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
 
@@ -504,8 +507,8 @@ afr_getxattr_wind(call_frame_t *frame, xlator_t *this, int subvol)
 }
 
 int32_t
-afr_getxattr_unwind(call_frame_t *frame, int op_ret, int op_errno, dict_t *dict,
-                    dict_t *xdata)
+afr_getxattr_unwind(call_frame_t *frame, gf_return_t op_ret, int op_errno,
+                    dict_t *dict, dict_t *xdata)
 
 {
     AFR_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, xdata);
@@ -514,7 +517,7 @@ afr_getxattr_unwind(call_frame_t *frame, int op_ret, int op_errno, dict_t *dict,
 
 int32_t
 afr_fgetxattr_clrlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *dict,
+                        gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                         dict_t *xdata)
 {
     afr_local_t *local = NULL;
@@ -543,7 +546,7 @@ afr_fgetxattr_clrlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     LOCK(&frame->lock);
     {
         callcnt = --local->call_count;
-        if (op_ret == -1)
+        if (IS_ERROR(op_ret))
             local->replies[cky].op_errno = op_errno;
 
         if (!local->dict)
@@ -565,14 +568,14 @@ unlock:
     if (!callcnt) {
         xattr = dict_new();
         if (!xattr) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unwind;
         }
         ret = dict_serialize_value_with_delim(local->dict, lk_summary,
                                               &serz_len, '\n');
         if (ret) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unwind;
         }
@@ -581,7 +584,7 @@ unlock:
         ret = dict_set_dynstrn(xattr, local->cont.getxattr.name, keylen,
                                gf_strdup(lk_summary));
         if (ret) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             gf_msg(this->name, GF_LOG_ERROR, ENOMEM, AFR_MSG_DICT_SET_FAILED,
                    "Error setting dictionary");
@@ -601,7 +604,7 @@ unlock:
 
 int32_t
 afr_getxattr_clrlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *dict,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                        dict_t *xdata)
 {
     afr_local_t *local = NULL;
@@ -631,7 +634,7 @@ afr_getxattr_clrlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     LOCK(&frame->lock);
     {
         callcnt = --local->call_count;
-        if (op_ret == -1)
+        if (IS_ERROR(op_ret))
             local->replies[cky].op_errno = op_errno;
 
         if (!local->dict)
@@ -653,14 +656,14 @@ unlock:
     if (!callcnt) {
         xattr = dict_new();
         if (!xattr) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unwind;
         }
         ret = dict_serialize_value_with_delim(local->dict, lk_summary,
                                               &serz_len, '\n');
         if (ret) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unwind;
         }
@@ -669,7 +672,7 @@ unlock:
         ret = dict_set_dynstrn(xattr, local->cont.getxattr.name, keylen,
                                gf_strdup(lk_summary));
         if (ret) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             gf_msg(this->name, GF_LOG_ERROR, ENOMEM, AFR_MSG_DICT_SET_FAILED,
                    "Error setting dictionary");
@@ -693,7 +696,7 @@ unlock:
  */
 int32_t
 afr_getxattr_node_uuid_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, dict_t *dict,
+                           gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                            dict_t *xdata)
 {
     afr_private_t *priv = NULL;
@@ -707,7 +710,7 @@ afr_getxattr_node_uuid_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret == -1) { /** query the _next_ child */
+    if (IS_ERROR(op_ret)) { /** query the _next_ child */
 
         /**
          * _current_ becomes _next_
@@ -741,7 +744,7 @@ unwind:
  */
 int32_t
 afr_getxattr_list_node_uuids_cbk(call_frame_t *frame, void *cookie,
-                                 xlator_t *this, int32_t op_ret,
+                                 xlator_t *this, gf_return_t op_ret,
                                  int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
     afr_local_t *local = NULL;
@@ -763,10 +766,10 @@ afr_getxattr_list_node_uuids_cbk(call_frame_t *frame, void *cookie,
         local->replies[cky].op_ret = op_ret;
         local->replies[cky].op_errno = op_errno;
 
-        if (op_ret < 0)
+        if (IS_ERROR(op_ret))
             goto unlock;
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
 
         if (!local->xdata_rsp && xdata)
             local->xdata_rsp = dict_ref(xdata);
@@ -777,7 +780,7 @@ unlock:
     UNLOCK(&frame->lock);
 
     if (!callcnt) {
-        if (local->op_ret != 0) {
+        if (IS_ERROR(local->op_ret)) {
             /* All bricks gave an error. */
             local->op_errno = afr_final_errno(local, priv);
             goto unwind;
@@ -792,7 +795,7 @@ unlock:
         if (!local->dict)
             local->dict = dict_new();
         if (!local->dict) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = ENOMEM;
             goto unwind;
         }
@@ -801,7 +804,7 @@ unlock:
                                gf_common_mt_char);
 
         if (!xattr_serz) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = ENOMEM;
             goto unwind;
         }
@@ -809,7 +812,7 @@ unlock:
         ret = afr_serialize_xattrs_with_delimiter(frame, this, xattr_serz,
                                                   UUID0_STR, &tlen, ' ');
         if (ret) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = ENOMEM;
             GF_FREE(xattr_serz);
             goto unwind;
@@ -819,12 +822,12 @@ unlock:
         if (ret) {
             gf_msg(this->name, GF_LOG_ERROR, -ret, AFR_MSG_DICT_SET_FAILED,
                    "Cannot set node_uuid key in dict");
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = ENOMEM;
             if (ret == -EINVAL)
                 GF_FREE(xattr_serz);
         } else {
-            local->op_ret = local->cont.getxattr.xattr_len - 1;
+            SET_RET(local->op_ret, (local->cont.getxattr.xattr_len - 1));
             local->op_errno = 0;
         }
 
@@ -838,7 +841,7 @@ unlock:
 
 int32_t
 afr_getxattr_quota_size_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *dict,
+                            gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                             dict_t *xdata)
 {
     int idx = (long)cookie;
@@ -868,10 +871,10 @@ afr_getxattr_quota_size_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 afr_getxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, dict_t *dict,
+                          gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                           dict_t *xdata)
 {
-    int call_cnt = 0, len = 0;
+    int call_cnt = 0, len = 0, ret = 0;
     char *lockinfo_buf = NULL;
     dict_t *lockinfo = NULL, *newdict = NULL;
     afr_local_t *local = NULL;
@@ -882,7 +885,7 @@ afr_getxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         call_cnt = --local->call_count;
 
-        if ((op_ret < 0) || (!dict && !xdata)) {
+        if ((IS_ERROR(op_ret)) || (!dict && !xdata)) {
             goto unlock;
         }
 
@@ -890,7 +893,7 @@ afr_getxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             if (!local->xdata_rsp) {
                 local->xdata_rsp = dict_new();
                 if (!local->xdata_rsp) {
-                    local->op_ret = -1;
+                    local->op_ret = gf_error;
                     local->op_errno = ENOMEM;
                     goto unlock;
                 }
@@ -901,8 +904,8 @@ afr_getxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             goto unlock;
         }
 
-        op_ret = dict_get_ptr_and_len(dict, GF_XATTR_LOCKINFO_KEY,
-                                      (void **)&lockinfo_buf, &len);
+        ret = dict_get_ptr_and_len(dict, GF_XATTR_LOCKINFO_KEY,
+                                   (void **)&lockinfo_buf, &len);
 
         if (!lockinfo_buf) {
             goto unlock;
@@ -911,7 +914,7 @@ afr_getxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         if (!local->dict) {
             local->dict = dict_new();
             if (!local->dict) {
-                local->op_ret = -1;
+                local->op_ret = gf_error;
                 local->op_errno = ENOMEM;
                 goto unlock;
             }
@@ -923,11 +926,10 @@ unlock:
     if (lockinfo_buf != NULL) {
         lockinfo = dict_new();
         if (lockinfo == NULL) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = ENOMEM;
         } else {
-            op_ret = dict_unserialize(lockinfo_buf, len, &lockinfo);
-
+            ret = dict_unserialize(lockinfo_buf, len, &lockinfo);
             if (lockinfo && local->dict) {
                 dict_copy(lockinfo, local->dict);
             }
@@ -941,23 +943,23 @@ unlock:
     if (!call_cnt) {
         newdict = dict_new();
         if (!newdict) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = ENOMEM;
             goto unwind;
         }
 
-        op_ret = dict_allocate_and_serialize(
-            local->dict, (char **)&lockinfo_buf, (unsigned int *)&len);
-        if (op_ret != 0) {
-            local->op_ret = -1;
+        ret = dict_allocate_and_serialize(local->dict, (char **)&lockinfo_buf,
+                                          (unsigned int *)&len);
+        if (ret != 0) {
+            local->op_ret = gf_error;
             goto unwind;
         }
 
-        op_ret = dict_set_dynptr(newdict, GF_XATTR_LOCKINFO_KEY,
-                                 (void *)lockinfo_buf, len);
-        if (op_ret < 0) {
-            local->op_ret = -1;
-            local->op_errno = -op_ret;
+        ret = dict_set_dynptr(newdict, GF_XATTR_LOCKINFO_KEY,
+                              (void *)lockinfo_buf, len);
+        if (ret) {
+            local->op_ret = gf_error;
+            local->op_errno = -ret;
             goto unwind;
         }
 
@@ -973,10 +975,10 @@ unlock:
 
 int32_t
 afr_fgetxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, dict_t *dict,
+                           gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                            dict_t *xdata)
 {
-    int call_cnt = 0, len = 0;
+    int call_cnt = 0, len = 0, ret = 0;
     char *lockinfo_buf = NULL;
     dict_t *lockinfo = NULL, *newdict = NULL;
     afr_local_t *local = NULL;
@@ -987,7 +989,7 @@ afr_fgetxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         call_cnt = --local->call_count;
 
-        if ((op_ret < 0) || (!dict && !xdata)) {
+        if ((IS_ERROR(op_ret)) || (!dict && !xdata)) {
             goto unlock;
         }
 
@@ -995,7 +997,7 @@ afr_fgetxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             if (!local->xdata_rsp) {
                 local->xdata_rsp = dict_new();
                 if (!local->xdata_rsp) {
-                    local->op_ret = -1;
+                    local->op_ret = gf_error;
                     local->op_errno = ENOMEM;
                     goto unlock;
                 }
@@ -1006,8 +1008,8 @@ afr_fgetxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             goto unlock;
         }
 
-        op_ret = dict_get_ptr_and_len(dict, GF_XATTR_LOCKINFO_KEY,
-                                      (void **)&lockinfo_buf, &len);
+        ret = dict_get_ptr_and_len(dict, GF_XATTR_LOCKINFO_KEY,
+                                   (void **)&lockinfo_buf, &len);
 
         if (!lockinfo_buf) {
             goto unlock;
@@ -1016,7 +1018,7 @@ afr_fgetxattr_lockinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         if (!local->dict) {
             local->dict = dict_new();
             if (!local->dict) {
-                local->op_ret = -1;
+                local->op_ret = gf_error;
                 local->op_errno = ENOMEM;
                 goto unlock;
             }
@@ -1028,10 +1030,10 @@ unlock:
     if (lockinfo_buf != NULL) {
         lockinfo = dict_new();
         if (lockinfo == NULL) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = ENOMEM;
         } else {
-            op_ret = dict_unserialize(lockinfo_buf, len, &lockinfo);
+            ret = dict_unserialize(lockinfo_buf, len, &lockinfo);
 
             if (lockinfo && local->dict) {
                 dict_copy(lockinfo, local->dict);
@@ -1046,23 +1048,23 @@ unlock:
     if (!call_cnt) {
         newdict = dict_new();
         if (!newdict) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = ENOMEM;
             goto unwind;
         }
 
-        op_ret = dict_allocate_and_serialize(
-            local->dict, (char **)&lockinfo_buf, (unsigned int *)&len);
-        if (op_ret != 0) {
-            local->op_ret = -1;
+        ret = dict_allocate_and_serialize(local->dict, (char **)&lockinfo_buf,
+                                          (unsigned int *)&len);
+        if (ret != 0) {
+            local->op_ret = gf_error;
             goto unwind;
         }
 
-        op_ret = dict_set_dynptr(newdict, GF_XATTR_LOCKINFO_KEY,
-                                 (void *)lockinfo_buf, len);
-        if (op_ret < 0) {
-            local->op_ret = -1;
-            local->op_errno = -op_ret;
+        ret = dict_set_dynptr(newdict, GF_XATTR_LOCKINFO_KEY,
+                              (void *)lockinfo_buf, len);
+        if (ret) {
+            local->op_ret = gf_error;
+            local->op_errno = -ret;
             goto unwind;
         }
 
@@ -1078,7 +1080,7 @@ unlock:
 
 int32_t
 afr_fgetxattr_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, dict_t *dict,
+                           gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                            dict_t *xdata)
 {
     afr_local_t *local = NULL;
@@ -1110,7 +1112,7 @@ afr_fgetxattr_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     {
         callcnt = --local->call_count;
 
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
         } else {
             local->op_ret = op_ret;
@@ -1118,7 +1120,7 @@ afr_fgetxattr_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 local->xdata_rsp = dict_ref(xdata);
         }
 
-        if (!dict || (op_ret < 0))
+        if (!dict || (IS_ERROR(op_ret)))
             goto unlock;
 
         if (!local->dict) {
@@ -1202,7 +1204,7 @@ out:
 
 int32_t
 afr_getxattr_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, dict_t *dict,
+                          gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                           dict_t *xdata)
 {
     afr_local_t *local = NULL;
@@ -1234,7 +1236,7 @@ afr_getxattr_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     {
         callcnt = --local->call_count;
 
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
         } else {
             local->op_ret = op_ret;
@@ -1242,7 +1244,7 @@ afr_getxattr_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 local->xdata_rsp = dict_ref(xdata);
         }
 
-        if (!dict || (op_ret < 0))
+        if (!dict || (IS_ERROR(op_ret)))
             goto unlock;
 
         if (!local->dict) {
@@ -1337,8 +1339,8 @@ afr_aggregate_stime_xattr(dict_t *this, char *key, data_t *value, void *data)
 
 int32_t
 afr_common_getxattr_stime_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                              int32_t op_ret, int32_t op_errno, dict_t *dict,
-                              dict_t *xdata)
+                              gf_return_t op_ret, int32_t op_errno,
+                              dict_t *dict, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int32_t callcnt = 0;
@@ -1354,7 +1356,7 @@ afr_common_getxattr_stime_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     {
         callcnt = --local->call_count;
 
-        if (!dict || (op_ret < 0)) {
+        if (!dict || (IS_ERROR(op_ret))) {
             local->op_errno = op_errno;
             goto cleanup;
         }
@@ -1363,7 +1365,7 @@ afr_common_getxattr_stime_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             local->dict = dict_copy_with_ref(dict, NULL);
         else
             dict_foreach(dict, afr_aggregate_stime_xattr, local->dict);
-        local->op_ret = 0;
+        local->op_ret = gf_success;
     }
 
 cleanup:
@@ -1518,7 +1520,7 @@ afr_handle_heal_xattrs(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 out:
     if (ret == 1) {
-        AFR_STACK_UNWIND(getxattr, frame, -1, ENOMEM, NULL, NULL);
+        AFR_STACK_UNWIND(getxattr, frame, gf_error, ENOMEM, NULL, NULL);
         if (data)
             GF_FREE(data);
         ret = 0;
@@ -1608,7 +1610,7 @@ no_name:
     ret = 0;
 out:
     if (ret < 0)
-        AFR_STACK_UNWIND(getxattr, frame, -1, op_errno, NULL, NULL);
+        AFR_STACK_UNWIND(getxattr, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
@@ -1616,14 +1618,15 @@ out:
 
 int32_t
 afr_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                  dict_t *xdata)
 {
     afr_local_t *local = NULL;
 
     local = frame->local;
 
-    if (op_ret < 0) {
-        local->op_ret = -1;
+    if (IS_ERROR(op_ret)) {
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
 
         afr_read_txn_continue(frame, this, (long)cookie);
@@ -1733,7 +1736,7 @@ afr_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
 
     return 0;
 out:
-    AFR_STACK_UNWIND(fgetxattr, frame, -1, op_errno, NULL, NULL);
+    AFR_STACK_UNWIND(fgetxattr, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -1743,16 +1746,17 @@ out:
 /* {{{ readv */
 
 int
-afr_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iovec *vector, int32_t count,
-              struct iatt *buf, struct iobref *iobref, dict_t *xdata)
+afr_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
+              int32_t count, struct iatt *buf, struct iobref *iobref,
+              dict_t *xdata)
 {
     afr_local_t *local = NULL;
 
     local = frame->local;
 
-    if (op_ret < 0) {
-        local->op_ret = -1;
+    if (IS_ERROR(op_ret)) {
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
 
         afr_read_txn_continue(frame, this, (long)cookie);
@@ -1812,7 +1816,7 @@ afr_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     return 0;
 out:
-    AFR_STACK_UNWIND(readv, frame, -1, op_errno, 0, 0, 0, 0, 0);
+    AFR_STACK_UNWIND(readv, frame, gf_error, op_errno, 0, 0, 0, 0, 0);
 
     return 0;
 }
@@ -1822,15 +1826,15 @@ out:
 /* {{{ seek */
 
 int
-afr_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, off_t offset, dict_t *xdata)
+afr_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
 {
     afr_local_t *local = NULL;
 
     local = frame->local;
 
-    if (op_ret < 0) {
-        local->op_ret = -1;
+    if (IS_ERROR(op_ret)) {
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
 
         afr_read_txn_continue(frame, this, (long)cookie);
@@ -1887,7 +1891,7 @@ afr_seek(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     return 0;
 out:
-    AFR_STACK_UNWIND(seek, frame, -1, op_errno, 0, NULL);
+    AFR_STACK_UNWIND(seek, frame, gf_error, op_errno, 0, NULL);
 
     return 0;
 }

--- a/xlators/cluster/afr/src/afr-read-txn.c
+++ b/xlators/cluster/afr/src/afr-read-txn.c
@@ -224,7 +224,7 @@ out:
     loc_wipe(&loc);
 
     if (read_subvol == -1) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
     }
     afr_read_txn_wind(frame, this, read_subvol);
@@ -241,7 +241,7 @@ afr_ta_read_txn_synctask(call_frame_t *frame, xlator_t *this)
     local = frame->local;
     ta_frame = afr_ta_frame_create(this);
     if (!ta_frame) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOMEM;
         gf_msg(this->name, GF_LOG_ERROR, ENOMEM, AFR_MSG_THIN_ARB,
                "Failed to create ta_frame");
@@ -254,7 +254,7 @@ afr_ta_read_txn_synctask(call_frame_t *frame, xlator_t *this)
                "Failed to launch "
                "afr_ta_read_txn synctask for gfid %s.",
                uuid_utoa(local->inode->gfid));
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOMEM;
         STACK_DESTROY(ta_frame->root);
         goto out;
@@ -414,18 +414,18 @@ afr_read_txn(call_frame_t *frame, xlator_t *this, inode_t *inode,
     local->transaction.type = type;
 
     if (priv->quorum_count && !afr_has_quorum(local->child_up, this, NULL)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = afr_quorum_errno(priv);
         goto read;
     }
 
     if (!afr_is_consistent_io_possible(local, priv, &local->op_errno)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         goto read;
     }
 
     if (priv->thin_arbiter_count && !afr_ta_has_quorum(priv, local)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = -afr_quorum_errno(priv);
         goto read;
     }

--- a/xlators/cluster/afr/src/afr-self-heal-common.c
+++ b/xlators/cluster/afr/src/afr-self-heal-common.c
@@ -37,7 +37,8 @@ afr_lookup_and_heal_gfid(xlator_t *this, inode_t *parent, const char *name,
 
     priv = this->private;
     wind_on = alloca0(priv->child_count);
-    if (source >= 0 && replies[source].valid && replies[source].op_ret == 0)
+    if (source >= 0 && replies[source].valid &&
+        IS_SUCCESS(replies[source].op_ret))
         ia_type = replies[source].poststat.ia_type;
 
     if (ia_type != IA_INVAL)
@@ -55,7 +56,7 @@ afr_lookup_and_heal_gfid(xlator_t *this, inode_t *parent, const char *name,
     for (i = 0; i < priv->child_count; i++) {
         if (source == -1) {
             /* case (a) above. */
-            if (replies[i].valid && replies[i].op_ret == 0 &&
+            if (replies[i].valid && IS_SUCCESS(replies[i].op_ret) &&
                 replies[i].poststat.ia_type != IA_INVAL) {
                 ia_type = replies[i].poststat.ia_type;
                 break;
@@ -64,7 +65,8 @@ afr_lookup_and_heal_gfid(xlator_t *this, inode_t *parent, const char *name,
             /* case (b) above. */
             if (i == source)
                 continue;
-            if (sources[i] && replies[i].valid && replies[i].op_ret == 0 &&
+            if (sources[i] && replies[i].valid &&
+                IS_SUCCESS(replies[i].op_ret) &&
                 replies[i].poststat.ia_type != IA_INVAL) {
                 ia_type = replies[i].poststat.ia_type;
                 break;
@@ -77,7 +79,7 @@ heal:
      * with the inode and update those replies.
      */
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret != 0)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
 
         if (gf_uuid_is_null(gfid) &&
@@ -132,7 +134,7 @@ heal:
         for (i = 0; i < priv->child_count; i++) {
             if (!wind_on[i])
                 continue;
-            if (replies[i].valid && replies[i].op_ret == 0 &&
+            if (replies[i].valid && IS_SUCCESS(replies[i].op_ret) &&
                 !gf_uuid_is_null(replies[i].poststat.ia_gfid)) {
                 *gfid_idx = i;
                 break;
@@ -161,7 +163,7 @@ afr_gfid_sbrain_source_from_src_brick(xlator_t *this, struct afr_reply *replies,
 
     priv = this->private;
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         if (strcmp(priv->children[i]->name, src_brick) == 0)
             return i;
@@ -178,7 +180,7 @@ afr_selfheal_gfid_mismatch_by_majority(struct afr_reply *replies,
     int votes;
 
     for (i = 0; i < child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
 
         votes = 1;
@@ -203,7 +205,7 @@ afr_gfid_sbrain_source_from_bigger_file(struct afr_reply *replies,
     uint64_t size = 0;
 
     for (i = 0; i < child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret == -1)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         if (size < replies[i].poststat.ia_size) {
             src = i;
@@ -225,7 +227,7 @@ afr_gfid_sbrain_source_from_latest_mtime(struct afr_reply *replies,
     uint32_t mtime_nsec = 0;
 
     for (i = 0; i < child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret != 0)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
         if ((mtime < replies[i].poststat.ia_mtime) ||
             ((mtime == replies[i].poststat.ia_mtime) &&
@@ -407,7 +409,8 @@ out:
 
 int
 afr_selfheal_post_op_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int op_ret, int op_errno, dict_t *xattr, dict_t *xdata)
+                         gf_return_t op_ret, int op_errno, dict_t *xattr,
+                         dict_t *xdata)
 {
     afr_local_t *local = NULL;
 
@@ -437,18 +440,18 @@ afr_selfheal_post_op(call_frame_t *frame, xlator_t *this, inode_t *inode,
     loc.inode = inode_ref(inode);
     gf_uuid_copy(loc.gfid, inode->gfid);
 
-    local->op_ret = 0;
+    local->op_ret = gf_success;
 
     STACK_WIND(frame, afr_selfheal_post_op_cbk, priv->children[subvol],
                priv->children[subvol]->fops->xattrop, &loc,
                GF_XATTROP_ADD_ARRAY, xattr, xdata);
 
     syncbarrier_wait(&local->barrier, 1);
-    if (local->op_ret < 0)
+    if (IS_ERROR(local->op_ret))
         ret = -local->op_errno;
 
     loc_wipe(&loc);
-    local->op_ret = 0;
+    local->op_ret = gf_success;
 
     return ret;
 }
@@ -476,7 +479,7 @@ afr_check_stale_error(struct afr_reply *replies, afr_private_t *priv)
 
 int
 afr_sh_generic_fop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, struct iatt *pre,
+                       gf_return_t op_ret, int op_errno, struct iatt *pre,
                        struct iatt *post, dict_t *xdata)
 {
     int i = (long)cookie;
@@ -797,7 +800,7 @@ afr_selfheal_extract_xattr(xlator_t *this, struct afr_reply *replies,
     priv = this->private;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret != 0)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
 
         if (!replies[i].xdata)
@@ -831,7 +834,7 @@ afr_mark_largest_file_as_source(xlator_t *this, unsigned char *sources,
     for (i = 0; i < priv->child_count; i++) {
         if (!sources[i])
             continue;
-        if (!replies[i].valid || replies[i].op_ret != 0) {
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret)) {
             sources[i] = 0;
             continue;
         }
@@ -862,7 +865,7 @@ afr_mark_latest_mtime_file_as_source(xlator_t *this, unsigned char *sources,
     for (i = 0; i < priv->child_count; i++) {
         if (!sources[i])
             continue;
-        if (!replies[i].valid || replies[i].op_ret != 0) {
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret)) {
             sources[i] = 0;
             continue;
         }
@@ -932,7 +935,7 @@ afr_can_decide_split_brain_source_sinks(struct afr_reply *replies,
     int i = 0;
 
     for (i = 0; i < child_count; i++)
-        if (replies[i].valid != 1 || replies[i].op_ret != 0)
+        if (replies[i].valid != 1 || IS_ERROR(replies[i].op_ret))
             return _gf_false;
 
     return _gf_true;
@@ -1315,7 +1318,7 @@ afr_is_file_empty_on_all_children(afr_private_t *priv,
     int i = 0;
 
     for (i = 0; i < priv->child_count; i++) {
-        if ((!replies[i].valid) || (replies[i].op_ret != 0) ||
+        if ((!replies[i].valid) || IS_ERROR(replies[i].op_ret) ||
             (replies[i].poststat.ia_size != 0))
             return _gf_false;
     }
@@ -1746,7 +1749,7 @@ afr_log_selfheal(uuid_t gfid, xlator_t *this, int ret, char *type, int source,
 
 int
 afr_selfheal_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int op_ret, int op_errno, inode_t *inode,
+                          gf_return_t op_ret, int op_errno, inode_t *inode,
                           struct iatt *buf, dict_t *xdata, struct iatt *parbuf)
 {
     afr_local_t *local = NULL;
@@ -1924,14 +1927,14 @@ afr_success_count(struct afr_reply *replies, unsigned int count)
     unsigned int success = 0;
 
     for (i = 0; i < count; i++)
-        if (replies[i].valid && replies[i].op_ret == 0)
+        if (replies[i].valid && IS_SUCCESS(replies[i].op_ret))
             success++;
     return success;
 }
 
 int
 afr_selfheal_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int i = 0;
@@ -1960,7 +1963,7 @@ afr_locked_fill(call_frame_t *frame, xlator_t *this, unsigned char *locked_on)
     priv = this->private;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (local->replies[i].valid && local->replies[i].op_ret == 0) {
+        if (local->replies[i].valid && IS_SUCCESS(local->replies[i].op_ret)) {
             locked_on[i] = 1;
             count++;
         } else {
@@ -2027,7 +2030,7 @@ afr_selfheal_inodelk(call_frame_t *frame, xlator_t *this, inode_t *inode,
               NULL);
 
     for (i = 0; i < priv->child_count; i++) {
-        if (local->replies[i].op_ret == -1 &&
+        if (IS_ERROR(local->replies[i].op_ret) &&
             local->replies[i].op_errno == EAGAIN) {
             afr_locked_fill(frame, this, locked_on);
             afr_selfheal_uninodelk(frame, this, inode, dom, off, size,
@@ -2053,9 +2056,10 @@ afr_get_lock_and_eagain_counts(afr_private_t *priv, struct afr_reply *replies,
     for (i = 0; i < priv->child_count; i++) {
         if (!replies[i].valid)
             continue;
-        if (replies[i].op_ret == 0) {
+        if (IS_SUCCESS(replies[i].op_ret)) {
             (*lock_count)++;
-        } else if (replies[i].op_ret == -1 && replies[i].op_errno == EAGAIN) {
+        } else if (IS_ERROR(replies[i].op_ret) &&
+                   replies[i].op_errno == EAGAIN) {
             (*eagain_count)++;
         }
     }
@@ -2175,7 +2179,7 @@ afr_selfheal_entrylk(call_frame_t *frame, xlator_t *this, inode_t *inode,
               ENTRYLK_LOCK_NB, ENTRYLK_WRLCK, NULL);
 
     for (i = 0; i < priv->child_count; i++) {
-        if (local->replies[i].op_ret == -1 &&
+        if (IS_ERROR(local->replies[i].op_ret) &&
             local->replies[i].op_errno == EAGAIN) {
             afr_locked_fill(frame, this, locked_on);
             afr_selfheal_unentrylk(frame, this, inode, dom, name, locked_on,
@@ -2310,7 +2314,7 @@ afr_selfheal_unlocked_inspect(call_frame_t *frame, xlator_t *this, uuid_t gfid,
     for (i = 0; i < priv->child_count; i++) {
         if (!replies[i].valid)
             continue;
-        if (replies[i].op_ret == -1)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         /* The data segment of the changelog can be non-zero to indicate

--- a/xlators/cluster/afr/src/afr-self-heal-data.c
+++ b/xlators/cluster/afr/src/afr-self-heal-data.c
@@ -17,8 +17,9 @@
 
 #define HAS_HOLES(i) ((i->ia_blocks * 512) < (i->ia_size))
 static int
-__checksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, uint32_t weak, uint8_t *strong, dict_t *xdata)
+__checksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, uint32_t weak, uint8_t *strong,
+               dict_t *xdata)
 {
     afr_local_t *local = NULL;
     struct afr_reply *replies = NULL;
@@ -84,7 +85,7 @@ __afr_can_skip_data_block_heal(call_frame_t *frame, xlator_t *this, fd_t *fd,
     if (xdata)
         dict_unref(xdata);
 
-    if (!replies[source].valid || replies[source].op_ret != 0)
+    if (!replies[source].valid || IS_ERROR(replies[source].op_ret))
         return _gf_false;
 
     for (i = 0; i < priv->child_count; i++) {
@@ -297,7 +298,7 @@ afr_selfheal_data_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd,
     AFR_ONLIST(healed_sinks, frame, afr_sh_generic_fop_cbk, fsync, fd, 0, NULL);
 
     for (i = 0; i < priv->child_count; i++)
-        if (healed_sinks[i] && local->replies[i].op_ret != 0)
+        if (healed_sinks[i] && IS_ERROR(local->replies[i].op_ret))
             /* fsync() failed. Do NOT consider this server
                as successfully healed. Mark it so.
             */
@@ -410,7 +411,7 @@ __afr_selfheal_truncate_sinks(call_frame_t *frame, xlator_t *this, fd_t *fd,
                NULL);
 
     for (i = 0; i < priv->child_count; i++)
-        if (healed_sinks[i] && local->replies[i].op_ret == -1)
+        if (healed_sinks[i] && IS_ERROR(local->replies[i].op_ret))
             /* truncate() failed. Do NOT consider this server
                as successfully healed. Mark it so.
             */
@@ -450,7 +451,7 @@ afr_does_size_mismatch(xlator_t *this, unsigned char *sources,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret < 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         if (!sources[i])
@@ -773,7 +774,7 @@ out:
 
 int
 afr_selfheal_data_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, fd_t *fd,
+                           gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                            dict_t *xdata)
 {
     afr_local_t *local = NULL;
@@ -828,7 +829,7 @@ afr_selfheal_data_open(xlator_t *this, inode_t *inode, fd_t **fd)
         if (!local->replies[i].valid)
             continue;
 
-        if (local->replies[i].op_ret < 0) {
+        if (IS_ERROR(local->replies[i].op_ret)) {
             ret = -local->replies[i].op_errno;
             continue;
         }

--- a/xlators/cluster/afr/src/afr-self-heal-entry.c
+++ b/xlators/cluster/afr/src/afr-self-heal-entry.c
@@ -37,7 +37,7 @@ afr_selfheal_entry_delete(xlator_t *this, inode_t *dir, const char *name,
     loc.name = name;
     loc.inode = inode_ref(inode);
 
-    if (replies[child].valid && replies[child].op_ret == 0) {
+    if (replies[child].valid && IS_SUCCESS(replies[child].op_ret)) {
         switch (replies[child].poststat.ia_type) {
             case IA_IFDIR:
                 gf_msg(this->name, GF_LOG_WARNING, 0,
@@ -187,10 +187,11 @@ __afr_selfheal_heal_dirent(call_frame_t *frame, xlator_t *this, fd_t *fd,
     /* Skip healing this entry if the last lookup on it failed for reasons
      * other than ENOENT.
      */
-    if ((replies[source].op_ret < 0) && (replies[source].op_errno != ENOENT))
+    if (IS_ERROR(replies[source].op_ret) &&
+        (replies[source].op_errno != ENOENT))
         return -replies[source].op_errno;
 
-    if (replies[source].op_ret == 0) {
+    if (IS_SUCCESS(replies[source].op_ret)) {
         ret = afr_lookup_and_heal_gfid(this, fd->inode, name, inode, replies,
                                        source, sources,
                                        &replies[source].poststat.ia_gfid, NULL);
@@ -201,7 +202,7 @@ __afr_selfheal_heal_dirent(call_frame_t *frame, xlator_t *this, fd_t *fd,
     for (i = 0; i < priv->child_count; i++) {
         if (!healed_sinks[i])
             continue;
-        if (replies[source].op_ret == -1 &&
+        if (IS_ERROR(replies[source].op_ret) &&
             replies[source].op_errno == ENOENT) {
             ret = afr_selfheal_entry_delete(this, fd->inode, name, inode, i,
                                             replies);
@@ -244,7 +245,7 @@ afr_selfheal_detect_gfid_and_type_mismatch(xlator_t *this,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret != 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         if (gf_uuid_is_null(replies[i].poststat.ia_gfid))
@@ -314,7 +315,7 @@ __afr_selfheal_merge_dirent(call_frame_t *frame, xlator_t *this, fd_t *fd,
     priv = this->private;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (replies[i].valid && replies[i].op_ret == 0) {
+        if (replies[i].valid && IS_SUCCESS(replies[i].op_ret)) {
             source = i;
             break;
         }
@@ -327,7 +328,7 @@ __afr_selfheal_merge_dirent(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     /* Set all the sources as 1, otheriwse newentry_mark won't be set */
     for (i = 0; i < priv->child_count; i++) {
-        if (replies[i].valid && replies[i].op_ret == 0) {
+        if (replies[i].valid && IS_SUCCESS(replies[i].op_ret)) {
             sources[i] = 1;
         }
     }

--- a/xlators/cluster/afr/src/afr-self-heal-metadata.c
+++ b/xlators/cluster/afr/src/afr-self-heal-metadata.c
@@ -143,7 +143,7 @@ afr_dirtime_splitbrain_source(call_frame_t *frame, xlator_t *this,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret != 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         if (mtime_ns(&replies[i].poststat) <= mtime)
@@ -167,7 +167,7 @@ afr_dirtime_splitbrain_source(call_frame_t *frame, xlator_t *this,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret != 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         child_ia = replies[i].poststat;

--- a/xlators/cluster/afr/src/afr-self-heal-name.c
+++ b/xlators/cluster/afr/src/afr-self-heal-name.c
@@ -72,7 +72,7 @@ __afr_selfheal_name_impunge(call_frame_t *frame, xlator_t *this,
     gf_uuid_copy(parent->gfid, pargfid);
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret != 0)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
 
         if (gf_uuid_compare(replies[i].poststat.ia_gfid,
@@ -117,7 +117,7 @@ __afr_selfheal_name_expunge(xlator_t *this, inode_t *parent, uuid_t pargfid,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         switch (replies[i].poststat.ia_type) {
@@ -161,7 +161,7 @@ afr_selfheal_name_need_heal_check(xlator_t *this, struct afr_reply *replies)
         if (!replies[i].valid)
             continue;
 
-        if ((replies[i].op_ret == -1) && (replies[i].op_errno == ENODATA))
+        if (IS_ERROR(replies[i].op_ret) && (replies[i].op_errno == ENODATA))
             need_heal = _gf_true;
 
         if (first_idx == -1) {
@@ -169,14 +169,14 @@ afr_selfheal_name_need_heal_check(xlator_t *this, struct afr_reply *replies)
             continue;
         }
 
-        if (replies[i].op_ret != replies[first_idx].op_ret)
+        if (GET_RET(replies[i].op_ret) != GET_RET(replies[first_idx].op_ret))
             need_heal = _gf_true;
 
         if (gf_uuid_compare(replies[i].poststat.ia_gfid,
                             replies[first_idx].poststat.ia_gfid))
             need_heal = _gf_true;
 
-        if ((replies[i].op_ret == 0) &&
+        if (IS_SUCCESS(replies[i].op_ret) &&
             (gf_uuid_is_null(replies[i].poststat.ia_gfid)))
             need_heal = _gf_true;
     }
@@ -198,7 +198,7 @@ afr_selfheal_name_type_mismatch_check(xlator_t *this, struct afr_reply *replies,
     priv = this->private;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret != 0)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
 
         if (replies[i].poststat.ia_type == IA_INVAL)
@@ -258,7 +258,7 @@ afr_selfheal_name_gfid_mismatch_check(xlator_t *this, struct afr_reply *replies,
     priv = this->private;
 
     for (i = 0; i < priv->child_count; i++) {
-        if (!replies[i].valid || replies[i].op_ret != 0)
+        if (!replies[i].valid || IS_ERROR(replies[i].op_ret))
             continue;
 
         if (gf_uuid_is_null(replies[i].poststat.ia_gfid))
@@ -316,7 +316,7 @@ afr_selfheal_name_source_empty_check(xlator_t *this, struct afr_reply *replies,
         if (!sources[i])
             continue;
 
-        if (replies[i].op_ret == -1 && replies[i].op_errno == ENOENT)
+        if (IS_ERROR(replies[i].op_ret) && replies[i].op_errno == ENOENT)
             continue;
 
         source_is_empty = _gf_false;
@@ -576,7 +576,7 @@ afr_selfheal_name_unlocked_inspect(call_frame_t *frame, xlator_t *this,
         if (!replies[i].valid)
             continue;
 
-        if ((replies[i].op_ret == -1) && (replies[i].op_errno == ENODATA)) {
+        if (IS_ERROR(replies[i].op_ret) && (replies[i].op_errno == ENODATA)) {
             *need_heal = _gf_true;
             break;
         }
@@ -586,7 +586,7 @@ afr_selfheal_name_unlocked_inspect(call_frame_t *frame, xlator_t *this,
             continue;
         }
 
-        if (replies[i].op_ret != replies[first_idx].op_ret) {
+        if (GET_RET(replies[i].op_ret) != GET_RET(replies[first_idx].op_ret)) {
             *need_heal = _gf_true;
             break;
         }

--- a/xlators/cluster/afr/src/afr-self-heal.h
+++ b/xlators/cluster/afr/src/afr-self-heal.h
@@ -209,7 +209,7 @@ afr_selfheal_extract_xattr(xlator_t *this, struct afr_reply *replies,
 
 int
 afr_sh_generic_fop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, struct iatt *pre,
+                       gf_return_t op_ret, int op_errno, struct iatt *pre,
                        struct iatt *post, dict_t *xdata);
 
 int
@@ -242,7 +242,7 @@ afr_inode_find(xlator_t *this, uuid_t gfid);
 
 int
 afr_selfheal_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int op_ret, int op_errno, inode_t *inode,
+                          gf_return_t op_ret, int op_errno, inode_t *inode,
                           struct iatt *buf, dict_t *xdata, struct iatt *parbuf);
 void
 afr_reply_copy(struct afr_reply *dst, struct afr_reply *src);
@@ -334,7 +334,7 @@ afr_selfheal_do(call_frame_t *frame, xlator_t *this, uuid_t gfid);
 
 int
 afr_selfheal_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, dict_t *xdata);
+                      gf_return_t op_ret, int op_errno, dict_t *xdata);
 
 int
 afr_locked_fill(call_frame_t *frame, xlator_t *this, unsigned char *locked_on);

--- a/xlators/cluster/afr/src/afr-self-heald.c
+++ b/xlators/cluster/afr/src/afr-self-heald.c
@@ -1371,7 +1371,7 @@ afr_xl_op(xlator_t *this, dict_t *input, dict_t *output)
     char key[64];
     int keylen = 0;
     int this_name_len = 0;
-    int op_ret = 0;
+    gf_return_t op_ret = {0};
     uint64_t cnt = 0;
 
 #define AFR_SET_DICT_AND_LOG(name, output, key, keylen, dict_str,              \
@@ -1410,7 +1410,6 @@ afr_xl_op(xlator_t *this, dict_t *input, dict_t *output)
     }
     switch (op) {
         case GF_SHD_OP_HEAL_INDEX:
-            op_ret = 0;
 
             for (i = 0; i < priv->child_count; i++) {
                 healer = &shd->index_healers[i];
@@ -1420,12 +1419,12 @@ afr_xl_op(xlator_t *this, dict_t *input, dict_t *output)
                     AFR_SET_DICT_AND_LOG(this->name, output, key, keylen,
                                          SBRICK_NOT_CONNECTED,
                                          SLEN(SBRICK_NOT_CONNECTED));
-                    op_ret = -1;
+                    op_ret = gf_error;
                 } else if (AFR_COUNT(priv->child_up, priv->child_count) < 2) {
                     AFR_SET_DICT_AND_LOG(this->name, output, key, keylen,
                                          SLESS_THAN2_BRICKS_in_REP,
                                          SLEN(SLESS_THAN2_BRICKS_in_REP));
-                    op_ret = -1;
+                    op_ret = gf_error;
                 } else if (!afr_shd_is_subvol_local(this, healer->subvol)) {
                     AFR_SET_DICT_AND_LOG(this->name, output, key, keylen,
                                          SBRICK_IS_REMOTE,
@@ -1445,7 +1444,7 @@ afr_xl_op(xlator_t *this, dict_t *input, dict_t *output)
             }
             break;
         case GF_SHD_OP_HEAL_FULL:
-            op_ret = -1;
+            op_ret = gf_error;
 
             for (i = 0; i < priv->child_count; i++) {
                 healer = &shd->full_healers[i];
@@ -1474,7 +1473,7 @@ afr_xl_op(xlator_t *this, dict_t *input, dict_t *output)
                         gf_smsg(this->name, GF_LOG_ERROR, -ret,
                                 AFR_MSG_HEALER_SPAWN_FAILED, NULL);
                     }
-                    op_ret = 0;
+                    op_ret = gf_success;
                 }
             }
             break;
@@ -1504,7 +1503,7 @@ afr_xl_op(xlator_t *this, dict_t *input, dict_t *output)
             break;
         case GF_SHD_OP_STATISTICS_HEAL_COUNT:
         case GF_SHD_OP_STATISTICS_HEAL_COUNT_PER_REPLICA:
-            op_ret = -1;
+            op_ret = gf_error;
 
             for (i = 0; i < priv->child_count; i++) {
                 if (!priv->child_up[i]) {
@@ -1523,7 +1522,7 @@ afr_xl_op(xlator_t *this, dict_t *input, dict_t *output)
                         gf_smsg(this->name, GF_LOG_ERROR, -ret,
                                 AFR_MSG_DICT_SET_FAILED, NULL);
                     }
-                    op_ret = 0;
+                    op_ret = gf_success;
                 }
             }
 
@@ -1536,7 +1535,7 @@ afr_xl_op(xlator_t *this, dict_t *input, dict_t *output)
     }
 out:
     dict_deln(output, this->name, this_name_len);
-    return op_ret;
+    return GET_RET(op_ret);
 
 #undef AFR_SET_DICT_AND_LOG
 }

--- a/xlators/cluster/afr/src/afr-transaction.c
+++ b/xlators/cluster/afr/src/afr-transaction.c
@@ -200,7 +200,7 @@ afr_pick_error_xdata(afr_local_t *local, afr_private_t *priv, inode_t *inode1,
         if (!local->replies[i].valid)
             continue;
 
-        if (local->replies[i].op_ret >= 0)
+        if (IS_SUCCESS(local->replies[i].op_ret))
             continue;
 
         if (local->replies[i].op_errno == ENOTCONN)
@@ -218,7 +218,7 @@ afr_pick_error_xdata(afr_local_t *local, afr_private_t *priv, inode_t *inode1,
             if (!local->replies[i].valid)
                 continue;
 
-            if (local->replies[i].op_ret >= 0)
+            if (IS_SUCCESS(local->replies[i].op_ret))
                 continue;
 
             if (!local->replies[i].xdata)
@@ -306,7 +306,7 @@ afr_transaction_fop(call_frame_t *frame, xlator_t *this)
                  AFR_COUNT(failed_subvols, priv->child_count);
     /* Fail if pre-op did not succeed on quorum no. of bricks. */
     if (!afr_changelog_has_quorum(local, this) || !call_count) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         /* local->op_errno is already captured in changelog cbk. */
         afr_transaction_resume(frame, this);
         return 0;
@@ -315,7 +315,7 @@ afr_transaction_fop(call_frame_t *frame, xlator_t *this)
     /* Fail if at least one writeable brick isn't up.*/
     if (local->transaction.type == AFR_DATA_TRANSACTION &&
         !afr_is_write_subvol_valid(frame, this)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = EIO;
         afr_transaction_resume(frame, this);
         return 0;
@@ -394,7 +394,7 @@ afr_lock_fail_shared(afr_local_t *local, struct list_head *list)
     while (!list_empty(list)) {
         each = list_entry(list->next, afr_local_t, transaction.wait_list);
         list_del_init(&each->transaction.wait_list);
-        each->op_ret = -1;
+        each->op_ret = gf_error;
         each->op_errno = local->op_errno;
         afr_transaction_done(each->transaction.frame,
                              each->transaction.frame->this);
@@ -435,7 +435,7 @@ afr_transaction_detach_fop_frame(call_frame_t *frame)
 
     local = frame->local;
 
-    afr_handle_inconsistent_fop(frame, &local->op_ret, &local->op_errno);
+    afr_handle_inconsistent_fop(frame, &local->op_ret.op_ret, &local->op_errno);
     LOCK(&frame->lock);
     {
         fop_frame = local->transaction.main_frame;
@@ -539,7 +539,7 @@ afr_txn_arbitrate_fop(call_frame_t *frame, xlator_t *this)
     /* If arbiter is the only source, do not proceed. */
     if (pre_op_sources_count < 2 &&
         local->transaction.pre_op_sources[ARBITER_BRICK_INDEX]) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOTCONN;
         for (i = 0; i < priv->child_count; i++)
             local->transaction.failed_subvols[i] = 1;
@@ -570,7 +570,7 @@ afr_transaction_perform_fop(call_frame_t *frame, xlator_t *this)
         ret = afr_write_subvol_set(frame, this);
         if (ret) {
             /*act as if operation failed on all subvols*/
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = -ret;
             for (i = 0; i < priv->child_count; i++)
                 local->transaction.failed_subvols[i] = 1;
@@ -736,7 +736,7 @@ afr_changelog_post_op_done(call_frame_t *frame, xlator_t *this)
 
     /* Fail the FOP if post-op did not succeed on quorum no. of bricks. */
     if (!afr_changelog_has_quorum(local, this)) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         /*local->op_errno is already captured in changelog cbk*/
     }
 
@@ -755,7 +755,7 @@ static void
 afr_changelog_post_op_fail(call_frame_t *frame, xlator_t *this, int op_errno)
 {
     afr_local_t *local = frame->local;
-    local->op_ret = -1;
+    local->op_ret = gf_error;
     local->op_errno = op_errno;
 
     gf_msg(this->name, GF_LOG_ERROR, op_errno, AFR_MSG_THIN_ARB,
@@ -957,7 +957,7 @@ afr_handle_quorum(call_frame_t *frame, xlator_t *this)
         return;
 
     /* If the fop already failed return right away to preserve errno */
-    if (local->op_ret == -1)
+    if (IS_ERROR(local->op_ret))
         return;
 
     /*
@@ -998,7 +998,7 @@ afr_handle_quorum(call_frame_t *frame, xlator_t *this)
     }
 
 set_response:
-    local->op_ret = -1;
+    local->op_ret = gf_error;
     local->op_errno = afr_final_errno(local, priv);
     if (local->op_errno == 0)
         local->op_errno = afr_quorum_errno(priv);
@@ -1395,7 +1395,7 @@ afr_changelog_post_op_do(call_frame_t *frame, xlator_t *this)
     else
         need_undirty = _gf_true;
 
-    if (local->op_ret < 0 && !nothing_failed) {
+    if (IS_ERROR(local->op_ret) && !nothing_failed) {
         if (afr_need_dirty_marking(frame, this)) {
             local->dirty[idx] = hton32(1);
             goto set_dirty;
@@ -1641,8 +1641,9 @@ unlock:
 }
 
 int
-afr_changelog_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, dict_t *xattr, dict_t *xdata)
+afr_changelog_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, dict_t *xattr,
+                  dict_t *xdata)
 {
     afr_local_t *local = NULL;
     int call_count = -1;
@@ -1651,7 +1652,7 @@ afr_changelog_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     local = frame->local;
     child_index = (long)cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
         afr_transaction_fop_failed(frame, this, child_index);
     }
@@ -1724,7 +1725,7 @@ afr_changelog_populate_xdata(call_frame_t *frame, afr_xattrop_type_t op,
                  * an earlier entry txn that may have failed on some
                  * of the sub-volumes.
                  */
-                if (local->op_ret)
+                if (IS_ERROR(local->op_ret))
                     need_entry_key_set = _gf_false;
             } else {
                 key = GF_XATTROP_ENTRY_IN_KEY;
@@ -2004,7 +2005,7 @@ next:
     return 0;
 err:
     local->internal_lock.lock_cbk = afr_transaction_done;
-    local->op_ret = -1;
+    local->op_ret = gf_error;
     local->op_errno = op_errno;
 
     afr_handle_lock_acquire_failure(local);
@@ -2025,7 +2026,7 @@ afr_post_nonblocking_lock_cbk(call_frame_t *frame, xlator_t *this)
     int_lock = &local->internal_lock;
 
     /* Initiate blocking locks if non-blocking has failed */
-    if (int_lock->lock_op_ret < 0) {
+    if (IS_ERROR(int_lock->lock_op_ret)) {
         gf_msg_debug(this->name, 0,
                      "Non blocking locks failed. Proceeding to blocking");
         int_lock->lock_cbk = afr_internal_lock_finish;
@@ -2049,7 +2050,7 @@ afr_post_blocking_rename_cbk(call_frame_t *frame, xlator_t *this)
     local = frame->local;
     int_lock = &local->internal_lock;
 
-    if (int_lock->lock_op_ret < 0) {
+    if (IS_ERROR(int_lock->lock_op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, 0, AFR_MSG_INTERNAL_LKS_FAILED,
                "Blocking entrylks failed.");
 
@@ -2268,14 +2269,14 @@ afr_internal_lock_finish(call_frame_t *frame, xlator_t *this)
 
     local->internal_lock.lock_cbk = NULL;
     if (!local->transaction.eager_lock_on) {
-        if (local->internal_lock.lock_op_ret < 0) {
+        if (IS_ERROR(local->internal_lock.lock_op_ret)) {
             afr_transaction_done(frame, this);
             return 0;
         }
         afr_changelog_pre_op(frame, this);
     } else {
         lock = &local->inode_ctx->lock[local->transaction.type];
-        if (local->internal_lock.lock_op_ret < 0) {
+        if (IS_ERROR(local->internal_lock.lock_op_ret)) {
             afr_handle_lock_acquire_failure(local);
         } else {
             lock->event_generation = local->event_generation;
@@ -2425,7 +2426,7 @@ afr_fd_has_witnessed_unstable_write(xlator_t *this, inode_t *inode)
 
 int
 afr_changelog_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, struct iatt *pre,
+                        gf_return_t op_ret, int op_errno, struct iatt *pre,
                         struct iatt *post, dict_t *xdata)
 {
     afr_private_t *priv = NULL;
@@ -2436,7 +2437,7 @@ afr_changelog_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         /* Failure of fsync() is as good as failure of previous
            write(). So treat it like one.
         */

--- a/xlators/cluster/afr/src/afr.h
+++ b/xlators/cluster/afr/src/afr.h
@@ -87,7 +87,7 @@ typedef int (*afr_changelog_resume_t)(call_frame_t *frame, xlator_t *this);
 
 #define AFR_SET_ERROR_AND_CHECK_SPLIT_BRAIN(ret, errnum)                       \
     do {                                                                       \
-        local->op_ret = ret;                                                   \
+        SET_RET(local->op_ret, ret);                                           \
         local->op_errno = errnum;                                              \
         if (local->op_errno == EIO)                                            \
             gf_msg(this->name, GF_LOG_ERROR, local->op_errno,                  \
@@ -358,7 +358,7 @@ typedef struct {
     int32_t lk_expected_count;
     int32_t lk_attempted_count;
 
-    int32_t lock_op_ret;
+    gf_return_t lock_op_ret;
     int32_t lock_op_errno;
     char *domain; /* Domain on which inode/entry lock/unlock in progress.*/
     int32_t lock_count;
@@ -368,7 +368,7 @@ typedef struct {
 
 struct afr_reply {
     int valid;
-    int32_t op_ret;
+    gf_return_t op_ret;
     dict_t *xattr; /*For xattrop*/
     dict_t *xdata;
     struct iatt poststat;
@@ -472,7 +472,7 @@ typedef struct _afr_local {
     uint32_t open_fd_count;
     int32_t num_inodelks;
 
-    int32_t op_ret;
+    gf_return_t op_ret;
     int32_t op_errno;
 
     int dirty[AFR_NUM_CHANGE_LOGS];
@@ -651,12 +651,12 @@ typedef struct _afr_local {
         struct {
             uint32_t *checksum;
             int success_count;
-            int32_t op_ret;
+            gf_return_t op_ret;
             int32_t op_errno;
         } opendir;
 
         struct {
-            int32_t op_ret;
+            gf_return_t op_ret;
             int32_t op_errno;
             size_t size;
             off_t offset;
@@ -675,7 +675,7 @@ typedef struct _afr_local {
             struct iovec *vector;
             struct iobref *iobref;
             off_t offset;
-            int32_t op_ret;
+            gf_return_t op_ret;
             int32_t count;
             uint32_t flags;
         } writev;
@@ -1100,19 +1100,19 @@ afr_local_transaction_cleanup(afr_local_t *local, xlator_t *this);
 int
 afr_cleanup_fd_ctx(xlator_t *this, fd_t *fd);
 
-#define AFR_STACK_UNWIND(fop, frame, op_ret, op_errno, params...)              \
+#define AFR_STACK_UNWIND(fop, frame, op_return, op_errno, params...)           \
     do {                                                                       \
         afr_local_t *__local = NULL;                                           \
         xlator_t *__this = NULL;                                               \
-        int32_t __op_ret = 0;                                                  \
+        gf_return_t __op_ret;                                                  \
         int32_t __op_errno = 0;                                                \
                                                                                \
-        __op_ret = op_ret;                                                     \
+        __op_ret = op_return;                                                  \
         __op_errno = op_errno;                                                 \
         if (frame) {                                                           \
             __local = frame->local;                                            \
             __this = frame->this;                                              \
-            afr_handle_inconsistent_fop(frame, &__op_ret, &__op_errno);        \
+            afr_handle_inconsistent_fop(frame, &__op_ret.op_ret, &__op_errno); \
             if (__local && __local->is_read_txn)                               \
                 afr_pending_read_decrement(__this->private,                    \
                                            __local->read_subvol);              \
@@ -1313,7 +1313,7 @@ afr_handle_inconsistent_fop(call_frame_t *frame, int32_t *op_ret,
 
 void
 afr_inode_write_fill(call_frame_t *frame, xlator_t *this, int child_index,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata);
 void
 afr_process_post_writev(call_frame_t *frame, xlator_t *this);

--- a/xlators/cluster/dht/src/dht-common.c
+++ b/xlators/cluster/dht/src/dht-common.c
@@ -25,7 +25,7 @@
 
 static int
 dht_rmdir_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, gf_dirent_t *entries,
+                       gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
                        dict_t *xdata);
 
 static int
@@ -39,7 +39,7 @@ dht_lookup_everywhere_done(call_frame_t *frame, xlator_t *this);
 
 static int
 dht_common_mark_mdsxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int op_ret, int op_errno, dict_t *xdata);
+                             gf_return_t op_ret, int op_errno, dict_t *xdata);
 
 static int
 dht_rmdir_unlock(call_frame_t *frame, xlator_t *this);
@@ -48,9 +48,10 @@ static const char *dht_dbg_vxattrs[] = {DHT_DBG_HASHED_SUBVOL_PATTERN, NULL};
 
 /* Check the xdata to make sure EBADF has been set by client xlator */
 int32_t
-dht_check_remote_fd_failed_error(dht_local_t *local, int op_ret, int op_errno)
+dht_check_remote_fd_failed_error(dht_local_t *local, gf_return_t op_ret,
+                                 int op_errno)
 {
-    if (op_ret == -1 && (op_errno == EBADF || op_errno == EBADFD) &&
+    if (IS_ERROR(op_ret) && (op_errno == EBADF || op_errno == EBADFD) &&
         !(local->fd_checked)) {
         return 1;
     }
@@ -452,7 +453,7 @@ dht_inode_ctx_mdsvol_get(inode_t *inode, xlator_t *this, xlator_t **mdsvol)
 
 static int
 dht_lookup_selfheal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     dht_layout_t *layout = NULL;
@@ -465,13 +466,14 @@ dht_lookup_selfheal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     conf = this->private;
-    ret = op_ret;
+    ret = GET_RET(op_ret);
 
     FRAME_SU_UNDO(frame, dht_local_t);
 
     if (ret == 0) {
         layout = local->selfheal.layout;
         ret = dht_layout_set(this, local->inode, layout);
+        SET_RET(op_ret, ret);
     }
 
     dht_inode_ctx_time_update(local->inode, this, &local->stbuf, 1);
@@ -485,7 +487,7 @@ dht_lookup_selfheal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     /* Delete mds xattr at the time of STACK UNWIND */
     GF_REMOVE_INTERNAL_XATTR(conf->mds_xattr_key, local->xattr);
 
-    DHT_STACK_UNWIND(lookup, frame, ret, local->op_errno, local->inode,
+    DHT_STACK_UNWIND(lookup, frame, op_ret, local->op_errno, local->inode,
                      &local->stbuf, local->xattr, &local->postparent);
 
 out:
@@ -565,7 +567,7 @@ dht_discover_complete(xlator_t *this, call_frame_t *discover_frame)
         }
     } else {
         ret = dht_layout_normalize(this, &local->loc, layout);
-        if ((ret < 0) || ((ret > 0) && (local->op_ret != 0))) {
+        if ((ret < 0) || ((ret > 0) && IS_ERROR(local->op_ret))) {
             /* either the layout is incorrect or the directory is
              * not found even in one subvolume.
              */
@@ -607,7 +609,7 @@ dht_discover_complete(xlator_t *this, call_frame_t *discover_frame)
         /* Call function to save hashed subvol on inode ctx if
            internal mds xattr is not present and all subvols are up
         */
-        if (!local->op_ret && !__is_root_gfid(local->stbuf.ia_gfid))
+        if (IS_SUCCESS(local->op_ret) && !__is_root_gfid(local->stbuf.ia_gfid))
             (void)dht_common_mark_mdsxattr(discover_frame,
                                            &error_while_marking_mds, 1);
 
@@ -676,14 +678,15 @@ done:
     return 0;
 
 out:
-    DHT_STACK_UNWIND(lookup, main_frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(lookup, main_frame, gf_error, op_errno, NULL, NULL, NULL,
+                     NULL);
 
     return ret;
 }
 
 static int
 dht_common_mark_mdsxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int op_ret, int op_errno, dict_t *xdata)
+                             gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *prev = cookie;
@@ -700,8 +703,8 @@ dht_common_mark_mdsxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     layout = local->selfheal.layout;
     mds_heal_fresh_lookup = local->mds_heal_fresh_lookup;
 
-    if (op_ret) {
-        gf_msg_debug(this->name, op_ret,
+    if (IS_ERROR(op_ret)) {
+        gf_msg_debug(this->name, GET_RET(op_ret),
                      "Failed to set %s on the MDS %s for path %s. ",
                      conf->mds_xattr_key, prev->name, local->loc.path);
     } else {
@@ -971,9 +974,9 @@ dht_dict_get_array(dict_t *dict, char *key, int32_t value[], int32_t size,
 }
 
 static int
-dht_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, inode_t *inode, struct iatt *stbuf,
-                 dict_t *xattr, struct iatt *postparent)
+dht_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, inode_t *inode,
+                 struct iatt *stbuf, dict_t *xattr, struct iatt *postparent)
 {
     dht_local_t *local = NULL;
     int this_call_cnt = 0;
@@ -1003,7 +1006,7 @@ dht_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     layout = local->layout;
 
     /* Check if the gfid is different for file from other node */
-    if (!op_ret && gf_uuid_compare(local->gfid, stbuf->ia_gfid)) {
+    if (IS_SUCCESS(op_ret) && gf_uuid_compare(local->gfid, stbuf->ia_gfid)) {
         gf_uuid_unparse(stbuf->ia_gfid, gfid_node);
         gf_uuid_unparse(local->gfid, gfid_local);
 
@@ -1027,7 +1030,7 @@ dht_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                    "%s: failed to merge layouts for subvol %s", local->loc.path,
                    prev->name);
 
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             gf_msg_debug(this->name, op_errno,
                          "lookup of %s on %s returned error", local->loc.path,
@@ -1060,7 +1063,7 @@ dht_discover_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
             }
         }
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
 
         if (local->xattr == NULL) {
             local->xattr = dict_ref(xattr);
@@ -1244,7 +1247,7 @@ dht_do_discover(call_frame_t *frame, xlator_t *this, loc_t *loc)
     return 0;
 
 err:
-    DHT_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL, NULL);
 
     return 0;
 }
@@ -1350,8 +1353,8 @@ is_permission_different(ia_prot_t *prot1, ia_prot_t *prot2)
 
 int
 dht_lookup_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, inode_t *inode, struct iatt *stbuf,
-                   dict_t *xattr, struct iatt *postparent)
+                   gf_return_t op_ret, int op_errno, inode_t *inode,
+                   struct iatt *stbuf, dict_t *xattr, struct iatt *postparent)
 {
     dht_local_t *local = NULL;
     dht_conf_t *conf = NULL;
@@ -1379,10 +1382,10 @@ dht_lookup_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     layout = local->layout;
     gf_msg_debug(this->name, op_errno,
                  "%s: lookup on %s returned with op_ret = %d, op_errno = %d",
-                 local->loc.path, prev->name, op_ret, op_errno);
+                 local->loc.path, prev->name, GET_RET(op_ret), op_errno);
 
     /* The first successful lookup*/
-    if (!op_ret && gf_uuid_is_null(local->gfid)) {
+    if (IS_SUCCESS(op_ret) && gf_uuid_is_null(local->gfid)) {
         memcpy(local->gfid, stbuf->ia_gfid, 16);
     }
     if (!gf_uuid_is_null(local->gfid)) {
@@ -1390,7 +1393,7 @@ dht_lookup_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* Check if the gfid is different for file from other node */
-    if (!op_ret && gf_uuid_compare(local->gfid, stbuf->ia_gfid)) {
+    if (IS_SUCCESS(op_ret) && gf_uuid_compare(local->gfid, stbuf->ia_gfid)) {
         gf_uuid_unparse(stbuf->ia_gfid, gfid_node);
 
         gf_msg(this->name, GF_LOG_WARNING, 0, DHT_MSG_GFID_MISMATCH,
@@ -1407,7 +1410,7 @@ dht_lookup_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         */
         ret = dht_layout_merge(this, layout, prev, op_ret, op_errno, xattr);
 
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
 
             /* The GFID is missing on this subvol. Force a heal. */
@@ -1428,7 +1431,7 @@ dht_lookup_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             goto unlock;
         }
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
         if (local->xattr == NULL) {
             local->xattr = dict_ref(xattr);
         } else {
@@ -1543,7 +1546,7 @@ unlock:
             return 0;
         }
 
-        if (local->op_ret == 0) {
+        if (IS_SUCCESS(local->op_ret)) {
             if (dht_needs_selfheal(frame, this)) {
                 goto selfheal;
             }
@@ -1628,15 +1631,15 @@ dht_lookup_directory(call_frame_t *frame, xlator_t *this, loc_t *loc)
     }
     return 0;
 unwind:
-    DHT_STACK_UNWIND(lookup, frame, -1, ENOMEM, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(lookup, frame, gf_error, ENOMEM, NULL, NULL, NULL, NULL);
 out:
     return 0;
 }
 
 int
 dht_revalidate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, inode_t *inode, struct iatt *stbuf,
-                   dict_t *xattr, struct iatt *postparent)
+                   gf_return_t op_ret, int op_errno, inode_t *inode,
+                   struct iatt *stbuf, dict_t *xattr, struct iatt *postparent)
 {
     dht_local_t *local = NULL;
     int this_call_cnt = 0;
@@ -1678,7 +1681,7 @@ dht_revalidate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     gf_msg_debug(this->name, op_errno,
                  "%s: revalidate lookup on %s returned op_ret %d",
-                 local->loc.path, prev->name, op_ret);
+                 local->loc.path, prev->name, GET_RET(op_ret));
 
     LOCK(&frame->lock);
     {
@@ -1686,7 +1689,7 @@ dht_revalidate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             memcpy(local->gfid, local->loc.gfid, 16);
         }
 
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
 
             if ((op_errno != ENOTCONN) && (op_errno != ENOENT) &&
@@ -1749,7 +1752,7 @@ dht_revalidate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                    (stbuf->ia_type), (local->inode->ia_type), local->loc.path,
                    gfid);
 
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = EINVAL;
 
             goto unlock;
@@ -1847,7 +1850,7 @@ dht_revalidate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         dht_iatt_merge(this, &local->stbuf, stbuf);
         dht_iatt_merge(this, &local->postparent, postparent);
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
 
         if (!local->xattr) {
             local->xattr = dict_ref(xattr);
@@ -1866,7 +1869,7 @@ unlock:
         subvol = dht_linkfile_subvol(this, inode, stbuf, xattr);
         if (!subvol) {
             op_errno = ESTALE;
-            local->op_ret = -1;
+            local->op_ret = gf_error;
         } else {
             STACK_WIND_COOKIE(frame, dht_lookup_linkfile_cbk, subvol, subvol,
                               subvol->fops->lookup, &local->loc,
@@ -1944,7 +1947,7 @@ unlock:
             return 0;
         }
         if (local->return_estale) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = ESTALE;
         }
 
@@ -1964,7 +1967,7 @@ unlock:
          * active in the cluster do not have layouts on disk.
          * Unwind with ESTALE to trigger a fresh lookup */
         if (is_dir && local->stbuf.ia_type == IA_INVAL) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = ESTALE;
         }
         /* Delete mds xattr at the time of STACK UNWIND */
@@ -1982,9 +1985,10 @@ err:
 
 static int
 dht_lookup_linkfile_create_cbk(call_frame_t *frame, void *cooie, xlator_t *this,
-                               int32_t op_ret, int32_t op_errno, inode_t *inode,
-                               struct iatt *stbuf, struct iatt *preparent,
-                               struct iatt *postparent, dict_t *xdata)
+                               gf_return_t op_ret, int32_t op_errno,
+                               inode_t *inode, struct iatt *stbuf,
+                               struct iatt *preparent, struct iatt *postparent,
+                               dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *cached_subvol = NULL;
@@ -2012,12 +2016,12 @@ dht_lookup_linkfile_create_cbk(call_frame_t *frame, void *cooie, xlator_t *this,
                      "Failed to set layout for subvolume %s, "
                      "(gfid = %s)",
                      cached_subvol ? cached_subvol->name : "<nil>", gfid);
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = EINVAL;
         goto unwind;
     }
 
-    local->op_ret = 0;
+    local->op_ret = gf_success;
     if ((local->stbuf.ia_nlink == 1) && (conf && conf->unhashed_sticky_bit)) {
         local->stbuf.ia_prot.sticky = 1;
     }
@@ -2030,7 +2034,7 @@ unwind:
     gf_msg_debug(this->name, 0,
                  "creation of linkto on hashed subvol:%s, "
                  "returned with op_ret %d and op_errno %d: %s",
-                 local->hashed_subvol->name, op_ret, op_errno,
+                 local->hashed_subvol->name, GET_RET(op_ret), op_errno,
                  uuid_utoa(local->loc.gfid));
 
     if (local->linked == _gf_true)
@@ -2048,7 +2052,7 @@ out:
 
 static int
 dht_lookup_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, struct iatt *preparent,
+                      gf_return_t op_ret, int op_errno, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata)
 {
     int this_call_cnt = 0;
@@ -2062,7 +2066,7 @@ dht_lookup_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     gf_msg(this->name, GF_LOG_INFO, 0, DHT_MSG_UNLINK_LOOKUP_INFO,
            "lookup_unlink returned with "
            "op_ret -> %d and op-errno -> %d for %s",
-           op_ret, op_errno, ((path == NULL) ? "null" : path));
+           GET_RET(op_ret), op_errno, ((path == NULL) ? "null" : path));
 
     this_call_cnt = dht_frame_return(frame);
     if (is_last_call(this_call_cnt)) {
@@ -2074,8 +2078,8 @@ dht_lookup_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int
 dht_lookup_unlink_of_false_linkto_cbk(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int op_ret, int op_errno,
-                                      struct iatt *preparent,
+                                      xlator_t *this, gf_return_t op_ret,
+                                      int op_errno, struct iatt *preparent,
                                       struct iatt *postparent, dict_t *xdata)
 {
     int this_call_cnt = 0;
@@ -2090,11 +2094,12 @@ dht_lookup_unlink_of_false_linkto_cbk(call_frame_t *frame, void *cookie,
     gf_msg(this->name, GF_LOG_INFO, 0, DHT_MSG_UNLINK_LOOKUP_INFO,
            "lookup_unlink returned with "
            "op_ret -> %d and op-errno -> %d for %s",
-           op_ret, op_errno, ((path == NULL) ? "null" : path));
+           GET_RET(op_ret), op_errno, ((path == NULL) ? "null" : path));
 
     this_call_cnt = dht_frame_return(frame);
     if (is_last_call(this_call_cnt)) {
-        if ((op_ret == 0) || ((op_errno != EBUSY) && (op_errno != ENOTCONN))) {
+        if ((IS_SUCCESS(op_ret)) ||
+            ((op_errno != EBUSY) && (op_errno != ENOTCONN))) {
             dht_lookup_everywhere_done(frame, this);
         } else {
             /*When dht_lookup_everywhere is performed, one cached
@@ -2117,7 +2122,8 @@ dht_lookup_unlink_of_false_linkto_cbk(call_frame_t *frame, void *cookie,
                        "is set for %s",
                        ((path == NULL) ? "null" : path));
             }
-            DHT_STACK_UNWIND(lookup, frame, -1, EIO, NULL, NULL, NULL, NULL);
+            DHT_STACK_UNWIND(lookup, frame, gf_error, EIO, NULL, NULL, NULL,
+                             NULL);
         }
     }
 
@@ -2126,8 +2132,8 @@ dht_lookup_unlink_of_false_linkto_cbk(call_frame_t *frame, void *cookie,
 
 static int
 dht_lookup_unlink_stale_linkto_cbk(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int op_ret, int op_errno,
-                                   struct iatt *preparent,
+                                   xlator_t *this, gf_return_t op_ret,
+                                   int op_errno, struct iatt *preparent,
                                    struct iatt *postparent, dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -2150,9 +2156,9 @@ dht_lookup_unlink_stale_linkto_cbk(call_frame_t *frame, void *cookie,
     gf_msg(this->name, GF_LOG_INFO, 0, DHT_MSG_UNLINK_LOOKUP_INFO,
            "Returned with op_ret %d and "
            "op_errno %d for %s",
-           op_ret, op_errno, ((path == NULL) ? "null" : path));
+           GET_RET(op_ret), op_errno, ((path == NULL) ? "null" : path));
 
-    DHT_STACK_UNWIND(lookup, frame, -1, ENOENT, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(lookup, frame, gf_error, ENOENT, NULL, NULL, NULL, NULL);
 
     return 0;
 }
@@ -2190,8 +2196,9 @@ err:
 
 static int32_t
 dht_linkfile_create_lookup_cbk(call_frame_t *frame, void *cookie,
-                               xlator_t *this, int32_t op_ret, int32_t op_errno,
-                               inode_t *inode, struct iatt *buf, dict_t *xdata,
+                               xlator_t *this, gf_return_t op_ret,
+                               int32_t op_errno, inode_t *inode,
+                               struct iatt *buf, dict_t *xdata,
                                struct iatt *postparent)
 {
     dht_local_t *local = NULL;
@@ -2206,7 +2213,7 @@ dht_linkfile_create_lookup_cbk(call_frame_t *frame, void *cookie,
     local = frame->local;
 
     if (subvol == local->hashed_subvol) {
-        if ((op_ret == 0) || (op_errno != ENOENT))
+        if ((IS_SUCCESS(op_ret)) || (op_errno != ENOENT))
             local->dont_create_linkto = _gf_true;
     } else {
         if (gf_uuid_is_null(local->gfid))
@@ -2214,7 +2221,7 @@ dht_linkfile_create_lookup_cbk(call_frame_t *frame, void *cookie,
         else
             gf_uuid_copy(gfid, local->gfid);
 
-        if ((op_ret == 0) && gf_uuid_compare(gfid, buf->ia_gfid)) {
+        if ((IS_SUCCESS(op_ret)) && gf_uuid_compare(gfid, buf->ia_gfid)) {
             gf_uuid_unparse(gfid, gfid_str);
             gf_msg_debug(this->name, 0,
                          "gfid (%s) different on cached subvol "
@@ -2222,7 +2229,7 @@ dht_linkfile_create_lookup_cbk(call_frame_t *frame, void *cookie,
                          "creating linkto",
                          uuid_utoa(buf->ia_gfid), subvol->name, gfid_str);
             local->dont_create_linkto = _gf_true;
-        } else if (op_ret == -1) {
+        } else if (IS_ERROR(op_ret)) {
             local->dont_create_linkto = _gf_true;
         }
     }
@@ -2256,15 +2263,16 @@ no_linkto:
                  local->loc.path, gfid_str, local->hashed_subvol->name,
                  local->cached_subvol->name);
 
-    dht_lookup_linkfile_create_cbk(frame, NULL, this, 0, 0, local->loc.inode,
-                                   &local->stbuf, &local->preparent,
-                                   &local->postparent, local->xattr);
+    op_ret = gf_success;
+    dht_lookup_linkfile_create_cbk(
+        frame, NULL, this, op_ret, 0, local->loc.inode, &local->stbuf,
+        &local->preparent, &local->postparent, local->xattr);
     return 0;
 }
 
 static int32_t
 dht_call_lookup_linkfile_create(call_frame_t *frame, void *cookie,
-                                xlator_t *this, int32_t op_ret,
+                                xlator_t *this, gf_return_t op_ret,
                                 int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -2278,7 +2286,7 @@ dht_call_lookup_linkfile_create(call_frame_t *frame, void *cookie,
     else
         gf_uuid_unparse(local->gfid, gfid);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_WARNING,
                "protecting namespace failed, skipping linkto "
                "creation (path:%s)(gfid:%s)(hashed-subvol:%s)"
@@ -2302,9 +2310,11 @@ dht_call_lookup_linkfile_create(call_frame_t *frame, void *cookie,
     return 0;
 
 err:
-    dht_lookup_linkfile_create_cbk(frame, NULL, this, 0, 0, local->loc.inode,
-                                   &local->stbuf, &local->preparent,
-                                   &local->postparent, local->xattr);
+
+    op_ret = gf_success;
+    dht_lookup_linkfile_create_cbk(
+        frame, NULL, this, op_ret, 0, local->loc.inode, &local->stbuf,
+        &local->preparent, &local->postparent, local->xattr);
     return 0;
 }
 
@@ -2371,12 +2381,12 @@ dht_lookup_everywhere_done(call_frame_t *frame, xlator_t *this)
                "subvolume and directory on another. "
                "Please fix it manually",
                local->loc.path, gfid);
-        DHT_STACK_UNWIND(lookup, frame, -1, EIO, NULL, NULL, NULL, NULL);
+        DHT_STACK_UNWIND(lookup, frame, gf_error, EIO, NULL, NULL, NULL, NULL);
         return 0;
     }
-    if (local->op_ret && local->gfid_missing) {
+    if (IS_ERROR(local->op_ret) && local->gfid_missing) {
         if (gf_uuid_is_null(local->gfid_req)) {
-            DHT_STACK_UNWIND(lookup, frame, -1, ENODATA, NULL, NULL, NULL,
+            DHT_STACK_UNWIND(lookup, frame, gf_error, ENODATA, NULL, NULL, NULL,
                              NULL);
             return 0;
         }
@@ -2428,8 +2438,8 @@ dht_lookup_everywhere_done(call_frame_t *frame, xlator_t *this)
                  * loss because of the above mentioned race.
                  */
 
-                DHT_STACK_UNWIND(lookup, frame, -1, ENOENT, NULL, NULL, NULL,
-                                 NULL);
+                DHT_STACK_UNWIND(lookup, frame, gf_error, ENOENT, NULL, NULL,
+                                 NULL, NULL);
             } else {
                 local->skip_unlink.handle_valid_link = _gf_false;
 
@@ -2450,7 +2460,8 @@ dht_lookup_everywhere_done(call_frame_t *frame, xlator_t *this)
                          "unlink on hashed is not skipped %s",
                          local->loc.path);
 
-            DHT_STACK_UNWIND(lookup, frame, -1, ENOENT, NULL, NULL, NULL, NULL);
+            DHT_STACK_UNWIND(lookup, frame, gf_error, ENOENT, NULL, NULL, NULL,
+                             NULL);
         }
         return 0;
     }
@@ -2487,8 +2498,8 @@ dht_lookup_everywhere_done(call_frame_t *frame, xlator_t *this)
                 if (gf_uuid_compare(local->skip_unlink.cached_gfid,
                                     local->skip_unlink.hashed_gfid)) {
                     /*GFID different, return error*/
-                    DHT_STACK_UNWIND(lookup, frame, -1, ESTALE, NULL, NULL,
-                                     NULL, NULL);
+                    DHT_STACK_UNWIND(lookup, frame, gf_error, ESTALE, NULL,
+                                     NULL, NULL, NULL);
 
                     return 0;
                 }
@@ -2502,14 +2513,14 @@ dht_lookup_everywhere_done(call_frame_t *frame, xlator_t *this)
                            cached_subvol->name);
                 }
 
-                local->op_ret = (ret == 0) ? ret : -1;
+                SET_RET(local->op_ret, ((ret == 0) ? ret : -1));
                 local->op_errno = (ret == 0) ? ret : EINVAL;
 
                 /* Presence of local->cached_subvol validates
                  * that lookup from cached node is successful
                  */
 
-                if (!local->op_ret && local->loc.parent) {
+                if (IS_SUCCESS(local->op_ret) && local->loc.parent) {
                     dht_inode_ctx_time_update(local->loc.parent, this,
                                               &local->postparent, 1);
                 }
@@ -2542,8 +2553,8 @@ dht_lookup_everywhere_done(call_frame_t *frame, xlator_t *this)
                         local->xattr_req);
 
                     if (ret) {
-                        DHT_STACK_UNWIND(lookup, frame, -1, EIO, NULL, NULL,
-                                         NULL, NULL);
+                        DHT_STACK_UNWIND(lookup, frame, gf_error, EIO, NULL,
+                                         NULL, NULL, NULL);
                     } else {
                         local->call_cnt = 1;
                         FRAME_SU_DO(frame, dht_local_t);
@@ -2564,13 +2575,13 @@ preset_layout:
         if (local->need_lookup_everywhere) {
             if (gf_uuid_compare(local->gfid, local->inode->gfid)) {
                 /* GFID different, return error */
-                DHT_STACK_UNWIND(lookup, frame, -1, ENOENT, NULL, NULL, NULL,
-                                 NULL);
+                DHT_STACK_UNWIND(lookup, frame, gf_error, ENOENT, NULL, NULL,
+                                 NULL, NULL);
                 return 0;
             }
         }
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
         local->op_errno = 0;
         layout = dht_layout_for_subvol(this, cached_subvol);
         if (!layout) {
@@ -2609,7 +2620,7 @@ preset_layout:
                      "hashed subvolume cannot be found, gfid = %s.",
                      local->loc.path, cached_subvol->name, gfid);
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
         local->op_errno = 0;
 
         ret = dht_layout_preset(frame->this, cached_subvol, local->inode);
@@ -2618,7 +2629,7 @@ preset_layout:
                    "Failed to set layout for subvol %s"
                    ", gfid = %s",
                    cached_subvol ? cached_subvol->name : "<nil>", gfid);
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = EINVAL;
         }
 
@@ -2664,7 +2675,7 @@ unwind_hashed_and_cached:
 
 static int
 dht_lookup_everywhere_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, inode_t *inode,
+                          gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                           struct iatt *buf, dict_t *xattr,
                           struct iatt *postparent)
 {
@@ -2696,11 +2707,11 @@ dht_lookup_everywhere_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     gf_msg_debug(this->name, 0,
                  "returned with op_ret %d and op_errno %d (%s) "
                  "from subvol %s",
-                 op_ret, op_errno, loc->path, prev->name);
+                 GET_RET(op_ret), op_errno, loc->path, prev->name);
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             if (op_errno != ENOENT)
                 local->op_errno = op_errno;
             if (op_errno == ENODATA)
@@ -2891,14 +2902,14 @@ dht_lookup_everywhere(call_frame_t *frame, xlator_t *this, loc_t *loc)
 
     return 0;
 out:
-    DHT_STACK_UNWIND(lookup, frame, -1, EINVAL, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(lookup, frame, gf_error, EINVAL, NULL, NULL, NULL, NULL);
 err:
     return -1;
 }
 
 int
 dht_lookup_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, inode_t *inode,
+                        gf_return_t op_ret, int op_errno, inode_t *inode,
                         struct iatt *stbuf, dict_t *xattr,
                         struct iatt *postparent)
 {
@@ -2924,7 +2935,7 @@ dht_lookup_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     gf_uuid_unparse(loc->gfid, gfid);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, op_errno, DHT_MSG_LINK_FILE_LOOKUP_INFO,
                "Lookup of %s on %s (following linkfile) failed "
                ",gfid = %s",
@@ -2976,7 +2987,7 @@ dht_lookup_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                "Failed to set layout for subvolume %s,"
                "gfid = %s",
                prev->name, gfid);
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
     }
 
@@ -3049,9 +3060,9 @@ out:
 }
 
 int
-dht_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, inode_t *inode, struct iatt *stbuf, dict_t *xattr,
-               struct iatt *postparent)
+dht_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, inode_t *inode,
+               struct iatt *stbuf, dict_t *xattr, struct iatt *postparent)
 {
     char is_linkfile = 0;
     char is_dir = 0;
@@ -3077,9 +3088,9 @@ dht_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     gf_msg_debug(this->name, op_errno,
                  "%s: fresh_lookup on %s returned with op_ret %d", loc->path,
-                 prev->name, op_ret);
+                 prev->name, GET_RET(op_ret));
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (ENTRY_MISSING(op_ret, op_errno)) {
             if (1 == conf->subvolume_cnt) {
                 /* No need to lookup again */
@@ -3151,7 +3162,7 @@ dht_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
             gf_msg(this->name, GF_LOG_INFO, 0, DHT_MSG_LAYOUT_PRESET_FAILED,
                    "%s: could not set pre-set layout for subvolume %s",
                    loc->path, prev->name);
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = EINVAL;
             goto out;
         }
@@ -3185,7 +3196,7 @@ out:
      * from each of the subvolume. See dht_iatt_merge for reference.
      */
 
-    if (!op_ret && local && local->loc.parent) {
+    if (IS_SUCCESS(op_ret) && local && local->loc.parent) {
         dht_inode_ctx_time_update(local->loc.parent, this, postparent, 1);
     }
 
@@ -3371,7 +3382,7 @@ dht_do_fresh_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc)
     return 0;
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL, NULL);
     return 0;
 }
 
@@ -3484,7 +3495,7 @@ dht_do_revalidate(call_frame_t *frame, xlator_t *this, loc_t *loc)
     return 0;
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL, NULL);
     return 0;
 }
 
@@ -3584,14 +3595,15 @@ dht_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr_req)
     return 0;
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL, NULL);
     return 0;
 }
 
 static int
 dht_unlink_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, struct iatt *preparent,
-                        struct iatt *postparent, dict_t *xdata)
+                        gf_return_t op_ret, int op_errno,
+                        struct iatt *preparent, struct iatt *postparent,
+                        dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *prev = NULL;
@@ -3601,7 +3613,7 @@ dht_unlink_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     LOCK(&frame->lock);
     {
-        if ((op_ret == -1) &&
+        if ((IS_ERROR(op_ret)) &&
             !((op_errno == ENOENT) || (op_errno == ENOTCONN))) {
             local->op_errno = op_errno;
             UNLOCK(&frame->lock);
@@ -3610,7 +3622,7 @@ dht_unlink_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             goto post_unlock;
         }
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
     }
     UNLOCK(&frame->lock);
 post_unlock:
@@ -3623,9 +3635,9 @@ post_unlock:
 }
 
 static int
-dht_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, struct iatt *preparent, struct iatt *postparent,
-               dict_t *xdata)
+dht_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, struct iatt *preparent,
+               struct iatt *postparent, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *prev = NULL;
@@ -3636,12 +3648,12 @@ dht_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             if (op_errno != ENOENT) {
-                local->op_ret = -1;
+                local->op_ret = gf_error;
                 local->op_errno = op_errno;
             } else {
-                local->op_ret = 0;
+                local->op_ret = gf_success;
             }
             UNLOCK(&frame->lock);
             gf_msg_debug(this->name, op_errno,
@@ -3649,7 +3661,7 @@ dht_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
             goto post_unlock;
         }
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
 
         local->postparent = *postparent;
         local->preparent = *preparent;
@@ -3663,7 +3675,7 @@ dht_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     }
     UNLOCK(&frame->lock);
 post_unlock:
-    if (!local->op_ret) {
+    if (IS_SUCCESS(local->op_ret)) {
         hashed_subvol = dht_subvol_get_hashed(this, &local->loc);
         if (hashed_subvol && hashed_subvol != local->cached_subvol) {
             /*
@@ -3688,7 +3700,7 @@ post_unlock:
 
 static int
 dht_common_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     DHT_STACK_UNWIND(setxattr, frame, op_ret, op_errno, xdata);
     return 0;
@@ -3696,12 +3708,12 @@ dht_common_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int
 dht_fix_layout_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                            gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     dht_layout_t *layout = NULL;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         /* update the layout in the inode ctx */
         local = frame->local;
         layout = local->selfheal.layout;
@@ -3714,8 +3726,8 @@ dht_fix_layout_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 }
 
 static int
-dht_err_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-            int op_errno, dict_t *xdata)
+dht_err_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int this_call_cnt = 0;
@@ -3726,7 +3738,7 @@ dht_err_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             UNLOCK(&frame->lock);
             gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -3734,7 +3746,7 @@ dht_err_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
             goto post_unlock;
         }
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
     }
     UNLOCK(&frame->lock);
 post_unlock:
@@ -3787,7 +3799,7 @@ dht_dict_set_array(dict_t *dict, char *key, int32_t value[], int32_t size)
 
 static int
 dht_common_mds_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, dict_t *dict,
+                           gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                            dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -3795,30 +3807,31 @@ dht_common_mds_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret)
+    if (IS_ERROR(op_ret))
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
                      prev->this->name);
 
+    op_ret = gf_success;
     if (local->fop == GF_FOP_SETXATTR) {
-        DHT_STACK_UNWIND(setxattr, frame, 0, op_errno, local->xdata);
+        DHT_STACK_UNWIND(setxattr, frame, op_ret, op_errno, local->xdata);
         /* 'local' itself may not be valid after this */
         goto out;
     }
 
     if (local->fop == GF_FOP_FSETXATTR) {
-        DHT_STACK_UNWIND(fsetxattr, frame, 0, op_errno, local->xdata);
+        DHT_STACK_UNWIND(fsetxattr, frame, op_ret, op_errno, local->xdata);
         /* 'local' itself may not be valid after this */
         goto out;
     }
 
     if (local->fop == GF_FOP_REMOVEXATTR) {
-        DHT_STACK_UNWIND(removexattr, frame, 0, op_errno, NULL);
+        DHT_STACK_UNWIND(removexattr, frame, op_ret, op_errno, NULL);
         /* 'local' itself may not be valid after this */
         goto out;
     }
 
     if (local->fop == GF_FOP_FREMOVEXATTR) {
-        DHT_STACK_UNWIND(fremovexattr, frame, 0, op_errno, NULL);
+        DHT_STACK_UNWIND(fremovexattr, frame, op_ret, op_errno, NULL);
     }
 
 out:
@@ -3830,7 +3843,7 @@ out:
 */
 static int
 dht_setxattr_non_mds_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int op_ret, int op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int this_call_cnt = 0;
@@ -3846,7 +3859,7 @@ dht_setxattr_non_mds_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     LOCK(&frame->lock);
     {
-        if (op_ret && !local->op_ret) {
+        if (IS_ERROR(op_ret) && IS_SUCCESS(local->op_ret)) {
             local->op_ret = op_ret;
             local->op_errno = op_errno;
             UNLOCK(&frame->lock);
@@ -3860,7 +3873,7 @@ post_unlock:
     this_call_cnt = dht_frame_return(frame);
 
     if (is_last_call(this_call_cnt)) {
-        if (!local->op_ret) {
+        if (IS_SUCCESS(local->op_ret)) {
             xattrop = dict_new();
             if (!xattrop) {
                 gf_msg(this->name, GF_LOG_ERROR, DHT_MSG_NO_MEMORY, 0,
@@ -3886,26 +3899,27 @@ post_unlock:
                            GF_XATTROP_ADD_ARRAY, xattrop, NULL);
             }
         } else {
+            op_ret = gf_success;
             if (local->fop == GF_FOP_SETXATTR) {
-                DHT_STACK_UNWIND(setxattr, frame, 0, 0, local->xdata);
+                DHT_STACK_UNWIND(setxattr, frame, op_ret, 0, local->xdata);
                 /* 'local' itself may not be valid after this */
                 goto just_return;
             }
 
             if (local->fop == GF_FOP_FSETXATTR) {
-                DHT_STACK_UNWIND(fsetxattr, frame, 0, 0, local->xdata);
+                DHT_STACK_UNWIND(fsetxattr, frame, op_ret, 0, local->xdata);
                 /* 'local' itself may not be valid after this */
                 goto just_return;
             }
 
             if (local->fop == GF_FOP_REMOVEXATTR) {
-                DHT_STACK_UNWIND(removexattr, frame, 0, 0, NULL);
+                DHT_STACK_UNWIND(removexattr, frame, op_ret, 0, NULL);
                 /* 'local' itself may not be valid after this */
                 goto just_return;
             }
 
             if (local->fop == GF_FOP_FREMOVEXATTR) {
-                DHT_STACK_UNWIND(fremovexattr, frame, 0, 0, NULL);
+                DHT_STACK_UNWIND(fremovexattr, frame, op_ret, 0, NULL);
                 /* 'local' itself may not be valid after this */
                 goto just_return;
             }
@@ -3913,26 +3927,27 @@ post_unlock:
     }
 out:
     if (ret) {
+        op_ret = gf_success;
         if (local->fop == GF_FOP_SETXATTR) {
-            DHT_STACK_UNWIND(setxattr, frame, 0, 0, local->xdata);
+            DHT_STACK_UNWIND(setxattr, frame, op_ret, 0, local->xdata);
             /* 'local' itself may not be valid after this */
             goto just_return;
         }
 
         if (local->fop == GF_FOP_FSETXATTR) {
-            DHT_STACK_UNWIND(fsetxattr, frame, 0, 0, local->xdata);
+            DHT_STACK_UNWIND(fsetxattr, frame, op_ret, 0, local->xdata);
             /* 'local' itself may not be valid after this */
             goto just_return;
         }
 
         if (local->fop == GF_FOP_REMOVEXATTR) {
-            DHT_STACK_UNWIND(removexattr, frame, 0, 0, NULL);
+            DHT_STACK_UNWIND(removexattr, frame, op_ret, 0, NULL);
             /* 'local' itself may not be valid after this */
             goto just_return;
         }
 
         if (local->fop == GF_FOP_FREMOVEXATTR) {
-            DHT_STACK_UNWIND(fremovexattr, frame, 0, 0, NULL);
+            DHT_STACK_UNWIND(fremovexattr, frame, op_ret, 0, NULL);
         }
     }
 just_return:
@@ -3943,7 +3958,7 @@ just_return:
 
 static int
 dht_setxattr_mds_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     dht_conf_t *conf = NULL;
@@ -3956,7 +3971,7 @@ dht_setxattr_mds_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     conf = this->private;
     mds_subvol = local->mds_subvol;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -3964,7 +3979,7 @@ dht_setxattr_mds_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    local->op_ret = 0;
+    local->op_ret = gf_success;
     local->call_cnt = conf->subvolume_cnt - 1;
     local->xdata = dict_ref(xdata);
 
@@ -4030,7 +4045,8 @@ just_return:
 
 static int
 dht_xattrop_mds_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, dict_t *dict, dict_t *xdata)
+                    gf_return_t op_ret, int op_errno, dict_t *dict,
+                    dict_t *xdata)
 {
     dht_local_t *local = NULL;
     call_frame_t *prev = NULL;
@@ -4038,7 +4054,7 @@ dht_xattrop_mds_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
         local->op_ret = op_ret;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -4152,7 +4168,7 @@ dht_vgetxattr_alloc_and_fill(dht_local_t *local, dict_t *xattr, xlator_t *this,
     if (ret) {
         gf_msg(this->name, GF_LOG_ERROR, op_errno, DHT_MSG_GET_XATTR_FAILED,
                "Subvolume %s returned -1", this->name);
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
         goto out;
     }
@@ -4182,7 +4198,7 @@ dht_vgetxattr_alloc_and_fill(dht_local_t *local, dict_t *xattr, xlator_t *this,
 
     (void)strcat(local->xattr_val, value);
     (void)strcat(local->xattr_val, " ");
-    local->op_ret = 0;
+    local->op_ret = gf_success;
 
     ret = 0;
 
@@ -4248,7 +4264,7 @@ out:
 
 static int
 dht_find_local_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int op_ret, int op_errno, dict_t *xattr,
+                          gf_return_t op_ret, int op_errno, dict_t *xattr,
                           dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -4284,8 +4300,8 @@ dht_find_local_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     LOCK(&frame->lock);
     {
         this_call_cnt = --local->call_cnt;
-        if (op_ret < 0) {
-            local->op_ret = -1;
+        if (IS_ERROR(op_ret)) {
+            local->op_ret = gf_error;
             local->op_errno = op_errno;
             UNLOCK(&frame->lock);
             if (op_errno == ENODATA)
@@ -4301,7 +4317,7 @@ dht_find_local_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         if (ret < 0) {
             gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_DICT_GET_FAILED,
                    "Failed to get %s", local->xsel);
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = EINVAL;
             goto unlock;
         }
@@ -4319,7 +4335,7 @@ dht_find_local_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
              uuid_str = next_uuid_str) {
             next_uuid_str = strtok_r(NULL, " ", &saveptr);
             if (gf_uuid_parse(uuid_str, node_uuid)) {
-                local->op_ret = -1;
+                local->op_ret = gf_error;
                 local->op_errno = EINVAL;
                 UNLOCK(&frame->lock);
                 gf_msg(this->name, GF_LOG_ERROR, 0, DHT_MSG_UUID_PARSE_ERROR,
@@ -4348,7 +4364,7 @@ dht_find_local_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
 
         if (!found) {
-            local->op_ret = 0;
+            local->op_ret = gf_success;
             goto unlock;
         }
 
@@ -4378,18 +4394,19 @@ dht_find_local_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    local->op_ret = 0;
+    local->op_ret = gf_success;
 unlock:
     UNLOCK(&frame->lock);
 post_unlock:
     if (!is_last_call(this_call_cnt))
         goto out;
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         goto unwind;
     }
 
-    DHT_STACK_UNWIND(getxattr, frame, 0, 0, xattr, xdata);
+    op_ret = gf_success;
+    DHT_STACK_UNWIND(getxattr, frame, op_ret, 0, xattr, xdata);
     goto out;
 
 unwind:
@@ -4397,7 +4414,7 @@ unwind:
     GF_FREE(conf->local_nodeuuids[index].elements);
     conf->local_nodeuuids[index].elements = NULL;
 
-    DHT_STACK_UNWIND(getxattr, frame, -1, local->op_errno, NULL, xdata);
+    DHT_STACK_UNWIND(getxattr, frame, gf_error, local->op_errno, NULL, xdata);
 out:
     GF_FREE(uuid_list_copy);
     return 0;
@@ -4405,7 +4422,8 @@ out:
 
 static int
 dht_vgetxattr_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, dict_t *xattr, dict_t *xdata)
+                      gf_return_t op_ret, int op_errno, dict_t *xattr,
+                      dict_t *xdata)
 {
     int ret = 0;
     dht_local_t *local = NULL;
@@ -4420,9 +4438,9 @@ dht_vgetxattr_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     LOCK(&frame->lock);
     {
         this_call_cnt = --local->call_cnt;
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             if (op_errno != ENOTCONN) {
-                local->op_ret = -1;
+                local->op_ret = gf_error;
                 local->op_errno = op_errno;
                 UNLOCK(&frame->lock);
                 gf_msg(this->name, GF_LOG_ERROR, op_errno,
@@ -4449,7 +4467,7 @@ post_unlock:
 
     /* -- last call: do patch ups -- */
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         goto unwind;
     }
 
@@ -4457,11 +4475,12 @@ post_unlock:
     if (ret)
         goto unwind;
 
-    DHT_STACK_UNWIND(getxattr, frame, 0, 0, dict, xdata);
+    op_ret = gf_success;
+    DHT_STACK_UNWIND(getxattr, frame, op_ret, 0, dict, xdata);
     goto cleanup;
 
 unwind:
-    DHT_STACK_UNWIND(getxattr, frame, -1, local->op_errno, NULL, NULL);
+    DHT_STACK_UNWIND(getxattr, frame, gf_error, local->op_errno, NULL, NULL);
 cleanup:
     if (dict)
         dict_unref(dict);
@@ -4470,8 +4489,9 @@ out:
 }
 
 static int
-dht_vgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, dict_t *xattr, dict_t *xdata)
+dht_vgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, dict_t *xattr,
+                  dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int ret = 0;
@@ -4482,8 +4502,8 @@ dht_vgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     local = frame->local;
     prev = cookie;
 
-    if (op_ret < 0) {
-        local->op_ret = -1;
+    if (IS_ERROR(op_ret)) {
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, DHT_MSG_GET_XATTR_FAILED,
                "vgetxattr: Subvolume %s returned -1", prev->name);
@@ -4503,11 +4523,12 @@ dht_vgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (ret)
         goto unwind;
 
-    DHT_STACK_UNWIND(getxattr, frame, 0, 0, dict, xdata);
+    op_ret = gf_success;
+    DHT_STACK_UNWIND(getxattr, frame, op_ret, 0, dict, xdata);
     goto cleanup;
 
 unwind:
-    DHT_STACK_UNWIND(getxattr, frame, -1, local->op_errno, NULL, NULL);
+    DHT_STACK_UNWIND(getxattr, frame, gf_error, local->op_errno, NULL, NULL);
 cleanup:
     if (dict)
         dict_unref(dict);
@@ -4517,13 +4538,13 @@ cleanup:
 
 static int
 dht_linkinfo_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int op_ret, int op_errno, dict_t *xattr,
+                          gf_return_t op_ret, int op_errno, dict_t *xattr,
                           dict_t *xdata)
 {
     int ret = 0;
     char *value = NULL;
 
-    if (op_ret != -1) {
+    if (IS_SUCCESS(op_ret)) {
         ret = dict_get_str(xattr, GF_XATTR_PATHINFO_KEY, &value);
         if (!ret) {
             ret = dict_set_str(xattr, GF_XATTR_LINKINFO_KEY, value);
@@ -4539,7 +4560,8 @@ dht_linkinfo_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int
 dht_mds_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, dict_t *xattr, dict_t *xdata)
+                     gf_return_t op_ret, int op_errno, dict_t *xattr,
+                     dict_t *xdata)
 {
     dht_local_t *local = NULL;
     dht_conf_t *conf = NULL;
@@ -4551,12 +4573,12 @@ dht_mds_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     conf = this->private;
     local = frame->local;
 
-    if (!xattr || (op_ret == -1)) {
+    if (!xattr || (IS_ERROR(op_ret))) {
         local->op_ret = op_ret;
         goto out;
     }
     dict_del(xattr, conf->xattr_name);
-    local->op_ret = 0;
+    local->op_ret = gf_success;
 
     if (!local->xattr) {
         local->xattr = dict_copy_with_ref(xattr, NULL);
@@ -4567,13 +4589,13 @@ out:
                      xdata);
     return 0;
 err:
-    DHT_STACK_UNWIND(getxattr, frame, -1, EINVAL, NULL, NULL);
+    DHT_STACK_UNWIND(getxattr, frame, gf_error, EINVAL, NULL, NULL);
     return 0;
 }
 
 int
-dht_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, dict_t *xattr, dict_t *xdata)
+dht_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, dict_t *xattr, dict_t *xdata)
 {
     int this_call_cnt = 0;
     dht_local_t *local = NULL;
@@ -4596,7 +4618,7 @@ dht_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (!xattr || (op_ret == -1)) {
+        if (!xattr || (IS_ERROR(op_ret))) {
             local->op_ret = op_ret;
             goto unlock;
         }
@@ -4621,7 +4643,7 @@ dht_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
             GF_REMOVE_INTERNAL_XATTR("trusted.pgfid*", xattr);
         }
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
 
         if (!local->xattr) {
             local->xattr = dict_copy_with_ref(xattr, NULL);
@@ -4644,7 +4666,7 @@ unlock:
         /* If we have a valid xattr received from any one of the
          * subvolume, let's return it */
         if (local->xattr) {
-            local->op_ret = 0;
+            local->op_ret = gf_success;
         }
 
         DHT_STACK_UNWIND(getxattr, frame, local->op_ret, op_errno, local->xattr,
@@ -4652,13 +4674,13 @@ unlock:
     }
     return 0;
 err:
-    DHT_STACK_UNWIND(getxattr, frame, -1, EINVAL, NULL, NULL);
+    DHT_STACK_UNWIND(getxattr, frame, gf_error, EINVAL, NULL, NULL);
     return 0;
 }
 
 static int32_t
-dht_getxattr_unwind(call_frame_t *frame, int op_ret, int op_errno, dict_t *dict,
-                    dict_t *xdata)
+dht_getxattr_unwind(call_frame_t *frame, gf_return_t op_ret, int op_errno,
+                    dict_t *dict, dict_t *xdata)
 {
     DHT_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, xdata);
     return 0;
@@ -4666,8 +4688,8 @@ dht_getxattr_unwind(call_frame_t *frame, int op_ret, int op_errno, dict_t *dict,
 
 static int
 dht_getxattr_get_real_filename_cbk(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int op_ret, int op_errno,
-                                   dict_t *xattr, dict_t *xdata)
+                                   xlator_t *this, gf_return_t op_ret,
+                                   int op_errno, dict_t *xattr, dict_t *xdata)
 {
     int this_call_cnt = 0;
     dht_local_t *local = NULL;
@@ -4684,7 +4706,7 @@ dht_getxattr_get_real_filename_cbk(call_frame_t *frame, void *cookie,
             goto unlock;
         }
 
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             if (op_errno == EOPNOTSUPP) {
                 /* This subvol does not have the optimization.
                  * Better let the user know we don't support it.
@@ -4780,7 +4802,7 @@ dht_getxattr_get_real_filename(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     cnt = local->call_cnt = layout->cnt;
 
-    local->op_ret = -1;
+    local->op_ret = gf_error;
     local->op_errno = ENOATTR;
 
     for (i = 0; i < cnt; i++) {
@@ -4830,6 +4852,7 @@ dht_handle_debug_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 {
     dht_local_t *local = NULL;
     int ret = -1;
+    gf_return_t op_ret;
     int op_errno = ENODATA;
     char *value = NULL;
     loc_t file_loc = {0};
@@ -4885,7 +4908,8 @@ dht_handle_debug_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 out:
     loc_wipe(&file_loc);
-    DHT_STACK_UNWIND(getxattr, frame, ret, op_errno, local->xattr, NULL);
+    SET_RET(op_ret, ret);
+    DHT_STACK_UNWIND(getxattr, frame, op_ret, op_errno, local->xattr, NULL);
     return 0;
 }
 
@@ -4905,6 +4929,7 @@ dht_vgetxattr_subvol_status(call_frame_t *frame, xlator_t *this,
 {
     dht_local_t *local = NULL;
     int ret = -1;
+    gf_return_t op_ret;
     int op_errno = ENODATA;
     int value = DHT_VXATTR_SUBVOLS_UP;
     int i = 0;
@@ -4939,7 +4964,8 @@ dht_vgetxattr_subvol_status(call_frame_t *frame, xlator_t *this,
     ret = 0;
 
 out:
-    DHT_STACK_UNWIND(getxattr, frame, ret, op_errno, local->xattr, NULL);
+    SET_RET(op_ret, ret);
+    DHT_STACK_UNWIND(getxattr, frame, op_ret, op_errno, local->xattr, NULL);
     return 0;
 }
 
@@ -5185,7 +5211,7 @@ no_key:
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(getxattr, frame, -1, op_errno, NULL, NULL);
+    DHT_STACK_UNWIND(getxattr, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -5295,7 +5321,7 @@ dht_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *key,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(fgetxattr, frame, -1, op_errno, NULL, NULL);
+    DHT_STACK_UNWIND(fgetxattr, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -5342,14 +5368,15 @@ dht_setxattr2(xlator_t *this, xlator_t *subvol, call_frame_t *frame, int ret)
     return 0;
 
 err:
-    DHT_STACK_UNWIND(setxattr, frame, (local ? local->op_ret : -1), op_errno,
-                     NULL);
+
+    DHT_STACK_UNWIND(setxattr, frame, (local ? local->op_ret : gf_error),
+                     op_errno, NULL);
     return 0;
 }
 
 int
 dht_file_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     int ret = -1;
     dht_local_t *local = NULL;
@@ -5371,7 +5398,7 @@ dht_file_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if ((IS_ERROR(op_ret)) && !dht_inode_missing(op_errno)) {
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1.",
                      prev->name);
         goto out;
@@ -5382,7 +5409,7 @@ dht_file_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     ret = dict_get_bin(xdata, DHT_IATT_IN_XDATA_KEY, (void **)&stbuf);
 
-    if ((!op_ret) && !stbuf) {
+    if ((IS_SUCCESS(op_ret)) && !stbuf) {
         goto out;
     }
 
@@ -5392,7 +5419,7 @@ dht_file_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->rebalance.xdata = dict_ref(xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(stbuf)) {
+    if ((IS_ERROR(op_ret)) || IS_DHT_MIGRATION_PHASE2(stbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -5687,14 +5714,14 @@ dht_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xattr,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(fsetxattr, frame, -1, op_errno, NULL);
+    DHT_STACK_UNWIND(fsetxattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 static int
 dht_checking_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int op_ret, int op_errno, dict_t *xattr,
+                          gf_return_t op_ret, int op_errno, dict_t *xattr,
                           dict_t *xdata)
 {
     int i = -1;
@@ -5709,7 +5736,7 @@ dht_checking_pathinfo_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     prev = cookie;
     conf = this->private;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto out;
 
     ret = dict_get_str(xattr, GF_XATTR_PATHINFO_KEY, &value);
@@ -5733,7 +5760,7 @@ out:
 
 static int
 dht_nuke_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(setxattr, frame, op_ret, op_errno, NULL);
@@ -5744,14 +5771,14 @@ static int
 dht_nuke_dir(call_frame_t *frame, xlator_t *this, loc_t *loc, data_t *tmp)
 {
     if (!IA_ISDIR(loc->inode->ia_type)) {
-        DHT_STACK_UNWIND(setxattr, frame, -1, ENOTSUP, NULL);
+        DHT_STACK_UNWIND(setxattr, frame, gf_error, ENOTSUP, NULL);
         return 0;
     }
 
     /* Setxattr didn't need the parent, but rmdir does. */
     loc->parent = inode_parent(loc->inode, NULL, NULL);
     if (!loc->parent) {
-        DHT_STACK_UNWIND(setxattr, frame, -1, ENOENT, NULL);
+        DHT_STACK_UNWIND(setxattr, frame, gf_error, ENOENT, NULL);
         return 0;
     }
     gf_uuid_copy(loc->pargfid, loc->parent->gfid);
@@ -6022,7 +6049,7 @@ dht_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(setxattr, frame, -1, op_errno, NULL);
+    DHT_STACK_UNWIND(setxattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
@@ -6067,13 +6094,13 @@ dht_removexattr2(xlator_t *this, xlator_t *subvol, call_frame_t *frame, int ret)
     return 0;
 
 err:
-    DHT_STACK_UNWIND(removexattr, frame, -1, op_errno, NULL);
+    DHT_STACK_UNWIND(removexattr, frame, gf_error, op_errno, NULL);
     return 0;
 }
 
 int
 dht_file_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int op_ret, int op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     int ret = -1;
     dht_local_t *local = NULL;
@@ -6095,7 +6122,7 @@ dht_file_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if ((IS_ERROR(op_ret)) && !dht_inode_missing(op_errno)) {
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
                      prev->name);
         goto out;
@@ -6106,18 +6133,18 @@ dht_file_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     ret = dict_get_bin(xdata, DHT_IATT_IN_XDATA_KEY, (void **)&stbuf);
 
-    if ((!op_ret) && !stbuf) {
+    if ((IS_SUCCESS(op_ret)) && !stbuf) {
         goto out;
     }
 
-    local->op_ret = 0;
+    local->op_ret = gf_success;
 
     local->rebalance.target_op_fn = dht_removexattr2;
     if (xdata)
         local->rebalance.xdata = dict_ref(xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(stbuf)) {
+    if ((IS_ERROR(op_ret)) || IS_DHT_MIGRATION_PHASE2(stbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -6226,7 +6253,7 @@ dht_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(removexattr, frame, -1, op_errno, NULL);
+    DHT_STACK_UNWIND(removexattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
@@ -6304,14 +6331,14 @@ dht_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *key,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(fremovexattr, frame, -1, op_errno, NULL);
+    DHT_STACK_UNWIND(fremovexattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 int
-dht_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-           int op_errno, fd_t *fd, dict_t *xdata)
+dht_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+           gf_return_t op_ret, int op_errno, fd_t *fd, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int this_call_cnt = 0;
@@ -6322,7 +6349,7 @@ dht_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             UNLOCK(&frame->lock);
             gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -6330,7 +6357,7 @@ dht_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
             goto post_unlock;
         }
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
     }
     UNLOCK(&frame->lock);
 post_unlock:
@@ -6365,8 +6392,9 @@ dht_normalize_stats(struct statvfs *buf, unsigned long bsize,
 }
 
 static int
-dht_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, struct statvfs *statvfs, dict_t *xdata)
+dht_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, struct statvfs *statvfs,
+               dict_t *xdata)
 {
     gf_boolean_t event = _gf_false;
     qdstatfs_action_t action = qdstatfs_action_OFF;
@@ -6386,16 +6414,16 @@ dht_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             goto unlock;
         }
         if (!statvfs) {
             op_errno = EINVAL;
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             goto unlock;
         }
-        local->op_ret = 0;
+        local->op_ret = gf_success;
 
         if (local->quota_deem_statfs) {
             if (event == _gf_true) {
@@ -6521,7 +6549,7 @@ dht_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(statfs, frame, -1, op_errno, NULL, NULL);
+    DHT_STACK_UNWIND(statfs, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -6602,7 +6630,7 @@ dht_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(opendir, frame, -1, op_errno, NULL, NULL);
+    DHT_STACK_UNWIND(opendir, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -6623,6 +6651,7 @@ dht_populate_inode_for_dentry(xlator_t *this, xlator_t *subvol,
 {
     dht_layout_t *layout = NULL;
     int ret = 0;
+    gf_return_t op_ret = {0};
     loc_t loc = {
         0,
     };
@@ -6643,7 +6672,7 @@ dht_populate_inode_for_dentry(xlator_t *this, xlator_t *subvol,
     if (!layout)
         goto out;
 
-    ret = dht_layout_merge(this, layout, subvol, 0, 0, orig_entry->dict);
+    ret = dht_layout_merge(this, layout, subvol, op_ret, 0, orig_entry->dict);
     if (!ret) {
         ret = dht_layout_normalize(this, &loc, layout);
         if (ret == 0) {
@@ -6665,8 +6694,9 @@ out:
  * entries
  */
 static int
-dht_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, gf_dirent_t *orig_entries, dict_t *xdata)
+dht_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, gf_dirent_t *orig_entries,
+                 dict_t *xdata)
 {
     dht_local_t *local = NULL;
     gf_dirent_t entries;
@@ -6700,7 +6730,7 @@ dht_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     methods = &(conf->methods);
 
-    if (op_ret <= 0) {
+    if (IS_ERROR(op_ret)) {
         goto done;
     }
 
@@ -6900,7 +6930,7 @@ done:
      *
      */
 
-    op_ret = count;
+    SET_RET(op_ret, count);
     if (count == 0) {
         /* non-zero next_offset means that
          * EOF is not yet hit on the current subvol
@@ -6943,8 +6973,8 @@ unwind:
      * distribute we're not concerned only with a posix's view of the
      * directory but the aggregated namespace' view of the directory.
      */
-    if (op_ret < 0)
-        op_ret = 0;
+    if (IS_ERROR(op_ret))
+        op_ret = gf_success;
 
     if (prev != dht_last_up_subvol(this))
         op_errno = 0;
@@ -6956,8 +6986,9 @@ unwind:
 }
 
 static int
-dht_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, gf_dirent_t *orig_entries, dict_t *xdata)
+dht_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, gf_dirent_t *orig_entries,
+                dict_t *xdata)
 {
     dht_local_t *local = NULL;
     gf_dirent_t entries;
@@ -6983,7 +7014,7 @@ dht_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     methods = &(conf->methods);
 
-    if (op_ret <= 0)
+    if (IS_ERROR(op_ret))
         goto done;
 
     if (!local->layout)
@@ -6996,7 +7027,7 @@ dht_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (conf->subvolume_cnt == 1) {
         /*return everything*/
         skip_hashed_check = _gf_true;
-        count = op_ret;
+        count = GET_RET(op_ret);
         goto done;
     }
 
@@ -7030,7 +7061,7 @@ dht_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         }
     }
 done:
-    op_ret = count;
+    SET_RET(op_ret, count);
     /* We need to ensure that only the last subvolume's end-of-directory
      * notification is respected so that directory reading does not stop
      * before all subvolumes have been read. That could happen because the
@@ -7105,7 +7136,7 @@ dht_do_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     local->size = size;
     local->xattr_req = (dict) ? dict_ref(dict) : NULL;
     local->first_up_subvol = dht_first_up_subvol(this);
-    local->op_ret = -1;
+    local->op_ret = gf_error;
 
     dht_deitransform(this, yoff, &xvol);
 
@@ -7162,7 +7193,7 @@ dht_do_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(readdir, frame, -1, op_errno, NULL, NULL);
+    DHT_STACK_UNWIND(readdir, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -7203,8 +7234,8 @@ dht_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 }
 
 static int
-dht_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, dict_t *xdata)
+dht_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int this_call_cnt = 0;
@@ -7213,10 +7244,10 @@ dht_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1)
+        if (IS_ERROR(op_ret))
             local->op_errno = op_errno;
-        else if (op_ret == 0)
-            local->op_ret = 0;
+        else if (IS_SUCCESS(op_ret))
+            local->op_ret = gf_success;
     }
     UNLOCK(&frame->lock);
     this_call_cnt = dht_frame_return(frame);
@@ -7261,26 +7292,27 @@ dht_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(fsyncdir, frame, -1, op_errno, NULL);
+    DHT_STACK_UNWIND(fsyncdir, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 int
-dht_newfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, inode_t *inode, struct iatt *stbuf,
-                struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+dht_newfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, inode_t *inode,
+                struct iatt *stbuf, struct iatt *preparent,
+                struct iatt *postparent, dict_t *xdata)
 {
     xlator_t *prev = NULL;
     int ret = -1;
     dht_local_t *local = NULL;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto out;
 
     local = frame->local;
     if (!local) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto out;
     }
@@ -7297,7 +7329,7 @@ dht_newfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         gf_msg_debug(this->name, EINVAL,
                      "could not set pre-set layout for subvolume %s",
                      prev ? prev->name : NULL);
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto out;
     }
@@ -7318,9 +7350,9 @@ out:
     if (local && local->lock[0].layout.parent_layout.locks) {
         /* store op_errno for failure case*/
         local->op_errno = op_errno;
-        local->refresh_layout_unlock(frame, this, op_ret, 1);
+        local->refresh_layout_unlock(frame, this, GET_RET(op_ret), 1);
 
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             DHT_STACK_UNWIND(mknod, frame, op_ret, op_errno, inode, stbuf,
                              preparent, postparent, xdata);
         }
@@ -7334,9 +7366,10 @@ out:
 
 static int
 dht_mknod_linkfile_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                              int32_t op_ret, int32_t op_errno, inode_t *inode,
-                              struct iatt *stbuf, struct iatt *preparent,
-                              struct iatt *postparent, dict_t *xdata)
+                              gf_return_t op_ret, int32_t op_errno,
+                              inode_t *inode, struct iatt *stbuf,
+                              struct iatt *preparent, struct iatt *postparent,
+                              dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *cached_subvol = NULL;
@@ -7349,7 +7382,7 @@ dht_mknod_linkfile_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto err;
     }
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
         goto err;
     }
@@ -7377,8 +7410,8 @@ err:
     if (local && local->lock[0].layout.parent_layout.locks) {
         local->refresh_layout_unlock(frame, this, -1, 1);
     } else {
-        DHT_STACK_UNWIND(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                         NULL);
+        DHT_STACK_UNWIND(mknod, frame, gf_error, op_errno, NULL, NULL, NULL,
+                         NULL, NULL);
     }
     return 0;
 }
@@ -7481,15 +7514,14 @@ err:
 
 static int32_t
 dht_mknod_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     DHT_STACK_DESTROY(frame);
     return 0;
 }
 
 static int32_t
-dht_mknod_finish(call_frame_t *frame, xlator_t *this, int op_ret,
-                 int invoke_cbk)
+dht_mknod_finish(call_frame_t *frame, xlator_t *this, int ret, int invoke_cbk)
 {
     dht_local_t *local = NULL, *lock_local = NULL;
     call_frame_t *lock_frame = NULL;
@@ -7531,9 +7563,11 @@ done:
         DHT_STACK_DESTROY(lock_frame);
     }
 
-    if (op_ret == 0)
+    if (ret == 0)
         return 0;
 
+    gf_return_t op_ret;
+    SET_RET(op_ret, ret);
     DHT_STACK_UNWIND(mknod, frame, op_ret, local->op_errno, NULL, NULL, NULL,
                      NULL, NULL);
     return 0;
@@ -7541,7 +7575,7 @@ done:
 
 static int32_t
 dht_mknod_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
 
@@ -7551,7 +7585,7 @@ dht_mknod_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto err;
     }
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg("DHT", GF_LOG_ERROR, 0, DHT_MSG_INODE_LK_ERROR,
                "mknod lock failed for file: %s", local->loc2.name);
 
@@ -7571,7 +7605,7 @@ err:
     if (local)
         dht_mknod_finish(frame, this, -1, 0);
     else
-        DHT_STACK_UNWIND(mknod, frame, -1, EINVAL, NULL, NULL, NULL, NULL,
+        DHT_STACK_UNWIND(mknod, frame, gf_error, EINVAL, NULL, NULL, NULL, NULL,
                          NULL);
     return 0;
 }
@@ -7638,10 +7672,10 @@ dht_refresh_parent_layout_resume(call_frame_t *frame, xlator_t *this, int ret,
     parent_local = parent_frame->local;
 
     if (ret < 0) {
-        parent_local->op_ret = -1;
+        parent_local->op_ret = gf_error;
         parent_local->op_errno = local->op_errno ? local->op_errno : EIO;
     } else {
-        parent_local->op_ret = 0;
+        parent_local->op_ret = gf_success;
     }
 
     call_resume(stub);
@@ -7659,7 +7693,7 @@ dht_refresh_parent_layout_done(call_frame_t *frame)
 
     local = frame->local;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         ret = -1;
         goto resume;
     }
@@ -7709,7 +7743,7 @@ dht_handle_parent_layout_change(xlator_t *this, call_stub_t *stub)
 
 static int32_t
 dht_call_mkdir_stub(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     call_stub_t *stub = NULL;
@@ -7718,11 +7752,11 @@ dht_call_mkdir_stub(call_frame_t *frame, void *cookie, xlator_t *this,
     stub = local->stub;
     local->stub = NULL;
 
-    if (op_ret < 0) {
-        local->op_ret = -1;
+    if (IS_ERROR(op_ret)) {
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
     } else {
-        local->op_ret = 0;
+        local->op_ret = gf_success;
     }
 
     call_resume(stub);
@@ -7957,7 +7991,8 @@ done:
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(mknod, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                     NULL);
 
     return 0;
 }
@@ -7997,7 +8032,8 @@ dht_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                     NULL);
 
     return 0;
 }
@@ -8036,7 +8072,7 @@ dht_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     return 0;
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(unlink, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(unlink, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
@@ -8093,9 +8129,10 @@ out:
 }
 
 static int
-dht_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-             int op_errno, inode_t *inode, struct iatt *stbuf,
-             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+dht_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int op_errno, inode_t *inode,
+             struct iatt *stbuf, struct iatt *preparent,
+             struct iatt *postparent, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int ret = -1;
@@ -8106,7 +8143,7 @@ dht_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     local = frame->local;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Remove the linkto if exists */
         if (local->linked) {
             cleanup_frame = create_frame(this, this->ctx->pool);
@@ -8213,6 +8250,7 @@ dht_link2(xlator_t *this, xlator_t *subvol, call_frame_t *frame, int ret)
 {
     dht_local_t *local = NULL;
     int op_errno = EINVAL;
+    gf_return_t op_ret;
 
     local = frame->local;
     if (!local)
@@ -8246,7 +8284,8 @@ dht_link2(xlator_t *this, xlator_t *subvol, call_frame_t *frame, int ret)
         DHT_STRIP_PHASE1_FLAGS(&local->stbuf);
         dht_set_fixed_dir_stat(&local->preparent);
         dht_set_fixed_dir_stat(&local->postparent);
-        DHT_STACK_UNWIND(link, frame, 0, 0, local->inode, &local->stbuf,
+        op_ret = gf_success;
+        DHT_STACK_UNWIND(link, frame, op_ret, 0, local->inode, &local->stbuf,
                          &local->preparent, &local->postparent, NULL);
 
         return 0;
@@ -8259,21 +8298,22 @@ dht_link2(xlator_t *this, xlator_t *subvol, call_frame_t *frame, int ret)
 
     return 0;
 err:
-    DHT_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                     NULL);
 
     return 0;
 }
 
 static int
 dht_link_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, inode_t *inode,
+                      gf_return_t op_ret, int op_errno, inode_t *inode,
                       struct iatt *stbuf, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *srcvol = NULL;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto err;
 
     local = frame->local;
@@ -8354,15 +8394,17 @@ dht_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                     NULL);
 
     return 0;
 }
 
 int
-dht_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, fd_t *fd, inode_t *inode, struct iatt *stbuf,
-               struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+dht_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, fd_t *fd, inode_t *inode,
+               struct iatt *stbuf, struct iatt *preparent,
+               struct iatt *postparent, dict_t *xdata)
 {
     xlator_t *prev = NULL;
     int ret = -1;
@@ -8375,12 +8417,12 @@ dht_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     local = frame->local;
     if (!local) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto out;
     }
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
         parent_layout_changed = (xdata &&
                                  dict_get(xdata, GF_PREOP_CHECK_FAILED))
@@ -8464,7 +8506,7 @@ dht_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (ret != 0) {
         gf_msg_debug(this->name, 0, "could not set preset layout for subvol %s",
                      prev->name);
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto out;
     }
@@ -8484,9 +8526,9 @@ out:
     if (local && local->lock[0].layout.parent_layout.locks) {
         /* store op_errno for failure case*/
         local->op_errno = op_errno;
-        local->refresh_layout_unlock(frame, this, op_ret, 1);
+        local->refresh_layout_unlock(frame, this, GET_RET(op_ret), 1);
 
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             DHT_STACK_UNWIND(create, frame, op_ret, op_errno, fd, inode, stbuf,
                              preparent, postparent, xdata);
         }
@@ -8499,10 +8541,10 @@ out:
 
 static int
 dht_create_linkfile_create_cbk(call_frame_t *frame, void *cookie,
-                               xlator_t *this, int32_t op_ret, int32_t op_errno,
-                               inode_t *inode, struct iatt *stbuf,
-                               struct iatt *preparent, struct iatt *postparent,
-                               dict_t *xdata)
+                               xlator_t *this, gf_return_t op_ret,
+                               int32_t op_errno, inode_t *inode,
+                               struct iatt *stbuf, struct iatt *preparent,
+                               struct iatt *postparent, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *cached_subvol = NULL;
@@ -8514,7 +8556,7 @@ dht_create_linkfile_create_cbk(call_frame_t *frame, void *cookie,
         goto err;
     }
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
         goto err;
     }
@@ -8542,8 +8584,8 @@ err:
     if (local && local->lock[0].layout.parent_layout.locks) {
         local->refresh_layout_unlock(frame, this, -1, 1);
     } else {
-        DHT_STACK_UNWIND(create, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                         NULL, NULL);
+        DHT_STACK_UNWIND(create, frame, gf_error, op_errno, NULL, NULL, NULL,
+                         NULL, NULL, NULL);
     }
     return 0;
 }
@@ -8710,15 +8752,14 @@ err:
 
 static int32_t
 dht_create_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     DHT_STACK_DESTROY(frame);
     return 0;
 }
 
 static int32_t
-dht_create_finish(call_frame_t *frame, xlator_t *this, int op_ret,
-                  int invoke_cbk)
+dht_create_finish(call_frame_t *frame, xlator_t *this, int ret, int invoke_cbk)
 {
     dht_local_t *local = NULL, *lock_local = NULL;
     call_frame_t *lock_frame = NULL;
@@ -8760,9 +8801,11 @@ done:
         DHT_STACK_DESTROY(lock_frame);
     }
 
-    if (op_ret == 0)
+    if (ret == 0)
         return 0;
 
+    gf_return_t op_ret;
+    SET_RET(op_ret, ret);
     DHT_STACK_UNWIND(create, frame, op_ret, local->op_errno, NULL, NULL, NULL,
                      NULL, NULL, NULL);
     return 0;
@@ -8770,7 +8813,7 @@ done:
 
 static int32_t
 dht_create_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
 
@@ -8780,7 +8823,7 @@ dht_create_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto err;
     }
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg("DHT", GF_LOG_ERROR, 0, DHT_MSG_INODE_LK_ERROR,
                "Create lock failed for file: %s", local->loc2.name);
 
@@ -8800,8 +8843,8 @@ err:
     if (local)
         dht_create_finish(frame, this, -1, 0);
     else
-        DHT_STACK_UNWIND(create, frame, -1, EINVAL, NULL, NULL, NULL, NULL,
-                         NULL, NULL);
+        DHT_STACK_UNWIND(create, frame, gf_error, EINVAL, NULL, NULL, NULL,
+                         NULL, NULL, NULL);
     return 0;
 }
 
@@ -9047,15 +9090,15 @@ done:
 err:
 
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(create, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL,
-                     NULL);
+    DHT_STACK_UNWIND(create, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                     NULL, NULL);
 
     return 0;
 }
 
 static int
 dht_mkdir_selfheal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     dht_layout_t *layout = NULL;
@@ -9067,7 +9110,7 @@ dht_mkdir_selfheal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     dht_set_fixed_dir_stat(&local->preparent);
     dht_set_fixed_dir_stat(&local->postparent);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         dht_layout_set(this, local->inode, layout);
 
         dht_inode_ctx_time_update(local->inode, this, &local->stbuf, 1);
@@ -9088,9 +9131,10 @@ dht_mkdir_selfheal_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 }
 
 static int
-dht_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, inode_t *inode, struct iatt *stbuf,
-              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+dht_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, inode_t *inode,
+              struct iatt *stbuf, struct iatt *preparent,
+              struct iatt *postparent, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int this_call_cnt = 0;
@@ -9108,10 +9152,10 @@ dht_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (subvol_filled && (op_ret != -1)) {
-            ret = dht_layout_merge(this, layout, prev, -1, ENOSPC, NULL);
+        if (subvol_filled && IS_SUCCESS(op_ret)) {
+            ret = dht_layout_merge(this, layout, prev, gf_error, ENOSPC, NULL);
         } else {
-            if (op_ret == -1 && op_errno == EEXIST) {
+            if (IS_ERROR(op_ret) && op_errno == EEXIST) {
                 /* Very likely just a race between mkdir and
                    self-heal (from lookup of a concurrent mkdir
                    attempt).
@@ -9119,7 +9163,7 @@ dht_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                    anyways fail if this was a different (old)
                    pre-existing different directory.
                 */
-                op_ret = 0;
+                op_ret = gf_success;
                 dir_exists = _gf_true;
             }
             ret = dht_layout_merge(this, layout, prev, op_ret, op_errno, NULL);
@@ -9129,7 +9173,7 @@ dht_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                    "%s: failed to merge layouts for subvol %s", local->loc.path,
                    prev->name);
 
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             goto unlock;
         }
@@ -9157,7 +9201,7 @@ unlock:
 
 static int
 dht_mkdir_hashed_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, inode_t *inode,
+                     gf_return_t op_ret, int op_errno, inode_t *inode,
                      struct iatt *stbuf, struct iatt *preparent,
                      struct iatt *postparent, dict_t *xdata);
 
@@ -9167,7 +9211,7 @@ dht_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 {
     dht_local_t *local = NULL;
     dht_conf_t *conf = NULL;
-    int op_errno = -1, ret = -1;
+    int op_errno = 1, ret = -1;
     xlator_t *hashed_subvol = NULL;
     int32_t *parent_disk_layout = NULL;
     dht_layout_t *parent_layout = NULL;
@@ -9185,7 +9229,7 @@ dht_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     conf = this->private;
     local = frame->local;
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, local->op_errno,
                DHT_MSG_PARENT_LAYOUT_CHANGED,
                "mkdir (%s/%s) (path: %s): refreshing parent layout "
@@ -9196,7 +9240,7 @@ dht_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
         goto err;
     }
 
-    local->op_ret = -1;
+    local->op_ret = gf_error;
 
     hashed_subvol = dht_subvol_get_hashed(this, loc);
     if (hashed_subvol == NULL) {
@@ -9273,7 +9317,8 @@ err:
     dht_unlock_namespace(frame, &local->lock[0]);
 
     op_errno = local ? local->op_errno : op_errno;
-    DHT_STACK_UNWIND(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                     NULL);
 
     if (parent_disk_layout != NULL)
         GF_FREE(parent_disk_layout);
@@ -9286,7 +9331,7 @@ err:
 
 static int
 dht_mkdir_hashed_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, inode_t *inode,
+                     gf_return_t op_ret, int op_errno, inode_t *inode,
                      struct iatt *stbuf, struct iatt *preparent,
                      struct iatt *postparent, dict_t *xdata)
 {
@@ -9309,10 +9354,10 @@ dht_mkdir_hashed_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     gf_uuid_unparse(local->loc.parent->gfid, pgfid);
 
-    if (gf_uuid_is_null(local->loc.gfid) && !op_ret)
+    if (gf_uuid_is_null(local->loc.gfid) && IS_SUCCESS(op_ret))
         gf_uuid_copy(local->loc.gfid, stbuf->ia_gfid);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
 
         parent_layout_changed = (xdata &&
@@ -9349,7 +9394,7 @@ dht_mkdir_hashed_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     dict_del(local->params, conf->xattr_name);
 
     if (dht_is_subvol_filled(this, hashed_subvol))
-        ret = dht_layout_merge(this, layout, prev, -1, ENOSPC, NULL);
+        ret = dht_layout_merge(this, layout, prev, gf_error, ENOSPC, NULL);
     else
         ret = dht_layout_merge(this, layout, prev, op_ret, op_errno, NULL);
 
@@ -9360,7 +9405,7 @@ dht_mkdir_hashed_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                "%s: failed to merge layouts for subvol %s", local->loc.path,
                prev->name);
 
-    local->op_ret = 0;
+    local->op_ret = gf_success;
 
     dht_iatt_merge(this, &local->stbuf, stbuf);
     dht_iatt_merge(this, &local->preparent, preparent);
@@ -9406,11 +9451,12 @@ dht_mkdir_hashed_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     return 0;
 err:
-    if (local->op_ret != 0) {
+    if (IS_ERROR(local->op_ret)) {
         dht_unlock_namespace(frame, &local->lock[0]);
     }
 
-    DHT_STACK_UNWIND(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                     NULL);
 
     return 0;
 }
@@ -9431,7 +9477,7 @@ dht_mkdir_guard_parent_layout_cbk(call_frame_t *frame, xlator_t *this,
 
     gf_uuid_unparse(loc->parent->gfid, pgfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, local->op_errno,
                DHT_MSG_PARENT_LAYOUT_CHANGED,
                "mkdir (%s/%s) (path: %s): "
@@ -9441,7 +9487,7 @@ dht_mkdir_guard_parent_layout_cbk(call_frame_t *frame, xlator_t *this,
         goto err;
     }
 
-    local->op_ret = -1;
+    local->op_ret = gf_error;
     /* Add internal MDS xattr on disk for hashed subvol
      */
     ret = dht_dict_set_array(params, conf->mds_xattr_key, zero, 1);
@@ -9458,8 +9504,8 @@ dht_mkdir_guard_parent_layout_cbk(call_frame_t *frame, xlator_t *this,
 
     return 0;
 err:
-    DHT_STACK_UNWIND(mkdir, frame, -1, local->op_errno, NULL, NULL, NULL, NULL,
-                     NULL);
+    DHT_STACK_UNWIND(mkdir, frame, gf_error, local->op_errno, NULL, NULL, NULL,
+                     NULL, NULL);
 
     return 0;
 }
@@ -9561,14 +9607,15 @@ dht_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
 err:
     op_errno = local ? local->op_errno : op_errno;
-    DHT_STACK_UNWIND(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                     NULL);
 
     return 0;
 }
 
 static int
 dht_rmdir_selfheal_cbk(call_frame_t *heal_frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     dht_local_t *heal_local = NULL;
@@ -9590,8 +9637,9 @@ dht_rmdir_selfheal_cbk(call_frame_t *heal_frame, void *cookie, xlator_t *this,
 
 static int
 dht_rmdir_hashed_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int op_ret, int op_errno, struct iatt *preparent,
-                            struct iatt *postparent, dict_t *xdata)
+                            gf_return_t op_ret, int op_errno,
+                            struct iatt *preparent, struct iatt *postparent,
+                            dict_t *xdata)
 {
     dht_local_t *local = NULL;
     dht_local_t *heal_local = NULL;
@@ -9609,9 +9657,9 @@ dht_rmdir_hashed_subvol_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             if (conf->subvolume_cnt != 1) {
                 if (op_errno != ENOENT && op_errno != EACCES &&
                     op_errno != ESTALE) {
@@ -9693,7 +9741,7 @@ err:
 
 static int
 dht_rmdir_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     DHT_STACK_DESTROY(frame);
     return 0;
@@ -9748,9 +9796,9 @@ done:
 }
 
 static int
-dht_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, struct iatt *preparent, struct iatt *postparent,
-              dict_t *xdata)
+dht_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, struct iatt *preparent,
+              struct iatt *postparent, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int this_call_cnt = 0;
@@ -9766,10 +9814,10 @@ dht_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             if ((op_errno != ENOENT) && (op_errno != ESTALE)) {
                 local->op_errno = op_errno;
-                local->op_ret = -1;
+                local->op_ret = gf_error;
 
                 if (op_errno != EACCES)
                     local->need_selfheal = 1;
@@ -9833,7 +9881,7 @@ unlock:
 
         } else if (this_call_cnt) {
             /* If non-hashed subvol's have responded, proceed */
-            if (local->op_ret == 0) {
+            if (IS_SUCCESS(local->op_ret)) {
                 /* Delete the dir from the hashed subvol if:
                  * The fop succeeded on at least one subvol
                  *  and did not fail on any
@@ -9878,13 +9926,13 @@ unlock:
     return 0;
 
 err:
-    DHT_STACK_UNWIND(rmdir, frame, -1, local->op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(rmdir, frame, gf_error, local->op_errno, NULL, NULL, NULL);
     return 0;
 }
 
 static int
 dht_rmdir_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     dht_conf_t *conf = NULL;
@@ -9894,12 +9942,12 @@ dht_rmdir_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     conf = this->private;
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, DHT_MSG_INODE_LK_ERROR,
                "acquiring entrylk after inodelk failed rmdir for %s)",
                local->loc.path);
 
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
         goto err;
     }
@@ -9937,7 +9985,7 @@ dht_rmdir_do(call_frame_t *frame, xlator_t *this)
     VALIDATE_OR_GOTO(this->private, out);
     conf = this->private;
 
-    if (local->op_ret == -1)
+    if (IS_ERROR(local->op_ret))
         goto out;
 
     local->call_cnt = conf->subvolume_cnt;
@@ -9968,7 +10016,7 @@ dht_rmdir_do(call_frame_t *frame, xlator_t *this)
     ret = dht_protect_namespace(frame, &local->loc, local->hashed_subvol,
                                 &local->current->ns, dht_rmdir_lock_cbk);
     if (ret < 0) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = errno ? errno : EINVAL;
         goto out;
     }
@@ -9983,7 +10031,7 @@ out:
                      &local->preparent, &local->postparent, NULL);
     return 0;
 err:
-    DHT_STACK_UNWIND(rmdir, frame, -1, EINVAL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(rmdir, frame, gf_error, EINVAL, NULL, NULL, NULL);
     return 0;
 }
 
@@ -10003,7 +10051,7 @@ dht_rmdir_readdirp_done(call_frame_t *readdirp_frame, xlator_t *this)
      * This is a bit hit or miss - if readdirp failed on more than
      * one subvol, we don't know which error is returned.
      */
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         main_local->op_ret = local->op_ret;
         main_local->op_errno = local->op_errno;
     }
@@ -10028,7 +10076,7 @@ dht_rmdir_readdirp_do(call_frame_t *readdirp_frame, xlator_t *this)
 
     local = readdirp_frame->local;
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         /* there is no point doing another readdirp on this
          * subvol . */
         dht_rmdir_readdirp_done(readdirp_frame, this);
@@ -10045,8 +10093,9 @@ dht_rmdir_readdirp_do(call_frame_t *readdirp_frame, xlator_t *this)
 
 static int
 dht_rmdir_linkfile_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                              int op_ret, int op_errno, struct iatt *preparent,
-                              struct iatt *postparent, dict_t *xdata)
+                              gf_return_t op_ret, int op_errno,
+                              struct iatt *preparent, struct iatt *postparent,
+                              dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *prev = NULL;
@@ -10065,12 +10114,12 @@ dht_rmdir_linkfile_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     gf_uuid_unparse(local->loc.gfid, gfid);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_msg_trace(this->name, 0, "Unlinked linkfile %s on %s, gfid = %s",
                      local->loc.path, src->name, gfid);
     } else {
         if (op_errno != ENOENT) {
-            readdirp_local->op_ret = -1;
+            readdirp_local->op_ret = gf_error;
             readdirp_local->op_errno = op_errno;
         }
         gf_msg_debug(this->name, op_errno,
@@ -10089,7 +10138,7 @@ dht_rmdir_linkfile_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int
 dht_rmdir_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, inode_t *inode,
+                     gf_return_t op_ret, int op_errno, inode_t *inode,
                      struct iatt *stbuf, dict_t *xattr, struct iatt *parent)
 {
     dht_local_t *local = NULL;
@@ -10110,14 +10159,14 @@ dht_rmdir_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     readdirp_frame = local->main_frame;
     readdirp_local = readdirp_frame->local;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, DHT_MSG_FILE_LOOKUP_FAILED,
                "lookup failed for %s on %s", local->loc.path, src->name);
         goto err;
     }
 
     if (!check_is_linkfile(inode, stbuf, xattr, conf->link_xattr_name)) {
-        readdirp_local->op_ret = -1;
+        readdirp_local->op_ret = gf_error;
         readdirp_local->op_errno = ENOTEMPTY;
 
         gf_uuid_unparse(local->loc.gfid, gfid);
@@ -10144,7 +10193,7 @@ err:
 
 static int
 dht_rmdir_cached_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int op_ret, int op_errno, inode_t *inode,
+                            gf_return_t op_ret, int op_errno, inode_t *inode,
                             struct iatt *stbuf, dict_t *xattr,
                             struct iatt *parent)
 {
@@ -10167,15 +10216,15 @@ dht_rmdir_cached_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     gf_msg_debug(this->name, 0, "returning for %s ", local->loc.path);
 
-    if (op_ret == 0) {
-        readdirp_local->op_ret = -1;
+    if (IS_SUCCESS(op_ret)) {
+        readdirp_local->op_ret = gf_error;
         readdirp_local->op_errno = ENOTEMPTY;
 
         gf_msg(this->name, GF_LOG_WARNING, 0, DHT_MSG_SUBVOL_ERROR,
                "%s found on cached subvol %s", local->loc.path, src->name);
         goto err;
     } else if (op_errno != ENOENT) {
-        readdirp_local->op_ret = -1;
+        readdirp_local->op_ret = gf_error;
         readdirp_local->op_errno = op_errno;
 
         gf_msg(this->name, GF_LOG_WARNING, op_errno, DHT_MSG_SUBVOL_ERROR,
@@ -10364,7 +10413,7 @@ err:
 
     LOCK(&frame->lock);
     {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOTEMPTY;
 
         local->call_cnt -= (count - ret);
@@ -10385,7 +10434,7 @@ err:
 
 static int
 dht_rmdir_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, gf_dirent_t *entries,
+                       gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
                        dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -10398,7 +10447,7 @@ dht_rmdir_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     prev = cookie;
     src = prev;
 
-    if (op_ret > 2) {
+    if (GET_RET(op_ret) > 2) {
         /* dht_rmdir_is_subvol_empty() may free the frame,
          * copy path for logging.
          */
@@ -10411,8 +10460,8 @@ dht_rmdir_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 gf_msg_trace(this->name, 0,
                              "readdir on %s for %s returned %d "
                              "entries",
-                             prev->name, local->loc.path, op_ret);
-                local->op_ret = -1;
+                             prev->name, local->loc.path, GET_RET(op_ret));
+                local->op_ret = gf_error;
                 local->op_errno = ENOTEMPTY;
                 break;
             default:
@@ -10435,7 +10484,7 @@ dht_rmdir_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int
 dht_rmdir_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, fd_t *fd, dict_t *xdata)
+                      gf_return_t op_ret, int op_errno, fd_t *fd, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int this_call_cnt = -1;
@@ -10453,7 +10502,7 @@ dht_rmdir_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     prev = cookie;
 
     this_call_cnt = dht_frame_return(frame);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_uuid_unparse(local->loc.gfid, gfid);
 
         gf_msg_debug(this->name, op_errno,
@@ -10461,7 +10510,7 @@ dht_rmdir_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "gfid = %s,",
                      prev->name, local->loc.path, gfid);
         if ((op_errno != ENOENT) && (op_errno != ESTALE)) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = op_errno;
         }
         goto err;
@@ -10470,14 +10519,14 @@ dht_rmdir_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!is_last_call(this_call_cnt))
         return 0;
 
-    if (local->op_ret == -1)
+    if (IS_ERROR(local->op_ret))
         goto err;
 
     fd_bind(fd);
 
     dict = dict_new();
     if (!dict) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOMEM;
         goto err;
     }
@@ -10516,7 +10565,7 @@ dht_rmdir_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             continue;
         }
         readdirp_local->main_frame = frame;
-        readdirp_local->op_ret = 0;
+        readdirp_local->op_ret = gf_success;
         readdirp_local->xattr = dict_ref(dict);
         /* overload this field to save the subvol info */
         readdirp_local->hashed_subvol = conf->subvolumes[i];
@@ -10572,7 +10621,7 @@ dht_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
     }
 
     local->call_cnt = conf->subvolume_cnt;
-    local->op_ret = 0;
+    local->op_ret = gf_success;
     local->fop_succeeded = 0;
 
     local->flags = flags;
@@ -10621,14 +10670,14 @@ dht_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(rmdir, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(rmdir, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int
 dht_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 
 {
     DHT_STACK_UNWIND(entrylk, frame, op_ret, op_errno, xdata);
@@ -10681,14 +10730,14 @@ dht_entrylk(call_frame_t *frame, xlator_t *this, const char *volume, loc_t *loc,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(entrylk, frame, -1, op_errno, NULL);
+    DHT_STACK_UNWIND(entrylk, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 static int
 dht_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 
 {
     DHT_STACK_UNWIND(fentrylk, frame, op_ret, op_errno, NULL);
@@ -10728,14 +10777,14 @@ dht_fentrylk(call_frame_t *frame, xlator_t *this, const char *volume, fd_t *fd,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(fentrylk, frame, -1, op_errno, NULL);
+    DHT_STACK_UNWIND(fentrylk, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 static int32_t
-dht_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, dict_t *xdata)
+dht_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int this_call_cnt = 0;
@@ -10748,11 +10797,11 @@ dht_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret < 0 && op_errno != ENOTCONN) {
+        if (IS_ERROR(op_ret) && op_errno != ENOTCONN) {
             local->op_errno = op_errno;
             goto unlock;
         }
-        local->op_ret = 0;
+        local->op_ret = gf_success;
     }
 unlock:
     UNLOCK(&frame->lock);
@@ -10806,7 +10855,7 @@ dht_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
     return 0;
 
 err:
-    DHT_STACK_UNWIND(ipc, frame, -1, op_errno, NULL);
+    DHT_STACK_UNWIND(ipc, frame, gf_error, op_errno, NULL);
 
     return 0;
 
@@ -11310,15 +11359,16 @@ dht_release(xlator_t *this, fd_t *fd)
 }
 
 static int
-dht_pt_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, inode_t *inode, struct iatt *stbuf,
-                 struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+dht_pt_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, inode_t *inode,
+                 struct iatt *stbuf, struct iatt *preparent,
+                 struct iatt *postparent, dict_t *xdata)
 {
     dht_local_t *local = NULL;
 
     local = frame->local;
 
-    if (!op_ret) {
+    if (IS_SUCCESS(op_ret)) {
         dht_layout_set(this, inode, local->layout);
     }
 
@@ -11382,14 +11432,16 @@ wind:
 
 err:
     op_errno = local ? local->op_errno : op_errno;
-    DHT_STACK_UNWIND(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                     NULL);
 
     return 0;
 }
 
 static int
 dht_pt_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, dict_t *xattr, dict_t *xdata)
+                    gf_return_t op_ret, int op_errno, dict_t *xattr,
+                    dict_t *xdata)
 {
     dht_conf_t *conf = NULL;
 
@@ -11418,7 +11470,8 @@ dht_pt_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 static int
 dht_pt_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, dict_t *xattr, dict_t *xdata)
+                     gf_return_t op_ret, int op_errno, dict_t *xattr,
+                     dict_t *xdata)
 {
     dht_conf_t *conf = NULL;
 

--- a/xlators/cluster/dht/src/dht-common.h
+++ b/xlators/cluster/dht/src/dht-common.h
@@ -56,13 +56,13 @@
 #define REBAL_NODEUUID_MINE 0x01
 
 typedef int (*dht_selfheal_dir_cbk_t)(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int32_t op_ret,
+                                      xlator_t *this, gf_return_t op_ret,
                                       int32_t op_errno, dict_t *xdata);
 typedef int (*dht_defrag_cbk_fn_t)(xlator_t *this, xlator_t *dst_node,
                                    call_frame_t *frame, int ret);
 
 typedef int (*dht_refresh_layout_unlock)(call_frame_t *frame, xlator_t *this,
-                                         int op_ret, int invoke_cbk);
+                                         int ret, int invoke_cbk);
 
 typedef int (*dht_refresh_layout_done_handle)(call_frame_t *frame);
 
@@ -202,7 +202,7 @@ typedef struct {
     dht_reaction_type_t reaction;
 
     /* whether locking failed on _any_ of the "locks" above */
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
 } dht_ilock_wrap_t;
 
@@ -214,7 +214,7 @@ typedef struct {
     dht_reaction_type_t reaction;
 
     /* whether locking failed on _any_ of the "locks" above */
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
 } dht_elock_wrap_t;
 
@@ -259,7 +259,7 @@ struct dht_local {
     loc_t loc;
     loc_t loc2;
     int call_cnt;
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
     int layout_mismatch;
     /* Use stbuf as the postbuf, when we require both
@@ -356,7 +356,7 @@ struct dht_local {
     int32_t parent_disk_layout[4];
 
     /* rename rollback */
-    int *ret_cache;
+    gf_return_t *ret_cache;
 
     loc_t loc2_copy;
 
@@ -763,7 +763,7 @@ typedef struct dht_fd_ctx {
     GF_REF_DECL;
 } dht_fd_ctx_t;
 
-#define ENTRY_MISSING(op_ret, op_errno) (op_ret == -1 && op_errno == ENOENT)
+#define ENTRY_MISSING(op_ret, op_errno) (IS_ERROR(op_ret) && op_errno == ENOENT)
 
 #define is_revalidate(loc)                                                     \
     (dht_inode_ctx_layout_get((loc)->inode, this, NULL) == 0)
@@ -892,7 +892,7 @@ int
 dht_layouts_init(xlator_t *this, dht_conf_t *conf);
 int
 dht_layout_merge(xlator_t *this, dht_layout_t *layout, xlator_t *subvol,
-                 int op_ret, int op_errno, dict_t *xattr);
+                 gf_return_t op_ret, int op_errno, dict_t *xattr);
 
 int
 dht_disk_layout_extract(xlator_t *this, dht_layout_t *layout, int pos,
@@ -984,7 +984,7 @@ int
 dht_rename_cleanup(call_frame_t *frame);
 int
 dht_rename_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *stbuf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata);
 
@@ -1197,41 +1197,44 @@ dht_notify(xlator_t *this, int32_t event, void *data, ...);
 /* definitions for nufa/switch */
 int
 dht_revalidate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, inode_t *inode, struct iatt *stbuf,
-                   dict_t *xattr, struct iatt *postparent);
+                   gf_return_t op_ret, int op_errno, inode_t *inode,
+                   struct iatt *stbuf, dict_t *xattr, struct iatt *postparent);
 int
 dht_lookup_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, inode_t *inode, struct iatt *stbuf,
-                   dict_t *xattr, struct iatt *postparent);
+                   gf_return_t op_ret, int op_errno, inode_t *inode,
+                   struct iatt *stbuf, dict_t *xattr, struct iatt *postparent);
 int
 dht_lookup_linkfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, inode_t *inode,
+                        gf_return_t op_ret, int op_errno, inode_t *inode,
                         struct iatt *stbuf, dict_t *xattr,
                         struct iatt *postparent);
 int
-dht_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, inode_t *inode, struct iatt *stbuf, dict_t *xattr,
-               struct iatt *postparent);
+dht_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, inode_t *inode,
+               struct iatt *stbuf, dict_t *xattr, struct iatt *postparent);
 int
-dht_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, fd_t *fd, inode_t *inode, struct iatt *stbuf,
-               struct iatt *preparent, struct iatt *postparent, dict_t *xdata);
+dht_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, fd_t *fd, inode_t *inode,
+               struct iatt *stbuf, struct iatt *preparent,
+               struct iatt *postparent, dict_t *xdata);
 int
-dht_newfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, inode_t *inode, struct iatt *stbuf,
-                struct iatt *preparent, struct iatt *postparent, dict_t *xdata);
+dht_newfile_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, inode_t *inode,
+                struct iatt *stbuf, struct iatt *preparent,
+                struct iatt *postparent, dict_t *xdata);
 
 int
 dht_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int
-dht_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, dict_t *xattr, dict_t *xdata);
+dht_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, dict_t *xattr,
+                 dict_t *xdata);
 
 int
 dht_common_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *dict,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                        dict_t *xdata);
 int
 gf_defrag_status_get(dht_conf_t *conf, dict_t *dict);
@@ -1308,7 +1311,7 @@ int
 dht_heal_full_path(void *data);
 
 int
-dht_heal_full_path_done(int op_ret, call_frame_t *frame, void *data);
+dht_heal_full_path_done(int ret, call_frame_t *frame, void *data);
 
 int
 dht_layout_missing_dirs(dht_layout_t *layout);
@@ -1347,7 +1350,7 @@ dht_get_lock_subvolume(xlator_t *this, struct gf_flock *lock,
                        dht_local_t *local);
 
 int
-dht_lk_inode_unref(call_frame_t *frame, int32_t op_ret);
+dht_lk_inode_unref(call_frame_t *frame, gf_return_t op_ret);
 
 int
 dht_fd_ctx_set(xlator_t *this, fd_t *fd, xlator_t *subvol);
@@ -1358,60 +1361,61 @@ dht_check_and_open_fd_on_subvol(xlator_t *this, call_frame_t *frame);
 /* FD fop callbacks */
 
 int
-dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-               dict_t *xdata);
+dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+               struct iatt *postbuf, dict_t *xdata);
 
 int
-dht_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, dict_t *xdata);
+dht_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, dict_t *xdata);
 
 int
 dht_file_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata);
 
 int
-dht_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                 dict_t *xdata);
+dht_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                 struct iatt *postbuf, dict_t *xdata);
 
 int
-dht_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                dict_t *xdata);
+dht_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                struct iatt *postbuf, dict_t *xdata);
 
 int
-dht_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, struct iatt *prebuf, struct iatt *postbuf,
+dht_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                  struct iatt *postbuf, dict_t *xdata);
+
+int
+dht_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                 struct iatt *postbuf, dict_t *xdata);
+
+int
+dht_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+              struct iatt *postbuf, dict_t *xdata);
+
+int
+dht_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, struct iovec *vector, int count,
+              struct iatt *stbuf, struct iobref *iobref, dict_t *xdata);
+
+int
+dht_file_attr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, struct iatt *stbuf,
                   dict_t *xdata);
 
 int
-dht_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                 dict_t *xdata);
-
-int
-dht_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-              dict_t *xdata);
-
-int
-dht_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, struct iovec *vector, int count, struct iatt *stbuf,
-              struct iobref *iobref, dict_t *xdata);
-
-int
-dht_file_attr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, struct iatt *stbuf, dict_t *xdata);
-
-int
 dht_file_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int op_ret, int op_errno, dict_t *xdata);
+                         gf_return_t op_ret, int op_errno, dict_t *xdata);
 
 int
 dht_file_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, dict_t *xdata);
+                      gf_return_t op_ret, int op_errno, dict_t *xdata);
 
 /* All custom xattr heal functions */
 int
@@ -1466,11 +1470,12 @@ dht_pt_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
               dict_t *xdata);
 
 int32_t
-dht_check_remote_fd_failed_error(dht_local_t *local, int op_ret, int op_errno);
+dht_check_remote_fd_failed_error(dht_local_t *local, gf_return_t op_ret,
+                                 int op_errno);
 
 int
 dht_common_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *dict,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                        dict_t *xdata);
 
 int32_t

--- a/xlators/cluster/dht/src/dht-diskusage.c
+++ b/xlators/cluster/dht/src/dht-diskusage.c
@@ -16,8 +16,9 @@
 #include <glusterfs/events.h>
 
 int
-dht_du_info_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, struct statvfs *statvfs, dict_t *xdata)
+dht_du_info_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, struct statvfs *statvfs,
+                dict_t *xdata)
 {
     dht_conf_t *conf = NULL;
     xlator_t *prev = NULL;
@@ -32,7 +33,7 @@ dht_du_info_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     conf = this->private;
     prev = cookie;
 
-    if (op_ret == -1 || !statvfs) {
+    if (IS_ERROR(op_ret) || !statvfs) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno,
                DHT_MSG_GET_DISK_INFO_ERROR, "failed to get disk info from %s",
                prev->name);

--- a/xlators/cluster/dht/src/dht-inode-write.c
+++ b/xlators/cluster/dht/src/dht-inode-write.c
@@ -24,9 +24,9 @@ static int
 dht_zerofill2(xlator_t *this, xlator_t *subvol, call_frame_t *frame, int ret);
 
 int
-dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-               dict_t *xdata)
+dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+               struct iatt *postbuf, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *prev = NULL;
@@ -38,7 +38,7 @@ dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     prev = cookie;
 
     if (!local) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto out;
     }
@@ -56,9 +56,9 @@ dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         return 0;
     }
 
-    if (op_ret == -1 && !dht_inode_missing(op_errno)) {
+    if (IS_ERROR(op_ret) && !dht_inode_missing(op_errno)) {
         local->op_errno = op_errno;
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         gf_msg_debug(this->name, 0, "subvolume %s returned -1 (%s)", prev->name,
                      strerror(op_errno));
         goto out;
@@ -85,7 +85,7 @@ dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     dht_set_local_rebalance(this, local, NULL, prebuf, postbuf, xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
+    if ((IS_ERROR(op_ret)) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -100,7 +100,7 @@ dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                     gf_msg(this->name, GF_LOG_ERROR, DHT_MSG_NO_MEMORY, ENOMEM,
                            "insufficient memory");
                     local->op_errno = ENOMEM;
-                    local->op_ret = -1;
+                    local->op_ret = gf_error;
                     goto out;
                 }
             }
@@ -112,7 +112,7 @@ dht_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
                        "Failed to set key %s in dictionary",
                        GF_PROTECT_FROM_EXTERNAL_WRITES);
                 local->op_errno = ENOMEM;
-                local->op_ret = -1;
+                local->op_ret = gf_error;
                 goto out;
             }
         }
@@ -179,7 +179,7 @@ dht_writev2(xlator_t *this, xlator_t *subvol, call_frame_t *frame, int ret)
     return 0;
 
 out:
-    DHT_STACK_UNWIND(writev, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(writev, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
@@ -230,15 +230,15 @@ dht_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(writev, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(writev, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 int
-dht_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                 dict_t *xdata)
+dht_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                 struct iatt *postbuf, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *prev = NULL;
@@ -270,9 +270,9 @@ dht_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if ((IS_ERROR(op_ret)) && !dht_inode_missing(op_errno)) {
         local->op_errno = op_errno;
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
                      prev->name);
 
@@ -299,7 +299,7 @@ dht_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     dht_set_local_rebalance(this, local, NULL, prebuf, postbuf, xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
+    if ((IS_ERROR(op_ret)) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -374,7 +374,7 @@ dht_truncate2(xlator_t *this, xlator_t *subvol, call_frame_t *frame, int ret)
     return 0;
 
 out:
-    DHT_STACK_UNWIND(truncate, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(truncate, frame, gf_error, op_errno, NULL, NULL, NULL);
     return 0;
 }
 
@@ -417,7 +417,7 @@ dht_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(truncate, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(truncate, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
@@ -459,15 +459,15 @@ dht_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(ftruncate, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(ftruncate, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 int
-dht_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                  dict_t *xdata)
+dht_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                  struct iatt *postbuf, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *prev = NULL;
@@ -496,9 +496,9 @@ dht_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if ((IS_ERROR(op_ret)) && !dht_inode_missing(op_errno)) {
         local->op_errno = op_errno;
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
                      prev->name);
 
@@ -520,7 +520,7 @@ dht_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     dht_set_local_rebalance(this, local, NULL, prebuf, postbuf, xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
+    if ((IS_ERROR(op_ret)) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -591,7 +591,7 @@ dht_fallocate2(xlator_t *this, xlator_t *subvol, call_frame_t *frame, int ret)
     return 0;
 
 out:
-    DHT_STACK_UNWIND(fallocate, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(fallocate, frame, gf_error, op_errno, NULL, NULL, NULL);
     return 0;
 }
 
@@ -637,15 +637,15 @@ dht_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(fallocate, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(fallocate, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 int
-dht_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                dict_t *xdata)
+dht_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                struct iatt *postbuf, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *prev = NULL;
@@ -673,9 +673,9 @@ dht_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if ((IS_ERROR(op_ret)) && !dht_inode_missing(op_errno)) {
         local->op_errno = op_errno;
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
                      prev->name);
 
@@ -697,7 +697,7 @@ dht_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     dht_set_local_rebalance(this, local, NULL, prebuf, postbuf, xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
+    if ((IS_ERROR(op_ret)) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -766,7 +766,7 @@ dht_discard2(xlator_t *this, xlator_t *subvol, call_frame_t *frame, int ret)
     return 0;
 
 out:
-    DHT_STACK_UNWIND(discard, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(discard, frame, gf_error, op_errno, NULL, NULL, NULL);
     return 0;
 }
 
@@ -810,15 +810,15 @@ dht_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(discard, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(discard, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 int
-dht_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                 dict_t *xdata)
+dht_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                 struct iatt *postbuf, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *prev = NULL;
@@ -845,9 +845,9 @@ dht_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if ((IS_ERROR(op_ret)) && !dht_inode_missing(op_errno)) {
         local->op_errno = op_errno;
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
                      prev->name);
         goto out;
@@ -868,7 +868,7 @@ dht_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     dht_set_local_rebalance(this, local, NULL, prebuf, postbuf, xdata);
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
+    if ((IS_ERROR(op_ret)) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
         ret = dht_rebalance_complete_check(this, frame);
         if (!ret)
             return 0;
@@ -941,7 +941,7 @@ dht_zerofill2(xlator_t *this, xlator_t *subvol, call_frame_t *frame, int ret)
 
 out:
 
-    DHT_STACK_UNWIND(zerofill, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(zerofill, frame, gf_error, op_errno, NULL, NULL, NULL);
     return 0;
 }
 
@@ -985,7 +985,7 @@ dht_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(zerofill, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(zerofill, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
@@ -993,7 +993,7 @@ err:
 /* handle cases of migration here for 'setattr()' calls */
 int
 dht_file_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -1013,7 +1013,7 @@ dht_file_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         return 0;
     }
 
-    if ((op_ret == -1) && !dht_inode_missing(op_errno)) {
+    if ((IS_ERROR(op_ret)) && !dht_inode_missing(op_errno)) {
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
                      prev->name);
         goto out;
@@ -1028,7 +1028,7 @@ dht_file_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local->rebalance.target_op_fn = dht_setattr2;
 
     /* Phase 2 of migration */
-    if ((op_ret == -1) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
+    if ((IS_ERROR(op_ret)) || IS_DHT_MIGRATION_PHASE2(postbuf)) {
         dht_set_local_rebalance(this, local, NULL, prebuf, postbuf, xdata);
 
         ret = dht_rebalance_complete_check(this, frame);
@@ -1092,15 +1092,15 @@ dht_setattr2(xlator_t *this, xlator_t *subvol, call_frame_t *frame, int ret)
     return 0;
 
 out:
-    DHT_STACK_UNWIND(setattr, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(setattr, frame, gf_error, op_errno, NULL, NULL, NULL);
     return 0;
 }
 
 /* Keep the existing code same for all the cases other than regular file */
 int
-dht_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, struct iatt *statpre, struct iatt *statpost,
-                dict_t *xdata)
+dht_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, struct iatt *statpre,
+                struct iatt *statpost, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int this_call_cnt = 0;
@@ -1111,7 +1111,7 @@ dht_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     LOCK(&frame->lock);
     {
-        if (op_ret == -1) {
+        if (IS_ERROR(op_ret)) {
             local->op_errno = op_errno;
             UNLOCK(&frame->lock);
             gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -1122,14 +1122,14 @@ dht_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
         dht_iatt_merge(this, &local->prebuf, statpre);
         dht_iatt_merge(this, &local->stbuf, statpost);
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
         local->op_errno = 0;
     }
     UNLOCK(&frame->lock);
 post_unlock:
     this_call_cnt = dht_frame_return(frame);
     if (is_last_call(this_call_cnt)) {
-        if (local->op_ret == 0)
+        if (IS_SUCCESS(local->op_ret))
             dht_inode_ctx_time_set(local->loc.inode, this, &local->stbuf);
         DHT_STACK_UNWIND(setattr, frame, local->op_ret, local->op_errno,
                          &local->prebuf, &local->stbuf, xdata);
@@ -1141,7 +1141,7 @@ post_unlock:
 /* Keep the existing code same for all the cases other than regular file */
 int
 dht_non_mds_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, struct iatt *statpre,
+                        gf_return_t op_ret, int op_errno, struct iatt *statpre,
                         struct iatt *statpost, dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -1151,7 +1151,7 @@ dht_non_mds_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, op_errno, 0, 0, "subvolume %s returned -1",
                prev->name);
         goto post_unlock;
@@ -1162,7 +1162,7 @@ dht_non_mds_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         dht_iatt_merge(this, &local->prebuf, statpre);
         dht_iatt_merge(this, &local->stbuf, statpost);
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
         local->op_errno = 0;
     }
     UNLOCK(&frame->lock);
@@ -1170,8 +1170,9 @@ post_unlock:
     this_call_cnt = dht_frame_return(frame);
     if (is_last_call(this_call_cnt)) {
         dht_inode_ctx_time_set(local->loc.inode, this, &local->stbuf);
-        DHT_STACK_UNWIND(setattr, frame, 0, 0, &local->prebuf, &local->stbuf,
-                         xdata);
+        op_ret = gf_success;
+        DHT_STACK_UNWIND(setattr, frame, op_ret, 0, &local->prebuf,
+                         &local->stbuf, xdata);
     }
 
     return 0;
@@ -1179,7 +1180,7 @@ post_unlock:
 
 int
 dht_mds_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata)
 
 {
@@ -1197,7 +1198,7 @@ dht_mds_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     conf = this->private;
     mds_subvol = local->mds_subvol;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
         gf_msg_debug(this->name, op_errno, "subvolume %s returned -1",
@@ -1205,7 +1206,7 @@ dht_mds_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    local->op_ret = 0;
+    local->op_ret = gf_success;
     loc_stbuf = local->stbuf;
     dht_iatt_merge(this, &local->prebuf, statpre);
     dht_iatt_merge(this, &local->stbuf, statpost);
@@ -1332,7 +1333,7 @@ dht_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc, struct iatt *stbuf,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(setattr, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(setattr, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
@@ -1400,7 +1401,7 @@ dht_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iatt *stbuf,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(fsetattr, frame, -1, op_errno, NULL, NULL, NULL);
+    DHT_STACK_UNWIND(fsetattr, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }

--- a/xlators/cluster/dht/src/dht-layout.c
+++ b/xlators/cluster/dht/src/dht-layout.c
@@ -306,7 +306,7 @@ dht_disk_layout_merge(xlator_t *this, dht_layout_t *layout, int pos,
 
 int
 dht_layout_merge(xlator_t *this, dht_layout_t *layout, xlator_t *subvol,
-                 int op_ret, int op_errno, dict_t *xattr)
+                 gf_return_t op_ret, int op_errno, dict_t *xattr)
 {
     int i = 0;
     int ret = -1;
@@ -315,7 +315,7 @@ dht_layout_merge(xlator_t *this, dht_layout_t *layout, xlator_t *subvol,
     int disk_layout_len = 0;
     dht_conf_t *conf = this->private;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         err = op_errno;
     }
 
@@ -330,7 +330,7 @@ dht_layout_merge(xlator_t *this, dht_layout_t *layout, xlator_t *subvol,
         }
     }
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         ret = 0;
         goto out;
     }

--- a/xlators/cluster/dht/src/dht-linkfile.c
+++ b/xlators/cluster/dht/src/dht-linkfile.c
@@ -13,7 +13,7 @@
 
 static int
 dht_linkfile_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, inode_t *inode,
+                        gf_return_t op_ret, int op_errno, inode_t *inode,
                         struct iatt *stbuf, dict_t *xattr,
                         struct iatt *postparent)
 {
@@ -27,7 +27,7 @@ dht_linkfile_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     prev = cookie;
     conf = this->private;
 
-    if (op_ret)
+    if (IS_ERROR(op_ret))
         goto out;
 
     gf_uuid_unparse(local->loc.gfid, gfid);
@@ -45,7 +45,7 @@ out:
 
 static int
 dht_linkfile_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, inode_t *inode,
+                        gf_return_t op_ret, int op_errno, inode_t *inode,
                         struct iatt *stbuf, struct iatt *preparent,
                         struct iatt *postparent, dict_t *xdata)
 {
@@ -57,12 +57,12 @@ dht_linkfile_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (!op_ret)
+    if (IS_SUCCESS(op_ret))
         local->linked = _gf_true;
 
     FRAME_SU_UNDO(frame, dht_local_t);
 
-    if (op_ret && (op_errno == EEXIST)) {
+    if (IS_ERROR(op_ret) && (op_errno == EEXIST)) {
         conf = this->private;
         subvol = cookie;
         if (!subvol)
@@ -156,8 +156,8 @@ dht_linkfile_create(call_frame_t *frame, fop_mknod_cbk_t linkfile_cbk,
 
     return 0;
 out:
-    local->linkfile.linkfile_cbk(frame, frame->this, frame->this, -1, ENOMEM,
-                                 loc->inode, NULL, NULL, NULL, NULL);
+    local->linkfile.linkfile_cbk(frame, frame->this, frame->this, gf_error,
+                                 ENOMEM, loc->inode, NULL, NULL, NULL, NULL);
 
     if (need_unref && dict)
         dict_unref(dict);
@@ -167,7 +167,7 @@ out:
 
 int
 dht_linkfile_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno,
+                        gf_return_t op_ret, int32_t op_errno,
                         struct iatt *preparent, struct iatt *postparent,
                         dict_t *xdata)
 {
@@ -178,7 +178,7 @@ dht_linkfile_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     subvol = cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_uuid_unparse(local->loc.gfid, gfid);
         gf_smsg(this->name, GF_LOG_INFO, op_errno, DHT_MSG_UNLINK_FAILED,
                 "path=%s", local->loc.path, "gfid=%s", gfid, "subvolume=%s",
@@ -252,7 +252,7 @@ out:
 
 static int
 dht_linkfile_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int op_ret, int op_errno, struct iatt *statpre,
+                         gf_return_t op_ret, int op_errno, struct iatt *statpre,
                          struct iatt *statpost, dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -261,7 +261,7 @@ dht_linkfile_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     loc = &local->loc;
 
-    if (op_ret)
+    if (IS_ERROR(op_ret))
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, DHT_MSG_SETATTR_FAILED,
                 "path=%s", (loc->path ? loc->path : "NULL"), "gfid=%s",
                 uuid_utoa(local->gfid), NULL);

--- a/xlators/cluster/dht/src/dht-lock.c
+++ b/xlators/cluster/dht/src/dht-lock.c
@@ -304,7 +304,7 @@ dht_entrylk_done(call_frame_t *lock_frame)
 
 static int32_t
 dht_unlock_entrylk_done(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     char gfid[GF_UUID_BUF_SIZE] = {0};
@@ -313,7 +313,7 @@ dht_unlock_entrylk_done(call_frame_t *frame, void *cookie, xlator_t *this,
     gf_uuid_unparse(local->lock[0].ns.directory_ns.locks[0]->loc.inode->gfid,
                     gfid);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, op_errno,
                 DHT_MSG_UNLOCK_GFID_FAILED, "gfid=%s", gfid,
                 "DHT_LAYOUT_HEAL_DOMAIN", NULL);
@@ -325,7 +325,7 @@ dht_unlock_entrylk_done(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int32_t
 dht_unlock_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int lk_index = 0, call_cnt = 0;
@@ -337,7 +337,7 @@ dht_unlock_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     uuid_utoa_r(local->lock[0].ns.directory_ns.locks[lk_index]->loc.gfid, gfid);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, op_errno, DHT_MSG_UNLOCKING_FAILED,
                 "name=%s",
                 local->lock[0].ns.directory_ns.locks[lk_index]->xl->name,
@@ -360,6 +360,7 @@ dht_unlock_entrylk(call_frame_t *frame, dht_lock_t **lk_array, int lk_count,
 {
     dht_local_t *local = NULL;
     int ret = -1, i = 0;
+    gf_return_t op_ret = {0};
     call_frame_t *lock_frame = NULL;
     int call_cnt = 0;
 
@@ -424,7 +425,7 @@ done:
 
     /* no locks acquired, invoke entrylk_cbk */
     if (ret == 0)
-        entrylk_cbk(frame, NULL, frame->this, 0, 0, NULL);
+        entrylk_cbk(frame, NULL, frame->this, op_ret, 0, NULL);
 
     return ret;
 }
@@ -486,7 +487,7 @@ out:
 
 static int
 dht_entrylk_cleanup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_entrylk_done(frame);
     return 0;
@@ -517,7 +518,7 @@ dht_entrylk_cleanup(call_frame_t *lock_frame)
 
 static int32_t
 dht_blocking_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     int lk_index = 0;
     int i = 0;
@@ -526,7 +527,7 @@ dht_blocking_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     lk_index = (long)cookie;
 
     local = frame->local;
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         local->lock[0].ns.directory_ns.locks[lk_index]->locked = _gf_true;
     } else {
         switch (op_errno) {
@@ -535,13 +536,13 @@ dht_blocking_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 if (local->lock[0]
                         .ns.directory_ns.locks[lk_index]
                         ->do_on_failure != IGNORE_ENOENT_ESTALE) {
-                    local->lock[0].ns.directory_ns.op_ret = -1;
+                    local->lock[0].ns.directory_ns.op_ret = gf_error;
                     local->lock[0].ns.directory_ns.op_errno = op_errno;
                     goto cleanup;
                 }
                 break;
             default:
-                local->lock[0].ns.directory_ns.op_ret = -1;
+                local->lock[0].ns.directory_ns.op_ret = gf_error;
                 local->lock[0].ns.directory_ns.op_errno = op_errno;
                 goto cleanup;
         }
@@ -554,7 +555,7 @@ dht_blocking_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             ;
 
         if (i == local->lock[0].ns.directory_ns.lk_count) {
-            local->lock[0].ns.directory_ns.op_ret = -1;
+            local->lock[0].ns.directory_ns.op_ret = gf_error;
             local->lock[0].ns.directory_ns.op_errno = op_errno;
         }
 
@@ -683,7 +684,7 @@ dht_inodelk_done(call_frame_t *lock_frame)
 
 static int32_t
 dht_unlock_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int lk_index = 0, call_cnt = 0;
@@ -692,7 +693,7 @@ dht_unlock_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     lk_index = (long)cookie;
 
     local = frame->local;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->lock[0].layout.my_layout.locks[lk_index]->loc.gfid,
                     gfid);
 
@@ -714,7 +715,7 @@ dht_unlock_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int32_t
 dht_unlock_inodelk_done(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     char gfid[GF_UUID_BUF_SIZE] = {0};
@@ -723,7 +724,7 @@ dht_unlock_inodelk_done(call_frame_t *frame, void *cookie, xlator_t *this,
     gf_uuid_unparse(local->lock[0].layout.my_layout.locks[0]->loc.inode->gfid,
                     gfid);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_smsg(this->name, GF_LOG_WARNING, op_errno,
                 DHT_MSG_UNLOCK_GFID_FAILED, "DHT_LAYOUT_HEAL_DOMAIN gfid=%s",
                 gfid, NULL);
@@ -741,6 +742,7 @@ dht_unlock_inodelk(call_frame_t *frame, dht_lock_t **lk_array, int lk_count,
     struct gf_flock flock = {
         0,
     };
+    gf_return_t op_ret = {0};
     int ret = -1, i = 0;
     call_frame_t *lock_frame = NULL;
     int call_cnt = 0;
@@ -807,7 +809,7 @@ done:
 
     /* no locks acquired, invoke inodelk_cbk */
     if (ret == 0)
-        inodelk_cbk(frame, NULL, frame->this, 0, 0, NULL);
+        inodelk_cbk(frame, NULL, frame->this, op_ret, 0, NULL);
 
     return ret;
 }
@@ -869,7 +871,7 @@ out:
 
 static int
 dht_inodelk_cleanup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_inodelk_done(frame);
     return 0;
@@ -900,7 +902,7 @@ dht_inodelk_cleanup(call_frame_t *lock_frame)
 
 static int32_t
 dht_nonblocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                            gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int lk_index = 0, call_cnt = 0;
@@ -909,8 +911,8 @@ dht_nonblocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     lk_index = (long)cookie;
 
-    if (op_ret == -1) {
-        local->lock[0].layout.my_layout.op_ret = -1;
+    if (IS_ERROR(op_ret)) {
+        local->lock[0].layout.my_layout.op_ret = gf_error;
         local->lock[0].layout.my_layout.op_errno = op_errno;
 
         if (local && local->lock[0].layout.my_layout.locks[lk_index]) {
@@ -935,7 +937,7 @@ dht_nonblocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 out:
     call_cnt = dht_frame_return(frame);
     if (is_last_call(call_cnt)) {
-        if (local->lock[0].layout.my_layout.op_ret < 0) {
+        if (IS_ERROR(local->lock[0].layout.my_layout.op_ret)) {
             dht_inodelk_cleanup(frame);
             return 0;
         }
@@ -1000,7 +1002,7 @@ out:
 
 static int32_t
 dht_blocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     int lk_index = 0;
     int i = 0;
@@ -1013,7 +1015,7 @@ dht_blocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     lk_index = (long)cookie;
 
     local = frame->local;
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         local->lock[0].layout.my_layout.locks[lk_index]->locked = _gf_true;
     } else {
         switch (op_errno) {
@@ -1028,7 +1030,7 @@ dht_blocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                         .layout.my_layout.locks[lk_index]
                                         ->loc.gfid,
                                     gfid);
-                    local->lock[0].layout.my_layout.op_ret = -1;
+                    local->lock[0].layout.my_layout.op_ret = gf_error;
                     local->lock[0].layout.my_layout.op_errno = op_errno;
                     gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                             DHT_MSG_INODELK_FAILED, "subvol=%s",
@@ -1048,7 +1050,7 @@ dht_blocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                         .layout.my_layout.locks[lk_index]
                                         ->loc.gfid,
                                     gfid);
-                    local->lock[0].layout.my_layout.op_ret = -1;
+                    local->lock[0].layout.my_layout.op_ret = gf_error;
                     local->lock[0].layout.my_layout.op_errno = op_errno;
                     gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                             DHT_MSG_INODELK_FAILED, "subvol=%s",
@@ -1064,7 +1066,7 @@ dht_blocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 gf_uuid_unparse(
                     local->lock[0].layout.my_layout.locks[lk_index]->loc.gfid,
                     gfid);
-                local->lock[0].layout.my_layout.op_ret = -1;
+                local->lock[0].layout.my_layout.op_ret = gf_error;
                 local->lock[0].layout.my_layout.op_errno = op_errno;
                 gf_smsg(
                     this->name, GF_LOG_ERROR, op_errno, DHT_MSG_INODELK_FAILED,
@@ -1082,7 +1084,7 @@ dht_blocking_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             ;
 
         if (i == local->lock[0].layout.my_layout.lk_count) {
-            local->lock[0].layout.my_layout.op_ret = -1;
+            local->lock[0].layout.my_layout.op_ret = gf_error;
             local->lock[0].layout.my_layout.op_errno = op_errno;
         }
 
@@ -1185,12 +1187,12 @@ out:
 
 static int32_t
 dht_protect_namespace_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
 
     local = frame->local;
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         dht_unlock_inodelk_wrapper(frame, &local->current->ns.parent_layout);
 
     local->current->ns.ns_cbk(frame, cookie, this, op_ret, op_errno, xdata);
@@ -1199,7 +1201,7 @@ dht_protect_namespace_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 dht_blocking_entrylk_after_inodelk(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -1213,8 +1215,8 @@ dht_blocking_entrylk_after_inodelk(call_frame_t *frame, void *cookie,
     local = frame->local;
     entrylk = &local->current->ns.directory_ns;
 
-    if (op_ret < 0) {
-        local->op_ret = -1;
+    if (IS_ERROR(op_ret)) {
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
         goto err;
     }
@@ -1222,7 +1224,7 @@ dht_blocking_entrylk_after_inodelk(call_frame_t *frame, void *cookie,
     loc = &entrylk->locks[0]->loc;
     gf_uuid_unparse(loc->gfid, pgfid);
 
-    local->op_ret = 0;
+    local->op_ret = gf_success;
     lk_array = entrylk->locks;
     count = entrylk->lk_count;
 
@@ -1230,7 +1232,7 @@ dht_blocking_entrylk_after_inodelk(call_frame_t *frame, void *cookie,
                                dht_protect_namespace_cbk);
 
     if (ret < 0) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = EIO;
         gf_smsg(this->name, GF_LOG_WARNING, local->op_errno,
                 DHT_MSG_ENTRYLK_FAILED_AFT_INODELK, "fop=%s",

--- a/xlators/cluster/dht/src/dht-lock.h
+++ b/xlators/cluster/dht/src/dht-lock.h
@@ -73,12 +73,12 @@ dht_blocking_inodelk(call_frame_t *frame, dht_lock_t **lk_array, int lk_count,
 
 int32_t
 dht_blocking_entrylk_after_inodelk(call_frame_t *frame, void *cookie,
-                                   xlator_t *this, int32_t op_ret,
+                                   xlator_t *this, gf_return_t op_ret,
                                    int32_t op_errno, dict_t *xdata);
 
 int32_t
 dht_blocking_entrylk_after_inodelk_rename(call_frame_t *frame, void *cookie,
-                                          xlator_t *this, int32_t op_ret,
+                                          xlator_t *this, gf_return_t op_ret,
                                           int32_t op_errno, dict_t *xdata);
 
 void

--- a/xlators/cluster/dht/src/dht-rebalance.c
+++ b/xlators/cluster/dht/src/dht-rebalance.c
@@ -2357,28 +2357,31 @@ rebalance_task(void *data)
 }
 
 static int
-rebalance_task_completion(int op_ret, call_frame_t *sync_frame, void *data)
+rebalance_task_completion(int ret, call_frame_t *sync_frame, void *data)
 {
     int32_t op_errno = EINVAL;
 
-    if (op_ret == -1) {
+    if (ret == -1) {
         /* Failure of migration process, mostly due to write process.
            as we can't preserve the exact errno, lets say there was
            no space to migrate-data
         */
         op_errno = ENOSPC;
-    } else if (op_ret == 1) {
+    } else if (ret == 1) {
         /* migration didn't happen, but is not a failure, let the user
            understand that he doesn't have permission to migrate the
            file.
         */
-        op_ret = -1;
+        ret = -1;
         op_errno = EPERM;
-    } else if (op_ret != 0) {
-        op_errno = -op_ret;
-        op_ret = -1;
+    } else if (ret != 0) {
+        op_errno = -ret;
+        ret = -1;
     }
 
+    /* */
+    gf_return_t op_ret;
+    SET_RET(op_ret, ret);
     DHT_STACK_UNWIND(setxattr, sync_frame, op_ret, op_errno, NULL);
     return 0;
 }

--- a/xlators/cluster/dht/src/dht-rename.c
+++ b/xlators/cluster/dht/src/dht-rename.c
@@ -19,11 +19,11 @@ int
 dht_rename_unlock(call_frame_t *frame, xlator_t *this);
 int32_t
 dht_rename_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int
 dht_rename_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
 
@@ -57,7 +57,8 @@ static void
 dht_rename_dir_unlock_dst(call_frame_t *frame, xlator_t *this)
 {
     dht_local_t *local = NULL;
-    int op_ret = -1;
+    gf_return_t op_ret;
+    int ret;
     char src_gfid[GF_UUID_BUF_SIZE] = {0};
     char dst_gfid[GF_UUID_BUF_SIZE] = {0};
 
@@ -67,10 +68,10 @@ dht_rename_dir_unlock_dst(call_frame_t *frame, xlator_t *this)
     dht_unlock_entrylk_wrapper(frame, &local->lock[1].ns.directory_ns);
 
     /* Unlock inodelk */
-    op_ret = dht_unlock_inodelk(frame, local->lock[1].ns.parent_layout.locks,
-                                local->lock[1].ns.parent_layout.lk_count,
-                                dht_rename_unlock_cbk);
-    if (op_ret < 0) {
+    ret = dht_unlock_inodelk(frame, local->lock[1].ns.parent_layout.locks,
+                             local->lock[1].ns.parent_layout.lk_count,
+                             dht_rename_unlock_cbk);
+    if (ret < 0) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -91,7 +92,8 @@ dht_rename_dir_unlock_dst(call_frame_t *frame, xlator_t *this)
                    "stale locks left on bricks",
                    local->loc.path, src_gfid, local->loc2.path, dst_gfid);
 
-        dht_rename_unlock_cbk(frame, NULL, this, 0, 0, NULL);
+        op_ret = gf_success;
+        dht_rename_unlock_cbk(frame, NULL, this, op_ret, 0, NULL);
     }
 
     return;
@@ -106,7 +108,7 @@ dht_rename_dir_unlock(call_frame_t *frame, xlator_t *this)
 }
 int
 dht_rename_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                    struct iatt *preoldparent, struct iatt *postoldparent,
                    struct iatt *prenewparent, struct iatt *postnewparent,
                    dict_t *xdata)
@@ -125,7 +127,7 @@ dht_rename_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     subvol_cnt = dht_subvol_cnt(this, prev);
     local->ret_cache[subvol_cnt] = op_ret;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_uuid_unparse(local->loc.inode->gfid, gfid);
 
         gf_msg(this->name, GF_LOG_INFO, op_errno, DHT_MSG_RENAME_FAILED,
@@ -155,23 +157,25 @@ unwind:
          * no contention. Therefore it's safe to manipulate or
          * deref local->call_cnt directly (without locking).
          */
-        if (local->ret_cache[conf->subvolume_cnt] == 0) {
+        if (IS_SUCCESS(local->ret_cache[conf->subvolume_cnt])) {
             /* count errant subvols in last field of ret_cache */
             for (i = 0; i < conf->subvolume_cnt; i++) {
-                if (local->ret_cache[i] != 0)
-                    ++local->ret_cache[conf->subvolume_cnt];
+                if (IS_ERROR(local->ret_cache[i])) {
+                    int temp = GET_RET(local->ret_cache[conf->subvolume_cnt]);
+                    SET_RET(local->ret_cache[conf->subvolume_cnt], (temp + 1));
+                }
             }
-            if (local->ret_cache[conf->subvolume_cnt]) {
+            if (IS_ERROR(local->ret_cache[conf->subvolume_cnt])) {
                 /* undoing the damage:
                  * for all subvolumes, where rename
                  * succeeded, we perform the reverse operation
                  */
                 for (i = 0; i < conf->subvolume_cnt; i++) {
-                    if (local->ret_cache[i] == 0)
+                    if (IS_SUCCESS(local->ret_cache[i]))
                         ++local->call_cnt;
                 }
                 for (i = 0; i < conf->subvolume_cnt; i++) {
-                    if (local->ret_cache[i])
+                    if (IS_ERROR(local->ret_cache[i]))
                         continue;
 
                     STACK_WIND(frame, dht_rename_dir_cbk, conf->subvolumes[i],
@@ -196,10 +200,10 @@ unwind:
 
 int
 dht_rename_hashed_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
-                          struct iatt *preoldparent, struct iatt *postoldparent,
-                          struct iatt *prenewparent, struct iatt *postnewparent,
-                          dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *stbuf, struct iatt *preoldparent,
+                          struct iatt *postoldparent, struct iatt *prenewparent,
+                          struct iatt *postnewparent, dict_t *xdata)
 {
     dht_conf_t *conf = NULL;
     dht_local_t *local = NULL;
@@ -212,7 +216,7 @@ dht_rename_hashed_dir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_uuid_unparse(local->loc.inode->gfid, gfid);
 
         gf_msg(this->name, GF_LOG_INFO, op_errno, DHT_MSG_RENAME_FAILED,
@@ -267,10 +271,10 @@ dht_rename_dir_do(call_frame_t *frame, xlator_t *this)
 
     local = frame->local;
 
-    if (local->op_ret == -1)
+    if (IS_ERROR(local->op_ret))
         goto err;
 
-    local->op_ret = 0;
+    local->op_ret = gf_success;
 
     STACK_WIND_COOKIE(frame, dht_rename_hashed_dir_cbk, local->dst_hashed,
                       local->dst_hashed, local->dst_hashed->fops->rename,
@@ -284,7 +288,7 @@ err:
 
 int
 dht_rename_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, gf_dirent_t *entries,
+                       gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
                        dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -294,10 +298,10 @@ dht_rename_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
 
-    if (op_ret > 2) {
+    if (GET_RET(op_ret) > 2) {
         gf_msg_trace(this->name, 0, "readdir on %s for %s returned %d entries",
-                     prev->name, local->loc.path, op_ret);
-        local->op_ret = -1;
+                     prev->name, local->loc.path, GET_RET(op_ret));
+        local->op_ret = gf_error;
         local->op_errno = ENOTEMPTY;
     }
 
@@ -312,7 +316,8 @@ dht_rename_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 dht_rename_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, fd_t *fd, dict_t *xdata)
+                       gf_return_t op_ret, int op_errno, fd_t *fd,
+                       dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int this_call_cnt = -1;
@@ -322,7 +327,7 @@ dht_rename_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_uuid_unparse(local->loc.inode->gfid, gfid);
         gf_msg(this->name, GF_LOG_INFO, op_errno, DHT_MSG_OPENDIR_FAILED,
                "opendir on %s for %s failed,(gfid = %s) ", prev->name,
@@ -348,7 +353,7 @@ err:
 
 int
 dht_rename_dir_lock2_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     char src_gfid[GF_UUID_BUF_SIZE] = {0};
@@ -359,7 +364,7 @@ dht_rename_dir_lock2_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     conf = this->private;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -372,7 +377,7 @@ dht_rename_dir_lock2_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                local->loc2.path, dst_gfid,
                local->dst_cached ? local->dst_cached->name : NULL);
 
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
         goto err;
     }
@@ -383,7 +388,7 @@ dht_rename_dir_lock2_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto err;
     }
 
-    local->op_ret = 0;
+    local->op_ret = gf_success;
 
     if (!local->dst_cached) {
         dht_rename_dir_do(frame, this);
@@ -407,7 +412,7 @@ err:
 
 int
 dht_rename_dir_lock1_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     char src_gfid[GF_UUID_BUF_SIZE] = {0};
@@ -418,7 +423,7 @@ dht_rename_dir_lock1_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -431,7 +436,7 @@ dht_rename_dir_lock1_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                local->loc2.path, dst_gfid,
                local->dst_cached ? local->dst_cached->name : NULL);
 
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
         goto err;
     }
@@ -560,7 +565,7 @@ dht_rename_dir(call_frame_t *frame, xlator_t *this)
     conf = frame->this->private;
     local = frame->local;
 
-    local->ret_cache = GF_CALLOC(conf->subvolume_cnt + 1, sizeof(int),
+    local->ret_cache = GF_CALLOC(conf->subvolume_cnt + 1, sizeof(gf_return_t),
                                  gf_dht_ret_cache_t);
 
     if (local->ret_cache == NULL) {
@@ -605,8 +610,8 @@ dht_rename_dir(call_frame_t *frame, xlator_t *this)
     return 0;
 
 err:
-    DHT_STACK_UNWIND(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL,
-                     NULL);
+    DHT_STACK_UNWIND(rename, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                     NULL, NULL);
     return 0;
 }
 
@@ -699,8 +704,8 @@ dht_rename_track_for_changelog(xlator_t *this, dict_t *xattr, loc_t *oldloc,
 int
 dht_rename_unlock(call_frame_t *frame, xlator_t *this)
 {
+    int ret;
     dht_local_t *local = NULL;
-    int op_ret = -1;
     char src_gfid[GF_UUID_BUF_SIZE] = {0};
     char dst_gfid[GF_UUID_BUF_SIZE] = {0};
     dht_ilock_wrap_t inodelk_wrapper = {
@@ -711,8 +716,8 @@ dht_rename_unlock(call_frame_t *frame, xlator_t *this)
     inodelk_wrapper.locks = local->rename_inodelk_backward_compatible;
     inodelk_wrapper.lk_count = local->rename_inodelk_bc_count;
 
-    op_ret = dht_unlock_inodelk_wrapper(frame, &inodelk_wrapper);
-    if (op_ret < 0) {
+    ret = dht_unlock_inodelk_wrapper(frame, &inodelk_wrapper);
+    if (ret) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -760,8 +765,9 @@ dht_rename_done(call_frame_t *frame, xlator_t *this)
 
 int
 dht_rename_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *preparent,
-                      struct iatt *postparent, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      struct iatt *preparent, struct iatt *postparent,
+                      dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *prev = NULL;
@@ -779,7 +785,7 @@ dht_rename_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     this_call_cnt = dht_frame_return(frame);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, DHT_MSG_UNLINK_FAILED,
                "%s: Rename: unlink on %s failed ", local->loc.path, prev->name);
     }
@@ -1005,9 +1011,10 @@ unwind:
 
 int
 dht_rename_links_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, inode_t *inode,
-                            struct iatt *stbuf, struct iatt *preparent,
-                            struct iatt *postparent, dict_t *xdata)
+                            gf_return_t op_ret, int32_t op_errno,
+                            inode_t *inode, struct iatt *stbuf,
+                            struct iatt *preparent, struct iatt *postparent,
+                            dict_t *xdata)
 {
     xlator_t *prev = NULL;
     dht_local_t *local = NULL;
@@ -1018,7 +1025,7 @@ dht_rename_links_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     main_frame = local->main_frame;
 
     /* TODO: Handle this case in lookup-optimize */
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, DHT_MSG_CREATE_LINK_FAILED,
                "link/file %s on %s failed", local->loc.path, prev->name);
     }
@@ -1035,7 +1042,7 @@ dht_rename_links_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 dht_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                struct iatt *preoldparent, struct iatt *postoldparent,
                struct iatt *prenewparent, struct iatt *postnewparent,
                dict_t *xdata)
@@ -1076,7 +1083,7 @@ dht_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
      * lookup, the first case by a rebalance, like for all stale linkto
      * files */
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Critical failure: unable to rename the cached file */
         if (prev == src_cached) {
             gf_msg(this->name, GF_LOG_WARNING, op_errno, DHT_MSG_RENAME_FAILED,
@@ -1199,7 +1206,7 @@ dht_do_rename(call_frame_t *frame)
 
 int
 dht_rename_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *stbuf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -1209,16 +1216,16 @@ dht_rename_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg_debug(this->name, 0, "link/file on %s failed (%s)", prev->name,
                      strerror(op_errno));
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
         local->added_link = _gf_false;
     } else
         dht_iatt_merge(this, &local->stbuf, stbuf);
 
-    if (local->op_ret == -1)
+    if (IS_ERROR(local->op_ret))
         goto cleanup;
 
     dht_do_rename(frame);
@@ -1233,7 +1240,7 @@ cleanup:
 
 int
 dht_rename_linkto_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, inode_t *inode,
+                      gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                       struct iatt *stbuf, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata)
 {
@@ -1247,16 +1254,16 @@ dht_rename_linkto_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     prev = cookie;
     src_cached = local->src_cached;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg_debug(this->name, 0, "link/file on %s failed (%s)", prev->name,
                      strerror(op_errno));
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
     }
 
     /* If linkto creation failed move to failure cleanup code,
      * instead of continuing with creating the link file */
-    if (local->op_ret != 0) {
+    if (IS_ERROR(local->op_ret)) {
         goto cleanup;
     }
 
@@ -1287,7 +1294,7 @@ cleanup:
 
 int
 dht_rename_unlink_links_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             struct iatt *preparent, struct iatt *postparent,
                             dict_t *xdata)
 {
@@ -1297,14 +1304,14 @@ dht_rename_unlink_links_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     prev = cookie;
 
-    if ((op_ret == -1) && (op_errno != ENOENT)) {
+    if ((IS_ERROR(op_ret)) && (op_errno != ENOENT)) {
         gf_msg_debug(this->name, 0, "unlink of %s on %s failed (%s)",
                      local->loc2.path, prev->name, strerror(op_errno));
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
     }
 
-    if (local->op_ret == -1)
+    if (IS_ERROR(local->op_ret))
         goto cleanup;
 
     dht_do_rename(frame);
@@ -1422,7 +1429,7 @@ nolinks:
 
 int
 dht_rename_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, inode_t *inode,
+                      gf_return_t op_ret, int op_errno, inode_t *inode,
                       struct iatt *stbuf, dict_t *xattr,
                       struct iatt *postparent)
 {
@@ -1446,7 +1453,7 @@ dht_rename_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     else
         loc = &local->loc2;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         if (is_src)
             local->src_cached = dht_subvol_get_cached(this, local->loc.inode);
         else {
@@ -1488,7 +1495,7 @@ dht_rename_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if (is_src) {
             /* The meaning of is_linkfile is overloaded here. For locking
              * to work properly both rebalance and rename should acquire
@@ -1525,7 +1532,7 @@ dht_rename_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->op_errno = ENOENT;
     }
 
-    if (!local->is_linkfile && (op_ret >= 0) &&
+    if (!local->is_linkfile && IS_SUCCESS(op_ret) &&
         gf_uuid_compare(loc->gfid, stbuf->ia_gfid)) {
         gf_uuid_unparse(loc->gfid, gfid_local);
         gf_uuid_unparse(stbuf->ia_gfid, gfid_server);
@@ -1546,7 +1553,7 @@ dht_rename_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     call_cnt = dht_frame_return(frame);
     if (is_last_call(call_cnt)) {
         if (local->is_linkfile) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             goto fail;
         }
 
@@ -1561,7 +1568,7 @@ fail:
 
 int
 dht_rename_file_lock1_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     char src_gfid[GF_UUID_BUF_SIZE] = {0};
@@ -1572,7 +1579,7 @@ dht_rename_file_lock1_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -1587,7 +1594,7 @@ dht_rename_file_lock1_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                local->loc2.path, dst_gfid,
                local->dst_hashed ? local->dst_hashed->name : NULL);
 
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
         goto err;
     }
@@ -1618,7 +1625,7 @@ err:
 
 int32_t
 dht_rename_file_protect_namespace(call_frame_t *frame, void *cookie,
-                                  xlator_t *this, int32_t op_ret,
+                                  xlator_t *this, gf_return_t op_ret,
                                   int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -1630,7 +1637,7 @@ dht_rename_file_protect_namespace(call_frame_t *frame, void *cookie,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -1643,7 +1650,7 @@ dht_rename_file_protect_namespace(call_frame_t *frame, void *cookie,
                local->loc2.path, dst_gfid,
                local->dst_cached ? local->dst_cached->name : NULL);
 
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
 
         goto err;
@@ -1679,8 +1686,9 @@ err:
 
 int32_t
 dht_rename_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
+    int ret;
     dht_local_t *local = NULL;
     char src_gfid[GF_UUID_BUF_SIZE] = {0};
     char dst_gfid[GF_UUID_BUF_SIZE] = {0};
@@ -1693,7 +1701,7 @@ dht_rename_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     conf = this->private;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(local->loc.inode->gfid, src_gfid);
 
         if (local->loc2.inode)
@@ -1708,7 +1716,7 @@ dht_rename_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                local->loc2.path, dst_gfid,
                local->dst_hashed ? local->dst_hashed->name : NULL);
 
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = op_errno;
 
         goto done;
@@ -1716,15 +1724,15 @@ dht_rename_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     xattr_req = dict_new();
     if (xattr_req == NULL) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOMEM;
         goto done;
     }
 
-    op_ret = dict_set_uint32(xattr_req, conf->link_xattr_name, 256);
-    if (op_ret < 0) {
-        local->op_ret = -1;
-        local->op_errno = -op_ret;
+    ret = dict_set_uint32(xattr_req, conf->link_xattr_name, 256);
+    if (ret) {
+        local->op_ret = gf_error;
+        local->op_errno = -ret;
         goto done;
     }
 
@@ -1957,7 +1965,7 @@ dht_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     if (IA_ISDIR(oldloc->inode->ia_type)) {
         dht_rename_dir(frame, this);
     } else {
-        local->op_ret = 0;
+        local->op_ret = gf_success;
         ret = dht_rename_lock(frame);
         if (ret < 0) {
             op_errno = ENOMEM;
@@ -1969,8 +1977,8 @@ dht_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
 err:
     op_errno = (op_errno == -1) ? errno : op_errno;
-    DHT_STACK_UNWIND(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL,
-                     NULL);
+    DHT_STACK_UNWIND(rename, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                     NULL, NULL);
 
     return 0;
 }

--- a/xlators/cluster/dht/src/dht-selfheal.c
+++ b/xlators/cluster/dht/src/dht-selfheal.c
@@ -65,7 +65,7 @@ dht_overlap_calc(dht_layout_t *old, int o, dht_layout_t *new, int n)
 
 int
 dht_selfheal_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     DHT_STACK_DESTROY(frame);
     return 0;
@@ -78,6 +78,7 @@ dht_selfheal_dir_finish(call_frame_t *frame, xlator_t *this, int ret,
     dht_local_t *local = NULL, *lock_local = NULL;
     call_frame_t *lock_frame = NULL;
     int lock_count = 0;
+    gf_return_t op_ret;
 
     local = frame->local;
 
@@ -115,9 +116,11 @@ dht_selfheal_dir_finish(call_frame_t *frame, xlator_t *this, int ret,
     lock_frame = NULL;
 
 done:
+
+    SET_RET(op_ret, ret);
     if (invoke_cbk)
-        local->selfheal.dir_cbk(frame, NULL, frame->this, ret, local->op_errno,
-                                NULL);
+        local->selfheal.dir_cbk(frame, NULL, frame->this, op_ret,
+                                local->op_errno, NULL);
     if (lock_frame != NULL) {
         DHT_STACK_DESTROY(lock_frame);
     }
@@ -170,10 +173,11 @@ err:
 
 int
 dht_refresh_layout_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, inode_t *inode,
+                       gf_return_t op_ret, int op_errno, inode_t *inode,
                        struct iatt *stbuf, dict_t *xattr,
                        struct iatt *postparent)
 {
+    int ret;
     dht_local_t *local = NULL;
     int this_call_cnt = 0;
     xlator_t *prev = NULL;
@@ -194,21 +198,22 @@ dht_refresh_layout_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     LOCK(&frame->lock);
     {
-        op_ret = dht_layout_merge(this, layout, prev, op_ret, op_errno, xattr);
+        ret = dht_layout_merge(this, layout, prev, op_ret, op_errno, xattr);
 
         dht_iatt_merge(this, &local->stbuf, stbuf);
 
-        if (op_ret == -1) {
+        if (ret == -1) {
             gf_uuid_unparse(local->loc.gfid, gfid);
             local->op_errno = op_errno;
             gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                     DHT_MSG_FILE_LOOKUP_FAILED, "path=%s", local->loc.path,
                     "name=%s", prev->name, "gfid=%s", gfid, NULL);
 
+            SET_RET(op_ret, ret);
             goto unlock;
         }
 
-        local->op_ret = 0;
+        local->op_ret = gf_success;
     }
 unlock:
     UNLOCK(&frame->lock);
@@ -216,7 +221,7 @@ unlock:
     this_call_cnt = dht_frame_return(frame);
 
     if (is_last_call(this_call_cnt)) {
-        if (local->op_ret == 0) {
+        if (IS_SUCCESS(local->op_ret)) {
             local->refresh_layout_done(frame);
         } else {
             goto err;
@@ -253,7 +258,7 @@ dht_refresh_layout(call_frame_t *frame)
 
     call_cnt = conf->subvolume_cnt;
     local->call_cnt = call_cnt;
-    local->op_ret = -1;
+    local->op_ret = gf_error;
 
     if (local->selfheal.refreshed_layout) {
         dht_layout_unref(this, local->selfheal.refreshed_layout);
@@ -309,7 +314,8 @@ out:
 
 int32_t
 dht_selfheal_layout_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                             gf_return_t op_ret, int32_t op_errno,
+                             dict_t *xdata)
 {
     dht_local_t *local = NULL;
 
@@ -319,7 +325,7 @@ dht_selfheal_layout_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto err;
     }
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_errno = op_errno;
         goto err;
     }
@@ -614,7 +620,7 @@ err:
 
 static int
 dht_selfheal_dir_xattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int op_ret, int op_errno, dict_t *xdata)
+                           gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     xlator_t *subvol = NULL;
@@ -630,7 +636,7 @@ dht_selfheal_dir_xattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     layout = local->selfheal.layout;
     subvol = cookie;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         err = 0;
     } else {
         gf_uuid_unparse(local->loc.gfid, gfid);
@@ -807,8 +813,8 @@ err:
 
     GF_FREE(disk_layout);
 
-    dht_selfheal_dir_xattr_cbk(frame, (void *)subvol, frame->this, -1, ENOMEM,
-                               NULL);
+    dht_selfheal_dir_xattr_cbk(frame, (void *)subvol, frame->this, gf_error,
+                               ENOMEM, NULL);
     return 0;
 }
 
@@ -940,8 +946,9 @@ out:
 
 int
 dht_selfheal_dir_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int op_ret, int op_errno, struct iatt *statpre,
-                             struct iatt *statpost, dict_t *xdata)
+                             gf_return_t op_ret, int op_errno,
+                             struct iatt *statpre, struct iatt *statpost,
+                             dict_t *xdata)
 {
     dht_local_t *local = NULL;
     dht_layout_t *layout = NULL;
@@ -1030,7 +1037,7 @@ dht_selfheal_dir_setattr(call_frame_t *frame, loc_t *loc, struct iatt *stbuf,
 
 static int
 dht_selfheal_dir_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int op_ret, int op_errno, inode_t *inode,
+                           gf_return_t op_ret, int op_errno, inode_t *inode,
                            struct iatt *stbuf, struct iatt *preparent,
                            struct iatt *postparent, dict_t *xdata)
 {
@@ -1047,7 +1054,7 @@ dht_selfheal_dir_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     prev = cookie;
     subvol = prev;
 
-    if ((op_ret == 0) || ((op_ret == -1) && (op_errno == EEXIST))) {
+    if (IS_SUCCESS(op_ret) || (IS_ERROR(op_ret) && (op_errno == EEXIST))) {
         for (i = 0; i < layout->cnt; i++) {
             if (layout->list[i].xlator == subvol) {
                 layout->list[i].err = -1;
@@ -1056,7 +1063,7 @@ dht_selfheal_dir_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_uuid_unparse(local->loc.gfid, gfid);
         gf_smsg(this->name,
                 ((op_errno == EEXIST) ? GF_LOG_DEBUG : GF_LOG_WARNING),
@@ -1159,9 +1166,10 @@ err:
 
 static int
 dht_selfheal_dir_mkdir_lookup_cbk(call_frame_t *frame, void *cookie,
-                                  xlator_t *this, int op_ret, int op_errno,
-                                  inode_t *inode, struct iatt *stbuf,
-                                  dict_t *xattr, struct iatt *postparent)
+                                  xlator_t *this, gf_return_t op_ret,
+                                  int op_errno, inode_t *inode,
+                                  struct iatt *stbuf, dict_t *xattr,
+                                  struct iatt *postparent)
 {
     dht_local_t *local = NULL;
     int i = 0;
@@ -1186,7 +1194,7 @@ dht_selfheal_dir_mkdir_lookup_cbk(call_frame_t *frame, void *cookie,
     LOCK(&frame->lock);
     {
         index = dht_layout_index_for_subvol(layout, prev);
-        if ((op_ret < 0) && (op_errno == ENOENT || op_errno == ESTALE)) {
+        if (IS_ERROR(op_ret) && (op_errno == ENOENT || op_errno == ESTALE)) {
             local->selfheal.hole_cnt = !local->selfheal.hole_cnt
                                            ? 1
                                            : local->selfheal.hole_cnt + 1;
@@ -1198,7 +1206,7 @@ dht_selfheal_dir_mkdir_lookup_cbk(call_frame_t *frame, void *cookie,
             }
         }
 
-        if (!op_ret) {
+        if (IS_SUCCESS(op_ret)) {
             dht_iatt_merge(this, &local->stbuf, stbuf);
             if (prev == local->mds_subvol) {
                 dict_unref(local->xattr);
@@ -1253,7 +1261,7 @@ err:
 
 static int
 dht_selfheal_dir_mkdir_lock_cbk(call_frame_t *frame, void *cookie,
-                                xlator_t *this, int32_t op_ret,
+                                xlator_t *this, gf_return_t op_ret,
                                 int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -1270,7 +1278,7 @@ dht_selfheal_dir_mkdir_lock_cbk(call_frame_t *frame, void *cookie,
 
     local->call_cnt = conf->subvolume_cnt;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         /* We get this error when the directory entry was not created
          * on a newky attached tier subvol. Hence proceed and do mkdir
          * on the tier subvol.
@@ -1893,7 +1901,7 @@ dht_selfheal_new_directory(call_frame_t *frame, dht_selfheal_dir_cbk_t dir_cbk,
 
 out:
     if (ret < 0) {
-        dir_cbk(frame, NULL, frame->this, -1, op_errno, NULL);
+        dir_cbk(frame, NULL, frame->this, gf_error, op_errno, NULL);
     }
 
     return 0;
@@ -2300,7 +2308,7 @@ dht_dir_attr_heal_done(int ret, call_frame_t *sync_frame, void *data)
 /* EXIT: dht_update_commit_hash_for_layout */
 static int
 dht_update_commit_hash_for_layout_done(call_frame_t *frame, void *cookie,
-                                       xlator_t *this, int32_t op_ret,
+                                       xlator_t *this, gf_return_t op_ret,
                                        int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -2308,7 +2316,7 @@ dht_update_commit_hash_for_layout_done(call_frame_t *frame, void *cookie,
     local = frame->local;
 
     /* preserve oldest error */
-    if (op_ret && !local->op_ret) {
+    if (IS_ERROR(op_ret) && IS_SUCCESS(local->op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
     }
@@ -2322,6 +2330,7 @@ static int
 dht_update_commit_hash_for_layout_unlock(call_frame_t *frame, xlator_t *this)
 {
     dht_local_t *local = NULL;
+    gf_return_t op_ret;
     int ret = 0;
 
     local = frame->local;
@@ -2331,15 +2340,17 @@ dht_update_commit_hash_for_layout_unlock(call_frame_t *frame, xlator_t *this)
                              dht_update_commit_hash_for_layout_done);
     if (ret < 0) {
         /* preserve oldest error, just ... */
-        if (!local->op_ret) {
+        if (IS_SUCCESS(local->op_ret)) {
             local->op_errno = errno;
-            local->op_ret = -1;
+            local->op_ret = gf_error;
         }
 
         gf_smsg(this->name, GF_LOG_WARNING, errno, DHT_MSG_WIND_UNLOCK_FAILED,
                 "path=%s", local->loc.path, NULL);
 
-        dht_update_commit_hash_for_layout_done(frame, NULL, this, 0, 0, NULL);
+        op_ret = gf_success;
+        dht_update_commit_hash_for_layout_done(frame, NULL, this, op_ret, 0,
+                                               NULL);
     }
 
     return 0;
@@ -2347,8 +2358,8 @@ dht_update_commit_hash_for_layout_unlock(call_frame_t *frame, xlator_t *this)
 
 static int
 dht_update_commit_hash_for_layout_cbk(call_frame_t *frame, void *cookie,
-                                      xlator_t *this, int op_ret, int op_errno,
-                                      dict_t *xdata)
+                                      xlator_t *this, gf_return_t op_ret,
+                                      int op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
     int this_call_cnt = 0;
@@ -2357,7 +2368,7 @@ dht_update_commit_hash_for_layout_cbk(call_frame_t *frame, void *cookie,
 
     LOCK(&frame->lock);
     /* store first failure, just because */
-    if (op_ret && !local->op_ret) {
+    if (IS_ERROR(op_ret) && IS_SUCCESS(local->op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
     }
@@ -2374,7 +2385,7 @@ dht_update_commit_hash_for_layout_cbk(call_frame_t *frame, void *cookie,
 
 static int
 dht_update_commit_hash_for_layout_resume(call_frame_t *frame, void *cookie,
-                                         xlator_t *this, int32_t op_ret,
+                                         xlator_t *this, gf_return_t op_ret,
                                          int32_t op_errno, dict_t *xdata)
 {
     dht_local_t *local = NULL;
@@ -2389,7 +2400,7 @@ dht_update_commit_hash_for_layout_resume(call_frame_t *frame, void *cookie,
     count = conf->local_subvols_cnt;
     layout = local->layout;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto err_done;
     }
 
@@ -2470,7 +2481,7 @@ dht_update_commit_hash_for_layout_resume(call_frame_t *frame, void *cookie,
 
     /* wind the setting of the commit hash across the local subvols */
     local->call_cnt = count;
-    local->op_ret = 0;
+    local->op_ret = gf_success;
     local->op_errno = 0;
     for (i = 0; i < count; i++) {
         STACK_WIND(frame, dht_update_commit_hash_for_layout_cbk,
@@ -2495,15 +2506,16 @@ err:
 
     GF_FREE(disk_layout);
 
-    local->op_ret = -1;
+    local->op_ret = gf_error;
 
     dht_update_commit_hash_for_layout_unlock(frame, this);
 
     return 0;
 err_done:
-    local->op_ret = -1;
 
-    dht_update_commit_hash_for_layout_done(frame, NULL, this, 0, 0, NULL);
+    local->op_ret = gf_error;
+    op_ret = gf_success;
+    dht_update_commit_hash_for_layout_done(frame, NULL, this, op_ret, 0, NULL);
 
     return 0;
 }

--- a/xlators/cluster/ec/src/ec-combine.c
+++ b/xlators/cluster/ec/src/ec-combine.c
@@ -907,15 +907,16 @@ ec_combine_check(ec_cbk_data_t *dst, ec_cbk_data_t *src, ec_combine_f combine)
 {
     ec_fop_data_t *fop = dst->fop;
 
-    if (dst->op_ret != src->op_ret) {
+    if (GET_RET(dst->op_ret) != GET_RET(src->op_ret)) {
         gf_msg_debug(fop->xl->name, 0,
                      "Mismatching return code in "
                      "answers of '%s': %d <-> %d",
-                     ec_fop_name(fop->id), dst->op_ret, src->op_ret);
+                     ec_fop_name(fop->id), GET_RET(dst->op_ret),
+                     GET_RET(src->op_ret));
 
         return 0;
     }
-    if (dst->op_ret < 0) {
+    if (IS_ERROR(dst->op_ret)) {
         if (dst->op_errno != src->op_errno) {
             gf_msg_debug(fop->xl->name, 0,
                          "Mismatching errno code in "
@@ -935,7 +936,7 @@ ec_combine_check(ec_cbk_data_t *dst, ec_cbk_data_t *src, ec_combine_f combine)
         return 0;
     }
 
-    if ((dst->op_ret >= 0) && (combine != NULL)) {
+    if (IS_SUCCESS(dst->op_ret) && (combine != NULL)) {
         return combine(fop, dst, src);
     }
 

--- a/xlators/cluster/ec/src/ec-common.h
+++ b/xlators/cluster/ec/src/ec-common.h
@@ -28,7 +28,7 @@ typedef enum { EC_DATA_TXN, EC_METADATA_TXN } ec_txn_t;
 #define QUORUM_CBK(fn, fop, frame, cookie, this, op_ret, op_errno, params...)  \
     do {                                                                       \
         ec_t *__ec = fop->xl->private;                                         \
-        int32_t __op_ret = 0;                                                  \
+        gf_return_t __op_ret;                                                  \
         int32_t __op_errno = 0;                                                \
         int32_t __success_count = gf_bits_count(fop->good);                    \
                                                                                \
@@ -37,8 +37,8 @@ typedef enum { EC_DATA_TXN, EC_METADATA_TXN } ec_txn_t;
         if (!fop->parent && frame &&                                           \
             (GF_CLIENT_PID_SELF_HEALD != frame->root->pid) &&                  \
             __ec->quorum_count && (__success_count < __ec->quorum_count) &&    \
-            op_ret >= 0) {                                                     \
-            __op_ret = -1;                                                     \
+            IS_SUCCESS(op_ret)) {                                              \
+            __op_ret = gf_error;                                               \
             __op_errno = EIO;                                                  \
             gf_msg(__ec->xl->name, GF_LOG_ERROR, 0,                            \
                    EC_MSG_CHILDS_INSUFFICIENT,                                 \
@@ -214,11 +214,11 @@ ec_get_heal_info(xlator_t *this, loc_t *loc, dict_t **dict);
 
 int32_t
 ec_lock_unlocked(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 void
 ec_update_fd_status(fd_t *fd, xlator_t *xl, int child_index,
-                    int32_t ret_status);
+                    gf_return_t ret_status);
 gf_boolean_t
 ec_is_entry_healing(ec_fop_data_t *fop);
 void

--- a/xlators/cluster/ec/src/ec-data.c
+++ b/xlators/cluster/ec/src/ec-data.c
@@ -15,7 +15,8 @@
 
 ec_cbk_data_t *
 ec_cbk_data_allocate(call_frame_t *frame, xlator_t *this, ec_fop_data_t *fop,
-                     int32_t id, int32_t idx, int32_t op_ret, int32_t op_errno)
+                     int32_t id, int32_t idx, gf_return_t op_ret,
+                     int32_t op_errno)
 {
     ec_cbk_data_t *cbk;
     ec_t *ec = this->private;

--- a/xlators/cluster/ec/src/ec-data.h
+++ b/xlators/cluster/ec/src/ec-data.h
@@ -15,7 +15,8 @@
 
 ec_cbk_data_t *
 ec_cbk_data_allocate(call_frame_t *frame, xlator_t *this, ec_fop_data_t *fop,
-                     int32_t id, int32_t idx, int32_t op_ret, int32_t op_errno);
+                     int32_t id, int32_t idx, gf_return_t op_ret,
+                     int32_t op_errno);
 ec_fop_data_t *
 ec_fop_data_allocate(call_frame_t *frame, xlator_t *this, int32_t id,
                      uint32_t flags, uintptr_t target, uint32_t fop_flags,

--- a/xlators/cluster/ec/src/ec-dir-read.c
+++ b/xlators/cluster/ec/src/ec-dir-read.c
@@ -38,7 +38,7 @@ ec_combine_opendir(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 
 int32_t
 ec_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -52,12 +52,12 @@ ec_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_OPENDIR, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (fd != NULL) {
                 cbk->fd = fd_ref(fd);
                 if (cbk->fd == NULL) {
@@ -189,8 +189,8 @@ ec_manager_opendir(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.opendir != NULL) {
-                fop->cbks.opendir(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                  NULL, NULL);
+                fop->cbks.opendir(fop->req_frame, fop, fop->xl, gf_error,
+                                  fop->error, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -272,7 +272,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }
 
@@ -330,8 +330,8 @@ ec_adjust_readdirp(ec_t *ec, int32_t idx, gf_dirent_t *entries)
 
 int32_t
 ec_common_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
-                      dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      gf_dirent_t *entries, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -345,14 +345,14 @@ ec_common_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, fop->id, idx, op_ret,
                                op_errno);
     if (cbk) {
         if (xdata)
             cbk->xdata = dict_ref(xdata);
-        if (cbk->op_ret >= 0)
+        if (IS_SUCCESS(cbk->op_ret))
             list_splice_init(&entries->list, &cbk->entries.list);
         ec_combine(cbk, NULL);
     }
@@ -449,7 +449,7 @@ ec_manager_readdir(ec_fop_data_t *fop, int32_t state)
                 return EC_STATE_DISPATCH;
             }
 
-            if ((cbk != NULL) && (cbk->op_ret > 0) &&
+            if ((cbk != NULL) && IS_SUCCESS(cbk->op_ret) &&
                 (fop->id == GF_FOP_READDIRP)) {
                 ec_adjust_readdirp(fop->xl->private, cbk->idx, &cbk->entries);
             }
@@ -483,12 +483,12 @@ ec_manager_readdir(ec_fop_data_t *fop, int32_t state)
         case -EC_STATE_REPORT:
             if (fop->id == GF_FOP_READDIR) {
                 if (fop->cbks.readdir != NULL) {
-                    fop->cbks.readdir(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.readdir(fop->req_frame, fop, fop->xl, gf_error,
                                       fop->error, NULL, NULL);
                 }
             } else {
                 if (fop->cbks.readdirp != NULL) {
-                    fop->cbks.readdirp(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.readdirp(fop->req_frame, fop, fop->xl, gf_error,
                                        fop->error, NULL, NULL);
                 }
             }
@@ -572,7 +572,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }
 
@@ -642,6 +642,6 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }

--- a/xlators/cluster/ec/src/ec-dir-write.c
+++ b/xlators/cluster/ec/src/ec-dir-write.c
@@ -17,10 +17,11 @@
 #include "ec-fops.h"
 
 int
-ec_dir_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie, int op_ret,
-                 int op_errno, struct iatt *poststat, struct iatt *preparent,
-                 struct iatt *postparent, struct iatt *preparent2,
-                 struct iatt *postparent2, dict_t *xdata)
+ec_dir_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie,
+                 gf_return_t op_ret, int op_errno, struct iatt *poststat,
+                 struct iatt *preparent, struct iatt *postparent,
+                 struct iatt *preparent2, struct iatt *postparent2,
+                 dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -36,7 +37,7 @@ ec_dir_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie, int op_ret,
     idx = (long)cookie;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, fop->id, idx, op_ret,
                                op_errno);
@@ -46,7 +47,7 @@ ec_dir_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie, int op_ret,
     if (xdata)
         cbk->xdata = dict_ref(xdata);
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     if (poststat)
@@ -76,9 +77,10 @@ out:
 /* FOP: create */
 
 int32_t
-ec_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, fd_t *fd, inode_t *inode, struct iatt *buf,
-              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+ec_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
+              struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+              dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, buf,
                             preparent, postparent, NULL, NULL, xdata);
@@ -231,8 +233,9 @@ ec_manager_create(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.create != NULL) {
-                fop->cbks.create(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL, NULL, NULL, NULL, NULL);
+                fop->cbks.create(fop->req_frame, fop, fop->xl, gf_error,
+                                 fop->error, NULL, NULL, NULL, NULL, NULL,
+                                 NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -318,16 +321,18 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL, NULL,
+             NULL);
     }
 }
 
 /* FOP: link */
 
 int32_t
-ec_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, inode_t *inode, struct iatt *buf,
-            struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+ec_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+            struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+            dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, buf,
                             preparent, postparent, NULL, NULL, xdata);
@@ -403,8 +408,8 @@ ec_manager_link(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.link != NULL) {
-                fop->cbks.link(fop->req_frame, fop, fop->xl, -1, fop->error,
-                               NULL, NULL, NULL, NULL, NULL);
+                fop->cbks.link(fop->req_frame, fop, fop->xl, gf_error,
+                               fop->error, NULL, NULL, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -483,16 +488,17 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL, NULL);
     }
 }
 
 /* FOP: mkdir */
 
 int32_t
-ec_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, inode_t *inode, struct iatt *buf,
-             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+ec_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+             struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+             dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, buf,
                             preparent, postparent, NULL, NULL, xdata);
@@ -584,8 +590,8 @@ ec_manager_mkdir(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.mkdir != NULL) {
-                fop->cbks.mkdir(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                NULL, NULL, NULL, NULL,
+                fop->cbks.mkdir(fop->req_frame, fop, fop->xl, gf_error,
+                                fop->error, NULL, NULL, NULL, NULL,
                                 ((cbk) ? cbk->xdata : NULL));
             }
 
@@ -660,16 +666,17 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL, NULL);
     }
 }
 
 /* FOP: mknod */
 
 int32_t
-ec_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, inode_t *inode, struct iatt *buf,
-             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+ec_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+             struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+             dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, buf,
                             preparent, postparent, NULL, NULL, xdata);
@@ -788,8 +795,8 @@ ec_manager_mknod(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.mknod != NULL) {
-                fop->cbks.mknod(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                NULL, NULL, NULL, NULL, NULL);
+                fop->cbks.mknod(fop->req_frame, fop, fop->xl, gf_error,
+                                fop->error, NULL, NULL, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -864,17 +871,18 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL, NULL);
     }
 }
 
 /* FOP: rename */
 
 int32_t
-ec_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *buf, struct iatt *preoldparent,
-              struct iatt *postoldparent, struct iatt *prenewparent,
-              struct iatt *postnewparent, dict_t *xdata)
+ec_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+              struct iatt *preoldparent, struct iatt *postoldparent,
+              struct iatt *prenewparent, struct iatt *postnewparent,
+              dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, buf,
                             preoldparent, postoldparent, prenewparent,
@@ -947,8 +955,9 @@ ec_manager_rename(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.rename != NULL) {
-                fop->cbks.rename(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL, NULL, NULL, NULL, NULL);
+                fop->cbks.rename(fop->req_frame, fop, fop->xl, gf_error,
+                                 fop->error, NULL, NULL, NULL, NULL, NULL,
+                                 NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -1028,16 +1037,17 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL, NULL,
+             NULL);
     }
 }
 
 /* FOP: rmdir */
 
 int32_t
-ec_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iatt *preparent, struct iatt *postparent,
-             dict_t *xdata)
+ec_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
+             struct iatt *postparent, dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, NULL,
                             preparent, postparent, NULL, NULL, xdata);
@@ -1098,8 +1108,8 @@ ec_manager_rmdir(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.rmdir != NULL) {
-                fop->cbks.rmdir(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                NULL, NULL, NULL);
+                fop->cbks.rmdir(fop->req_frame, fop, fop->xl, gf_error,
+                                fop->error, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -1172,7 +1182,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -1180,7 +1190,7 @@ out:
 
 int32_t
 ec_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *buf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -1253,8 +1263,8 @@ ec_manager_symlink(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.symlink != NULL) {
-                fop->cbks.symlink(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                  NULL, NULL, NULL, NULL, NULL);
+                fop->cbks.symlink(fop->req_frame, fop, fop->xl, gf_error,
+                                  fop->error, NULL, NULL, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -1337,16 +1347,16 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL, NULL);
     }
 }
 
 /* FOP: unlink */
 
 int32_t
-ec_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *preparent, struct iatt *postparent,
-              dict_t *xdata)
+ec_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
+              struct iatt *postparent, dict_t *xdata)
 {
     return ec_dir_write_cbk(frame, this, cookie, op_ret, op_errno, NULL,
                             preparent, postparent, NULL, NULL, xdata);
@@ -1407,8 +1417,8 @@ ec_manager_unlink(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.unlink != NULL) {
-                fop->cbks.unlink(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL, NULL);
+                fop->cbks.unlink(fop->req_frame, fop, fop->xl, gf_error,
+                                 fop->error, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -1482,6 +1492,6 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }

--- a/xlators/cluster/ec/src/ec-generic.c
+++ b/xlators/cluster/ec/src/ec-generic.c
@@ -20,8 +20,8 @@
 /* FOP: flush */
 
 int32_t
-ec_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, dict_t *xdata)
+ec_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -35,7 +35,7 @@ ec_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_FLUSH, idx, op_ret,
                                op_errno);
@@ -121,8 +121,8 @@ ec_manager_flush(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.flush != NULL) {
-                fop->cbks.flush(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                NULL);
+                fop->cbks.flush(fop->req_frame, fop, fop->xl, gf_error,
+                                fop->error, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -238,7 +238,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }
 
@@ -259,9 +259,9 @@ ec_combine_fsync(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 }
 
 int32_t
-ec_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
-             dict_t *xdata)
+ec_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
+             struct iatt *postbuf, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -275,12 +275,12 @@ ec_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_FSYNC, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (prebuf != NULL) {
                 cbk->iatt[0] = *prebuf;
             }
@@ -378,8 +378,8 @@ ec_manager_fsync(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.fsync != NULL) {
-                fop->cbks.fsync(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                NULL, NULL, NULL);
+                fop->cbks.fsync(fop->req_frame, fop, fop->xl, gf_error,
+                                fop->error, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -466,7 +466,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -474,7 +474,7 @@ out:
 
 int32_t
 ec_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -488,7 +488,7 @@ ec_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_FSYNCDIR, idx, op_ret,
                                op_errno);
@@ -574,8 +574,8 @@ ec_manager_fsyncdir(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.fsyncdir != NULL) {
-                fop->cbks.fsyncdir(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                   NULL);
+                fop->cbks.fsyncdir(fop->req_frame, fop, fop->xl, gf_error,
+                                   fop->error, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -653,7 +653,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }
 
@@ -666,7 +666,7 @@ ec_lookup_rebuild(ec_t *ec, ec_fop_data_t *fop, ec_cbk_data_t *cbk)
     uint64_t size = 0;
     int32_t have_size = 0, err;
 
-    if (cbk->op_ret < 0) {
+    if (IS_ERROR(cbk->op_ret)) {
         return;
     }
 
@@ -718,9 +718,9 @@ ec_combine_lookup(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 }
 
 int32_t
-ec_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode, struct iatt *buf, dict_t *xdata,
-              struct iatt *postparent)
+ec_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+              struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -735,12 +735,12 @@ ec_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_LOOKUP, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (inode != NULL) {
                 cbk->inode = inode_ref(inode);
                 if (cbk->inode == NULL) {
@@ -881,8 +881,8 @@ ec_manager_lookup(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.lookup != NULL) {
-                fop->cbks.lookup(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL, NULL, NULL);
+                fop->cbks.lookup(fop->req_frame, fop, fop->xl, gf_error,
+                                 fop->error, NULL, NULL, NULL, NULL);
             }
 
             return EC_STATE_END;
@@ -939,7 +939,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL, NULL);
     }
 }
 
@@ -954,8 +954,9 @@ ec_combine_statfs(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 }
 
 int32_t
-ec_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct statvfs *buf, dict_t *xdata)
+ec_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
+              dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -969,12 +970,12 @@ ec_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_STATFS, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (buf != NULL) {
                 cbk->statvfs = *buf;
             }
@@ -1066,8 +1067,8 @@ ec_manager_statfs(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.statfs != NULL) {
-                fop->cbks.statfs(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL);
+                fop->cbks.statfs(fop->req_frame, fop, fop->xl, gf_error,
+                                 fop->error, NULL, NULL);
             }
 
             return EC_STATE_END;
@@ -1127,7 +1128,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }
 
@@ -1149,7 +1150,8 @@ ec_combine_xattrop(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 
 int32_t
 ec_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, dict_t *xattr, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
+               dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_lock_link_t *link = NULL;
@@ -1167,14 +1169,14 @@ ec_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, fop->id, idx, op_ret,
                                op_errno);
     if (!cbk)
         goto out;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         cbk->dict = dict_ref(xattr);
 
         data = dict_get(cbk->dict, EC_XATTR_VERSION);
@@ -1285,12 +1287,12 @@ ec_manager_xattrop(ec_fop_data_t *fop, int32_t state)
 
             if (fop->id == GF_FOP_XATTROP) {
                 if (fop->cbks.xattrop != NULL) {
-                    fop->cbks.xattrop(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.xattrop(fop->req_frame, fop, fop->xl, gf_error,
                                       fop->error, NULL, NULL);
                 }
             } else {
                 if (fop->cbks.fxattrop != NULL) {
-                    fop->cbks.fxattrop(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.fxattrop(fop->req_frame, fop, fop->xl, gf_error,
                                        fop->error, NULL, NULL);
                 }
             }
@@ -1376,7 +1378,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }
 
@@ -1453,15 +1455,15 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }
 
 /* FOP: IPC */
 
 int32_t
-ec_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-           int32_t op_errno, dict_t *xdata)
+ec_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+           gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -1475,7 +1477,7 @@ ec_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_IPC, idx, op_ret,
                                op_errno);
@@ -1541,8 +1543,8 @@ ec_manager_ipc(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.ipc != NULL) {
-                fop->cbks.ipc(fop->req_frame, fop, fop->xl, -1, fop->error,
-                              NULL);
+                fop->cbks.ipc(fop->req_frame, fop, fop->xl, gf_error,
+                              fop->error, NULL);
             }
 
             return EC_STATE_END;
@@ -1586,6 +1588,6 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }

--- a/xlators/cluster/ec/src/ec-heal.c
+++ b/xlators/cluster/ec/src/ec-heal.c
@@ -152,7 +152,7 @@ ec_heal_check(ec_fop_data_t *fop, uintptr_t *pgood)
 
     list_for_each_entry(cbk, &fop->cbk_list, list)
     {
-        mask[cbk->op_ret >= 0] |= cbk->mask;
+        mask[GET_RET(cbk->op_ret) >= 0] |= cbk->mask;
     }
 
     if (pgood != NULL) {
@@ -199,12 +199,12 @@ ec_heal_avoid(ec_fop_data_t *fop)
 
 int32_t
 ec_heal_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     ec_fop_data_t *fop = cookie;
     ec_heal_t *heal = fop->data;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         GF_ASSERT(
             ec_set_inode_size(heal->fop, heal->fd->inode, heal->total_size));
     }
@@ -295,19 +295,20 @@ ec_wind_xattrop_parallel(call_frame_t *frame, xlator_t *subvol, int child_index,
 
 int32_t
 ec_heal_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     ec_fop_data_t *fop = cookie;
     ec_heal_t *heal = fop->data;
 
-    ec_trace("WRITE_CBK", cookie, "ret=%d, errno=%d", op_ret, op_errno);
+    ec_trace("WRITE_CBK", cookie, "ret=%d, errno=%d", GET_RET(op_ret),
+             op_errno);
 
     gf_msg_debug(fop->xl->name, 0,
                  "%s: write op_ret %d, op_errno %s"
                  " at %" PRIu64,
-                 uuid_utoa(heal->fd->inode->gfid), op_ret, strerror(op_errno),
-                 heal->offset);
+                 uuid_utoa(heal->fd->inode->gfid), GET_RET(op_ret),
+                 strerror(op_errno), heal->offset);
 
     ec_heal_update(cookie, 0);
 
@@ -316,18 +317,18 @@ ec_heal_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 ec_heal_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                  gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                   int32_t count, struct iatt *stbuf, struct iobref *iobref,
                   dict_t *xdata)
 {
     ec_fop_data_t *fop = cookie;
     ec_heal_t *heal = fop->data;
 
-    ec_trace("READ_CBK", fop, "ret=%d, errno=%d", op_ret, op_errno);
+    ec_trace("READ_CBK", fop, "ret=%d, errno=%d", GET_RET(op_ret), op_errno);
 
     ec_heal_avoid(fop);
 
-    if (op_ret > 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_msg_debug(fop->xl->name, 0,
                      "%s: read succeeded, proceeding "
                      "to write at %" PRIu64,
@@ -336,7 +337,7 @@ ec_heal_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                   ec_heal_writev_cbk, heal, heal->fd, vector, count,
                   heal->offset, 0, iobref, NULL);
     } else {
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             gf_msg_debug(fop->xl->name, 0,
                          "%s: read failed %s, failing "
                          "to heal block at %" PRIu64,
@@ -422,7 +423,7 @@ ec_heal_entry_find_direction(ec_t *ec, default_args_cbk_t *replies,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret == -1)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         if (source == -1)
@@ -453,7 +454,7 @@ ec_heal_entry_find_direction(ec_t *ec, default_args_cbk_t *replies,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret == -1)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
 
         if (versions[i] == versions[source])
@@ -476,7 +477,7 @@ ec_adjust_versions(call_frame_t *frame, ec_t *ec, ec_txn_t type, inode_t *inode,
     int ret = 0;
     int call_count = 0;
     dict_t **xattr = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret;
     loc_t loc = {0};
     gf_boolean_t erase_dirty = _gf_false;
     uint64_t *versions_xattr = NULL;
@@ -494,13 +495,13 @@ ec_adjust_versions(call_frame_t *frame, ec_t *ec, ec_txn_t type, inode_t *inode,
     EC_REPLIES_ALLOC(replies, ec->nodes);
     xattr = GF_CALLOC(ec->nodes, sizeof(*xattr), gf_common_mt_pointer);
     if (!xattr) {
-        op_ret = -ENOMEM;
+        SET_RET(op_ret, -ENOMEM);
         goto out;
     }
     for (i = 0; i < ec->nodes; i++) {
         xattr[i] = dict_new();
         if (!xattr[i]) {
-            op_ret = -ENOMEM;
+            SET_RET(op_ret, -ENOMEM);
             goto out;
         }
     }
@@ -511,7 +512,7 @@ ec_adjust_versions(call_frame_t *frame, ec_t *ec, ec_txn_t type, inode_t *inode,
         ec->nodes)
         erase_dirty = _gf_true;
     else
-        op_ret = -ENOTCONN;
+        SET_RET(op_ret, -ENOTCONN);
 
     /* Populate the xattr array */
     for (i = 0; i < ec->nodes; i++) {
@@ -520,7 +521,7 @@ ec_adjust_versions(call_frame_t *frame, ec_t *ec, ec_txn_t type, inode_t *inode,
         versions_xattr = GF_CALLOC(EC_VERSION_SIZE, sizeof(*versions_xattr),
                                    gf_common_mt_pointer);
         if (!versions_xattr) {
-            op_ret = -ENOMEM;
+            SET_RET(op_ret, -ENOMEM);
             continue;
         }
 
@@ -528,7 +529,7 @@ ec_adjust_versions(call_frame_t *frame, ec_t *ec, ec_txn_t type, inode_t *inode,
         ret = dict_set_bin(xattr[i], EC_XATTR_VERSION, versions_xattr,
                            (sizeof(*versions_xattr) * EC_VERSION_SIZE));
         if (ret < 0) {
-            op_ret = -ENOMEM;
+            SET_RET(op_ret, -ENOMEM);
             continue;
         }
 
@@ -536,7 +537,7 @@ ec_adjust_versions(call_frame_t *frame, ec_t *ec, ec_txn_t type, inode_t *inode,
             dirty_xattr = GF_CALLOC(EC_VERSION_SIZE, sizeof(*dirty_xattr),
                                     gf_common_mt_pointer);
             if (!dirty_xattr) {
-                op_ret = -ENOMEM;
+                SET_RET(op_ret, -ENOMEM);
                 continue;
             }
 
@@ -544,7 +545,7 @@ ec_adjust_versions(call_frame_t *frame, ec_t *ec, ec_txn_t type, inode_t *inode,
             ret = dict_set_bin(xattr[i], EC_XATTR_DIRTY, dirty_xattr,
                                (sizeof(*dirty_xattr) * EC_VERSION_SIZE));
             if (ret < 0) {
-                op_ret = -ENOMEM;
+                SET_RET(op_ret, -ENOMEM);
                 continue;
             }
         }
@@ -574,7 +575,7 @@ ec_adjust_versions(call_frame_t *frame, ec_t *ec, ec_txn_t type, inode_t *inode,
     }
 
     if (ret < call_count) {
-        op_ret = -ENOTCONN;
+        SET_RET(op_ret, -ENOTCONN);
         goto out;
     }
 
@@ -589,7 +590,7 @@ out:
     }
     cluster_replies_wipe(replies, ec->nodes);
     loc_wipe(&loc);
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 int
@@ -617,7 +618,7 @@ ec_heal_metadata_find_direction(ec_t *ec, default_args_cbk_t *replies,
     for (i = 0; i < ec->nodes; i++) {
         if (!replies[i].valid)
             continue;
-        if (replies[i].op_ret < 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
         ret = ec_dict_get_array(replies[i].xdata, EC_XATTR_VERSION, xattr,
                                 EC_VERSION_SIZE);
@@ -637,7 +638,7 @@ ec_heal_metadata_find_direction(ec_t *ec, default_args_cbk_t *replies,
         same_count = 1;
         source_ia = replies[i].stat;
         for (j = i + 1; j < ec->nodes; j++) {
-            if (!replies[j].valid || replies[j].op_ret < 0)
+            if (!replies[j].valid || IS_ERROR(replies[j].op_ret))
                 continue;
             child_ia = replies[j].stat;
             if (!IA_EQUAL(source_ia, child_ia, gfid) ||
@@ -667,7 +668,7 @@ ec_heal_metadata_find_direction(ec_t *ec, default_args_cbk_t *replies,
     for (i = 0; i < ec->nodes; i++) {
         if (groups[i] == groups[same_source])
             sources[i] = 1;
-        else if (replies[i].valid && replies[i].op_ret >= 0)
+        else if (replies[i].valid && IS_SUCCESS(replies[i].op_ret))
             healed_sinks[i] = 1;
     }
     for (i = 0; i < ec->nodes; i++) {
@@ -1045,7 +1046,7 @@ ec_delete_stale_name(dict_t *gfid_db, char *key, data_t *d, void *data)
     for (i = 0; i < ec->nodes; i++) {
         if (!replies[i].valid)
             continue;
-        if (replies[i].op_ret == -1) {
+        if (IS_ERROR(replies[i].op_ret)) {
             if (replies[i].op_errno == ESTALE || replies[i].op_errno == ENOENT)
                 estale_count++;
             else
@@ -1076,7 +1077,7 @@ ec_delete_stale_name(dict_t *gfid_db, char *key, data_t *d, void *data)
     gf_uuid_copy(loc.pargfid, loc.parent->gfid);
     loc.name = name_data->name;
     for (i = 0; i < ec->nodes; i++) {
-        if (same[i] && replies[i].valid && (replies[i].op_ret == 0)) {
+        if (same[i] && replies[i].valid && IS_SUCCESS(replies[i].op_ret)) {
             ia = &replies[i].stat;
             break;
         }
@@ -1219,7 +1220,7 @@ ec_create_name(call_frame_t *frame, ec_t *ec, inode_t *parent, char *name,
     for (i = 0; i < ec->nodes; i++) {
         if (!lookup_replies[i].valid)
             continue;
-        if (lookup_replies[i].op_ret)
+        if (IS_ERROR(lookup_replies[i].op_ret))
             continue;
         on[i] = 1;
     }
@@ -1364,7 +1365,7 @@ __ec_heal_name(call_frame_t *frame, ec_t *ec, inode_t *parent, char *name,
         if (!replies[i].valid)
             continue;
 
-        if (replies[i].op_ret == -1) {
+        if (IS_ERROR(replies[i].op_ret)) {
             /*If ESTALE comes here, that means parent dir is not
              * present, nothing to do there, so reset participants
              * for that brick*/
@@ -1692,7 +1693,7 @@ ec_heal_data_find_direction(ec_t *ec, default_args_cbk_t *replies,
     for (i = 0; i < ec->nodes; i++) {
         if (!replies[i].valid)
             continue;
-        if (replies[i].op_ret < 0)
+        if (IS_ERROR(replies[i].op_ret))
             continue;
         dict = (which == EC_COMBINE_XDATA) ? replies[i].xdata
                                            : replies[i].xattr;
@@ -1747,7 +1748,8 @@ ec_heal_data_find_direction(ec_t *ec, default_args_cbk_t *replies,
             goto out;
         memcpy(sources, same, ec->nodes);
         for (i = 0; i < ec->nodes; i++) {
-            if (replies[i].valid && (replies[i].op_ret == 0) && !sources[i])
+            if (replies[i].valid && IS_SUCCESS(replies[i].op_ret) &&
+                !sources[i])
                 healed_sinks[i] = 1;
         }
     }
@@ -1974,15 +1976,15 @@ ec_manager_heal_block(ec_fop_data_t *fop, int32_t state)
 
         case EC_STATE_REPORT:
             if (fop->cbks.heal) {
-                fop->cbks.heal(fop->req_frame, fop->data, fop->xl, 0, 0,
-                               (heal->good | heal->bad), heal->good, heal->bad,
-                               0, NULL);
+                fop->cbks.heal(fop->req_frame, fop->data, fop->xl, gf_success,
+                               0, (heal->good | heal->bad), heal->good,
+                               heal->bad, 0, NULL);
             }
 
             return EC_STATE_END;
         case -EC_STATE_REPORT:
             if (fop->cbks.heal) {
-                fop->cbks.heal(fop->req_frame, fop->data, fop->xl, -1,
+                fop->cbks.heal(fop->req_frame, fop->data, fop->xl, gf_error,
                                fop->error, 0, 0, 0, 0, NULL);
             }
 
@@ -2020,13 +2022,13 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, heal, this, -1, error, 0, 0, 0, 0, NULL);
+        func(frame, heal, this, gf_error, error, 0, 0, 0, 0, NULL);
     }
 }
 
 int32_t
 ec_heal_block_done(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, uintptr_t mask,
+                   gf_return_t op_ret, int32_t op_errno, uintptr_t mask,
                    uintptr_t good, uintptr_t bad, uint32_t pending,
                    dict_t *xdata)
 {
@@ -2036,7 +2038,7 @@ ec_heal_block_done(call_frame_t *frame, void *cookie, xlator_t *this,
         heal->fop->heal = NULL;
     }
     heal->fop = NULL;
-    heal->error = op_ret < 0 ? op_errno : 0;
+    heal->error = IS_ERROR(op_ret) ? op_errno : 0;
     syncbarrier_wake(heal->data);
     return 0;
 }
@@ -2211,13 +2213,13 @@ __ec_fd_data_adjust_versions(call_frame_t *frame, ec_t *ec, fd_t *fd,
     dict_t *xattr = NULL;
     int i = 0;
     int ret = 0;
-    int op_ret = 0;
+    gf_return_t op_ret;
     int source = -1;
     gf_boolean_t erase_dirty = _gf_false;
 
     xattr = dict_new();
     if (!xattr) {
-        op_ret = -ENOMEM;
+        SET_RET(op_ret, -ENOMEM);
         goto out;
     }
 
@@ -2235,7 +2237,7 @@ __ec_fd_data_adjust_versions(call_frame_t *frame, ec_t *ec, fd_t *fd,
     }
 
     if (source == -1) {
-        op_ret = -ENOTCONN;
+        SET_RET(op_ret, -ENOTCONN);
         goto out;
     }
 
@@ -2262,7 +2264,7 @@ __ec_fd_data_adjust_versions(call_frame_t *frame, ec_t *ec, fd_t *fd,
 out:
     if (xattr)
         dict_unref(xattr);
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 int
@@ -2560,7 +2562,7 @@ ec_heal_do(xlator_t *this, void *data, loc_t *loc, int32_t partial)
     unsigned char *healed_sinks = NULL;
     ec_t *ec = NULL;
     int ret = 0;
-    int op_ret = 0;
+    gf_return_t op_ret;
     int op_errno = 0;
     intptr_t mgood = 0;
     intptr_t mbad = 0;
@@ -2658,7 +2660,7 @@ ec_heal_do(xlator_t *this, void *data, loc_t *loc, int32_t partial)
         good = ec_char_array_to_mask(sources, ec->nodes);
         bad = ec_char_array_to_mask(healed_sinks, ec->nodes);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = -ret;
     }
     msources = alloca0(ec->nodes);
@@ -2668,7 +2670,7 @@ ec_heal_do(xlator_t *this, void *data, loc_t *loc, int32_t partial)
         mgood = ec_char_array_to_mask(msources, ec->nodes);
         mbad = ec_char_array_to_mask(mhealed_sinks, ec->nodes);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = -ret;
     }
 
@@ -2728,8 +2730,8 @@ void
 ec_heal_fail(ec_t *ec, ec_fop_data_t *fop)
 {
     if (fop->cbks.heal) {
-        fop->cbks.heal(fop->req_frame, fop->data, ec->xl, -1, fop->error, 0, 0,
-                       0, 0, NULL);
+        fop->cbks.heal(fop->req_frame, fop->data, ec->xl, gf_error, fop->error,
+                       0, 0, 0, 0, NULL);
     }
     ec_fop_data_release(fop);
 }
@@ -2916,7 +2918,7 @@ fail:
     if (fop)
         ec_fop_data_release(fop);
     if (func)
-        func(frame, data, this, -1, err, 0, 0, 0, 0, NULL);
+        func(frame, data, this, gf_error, err, 0, 0, 0, 0, NULL);
 }
 
 int

--- a/xlators/cluster/ec/src/ec-heald.c
+++ b/xlators/cluster/ec/src/ec-heald.c
@@ -575,14 +575,14 @@ int
 ec_heal_op(xlator_t *this, dict_t *output, gf_xl_afr_op_t op, int xl_id)
 {
     char key[64] = {0};
-    int op_ret = 0;
+    gf_return_t op_ret;
     ec_t *ec = NULL;
     int i = 0;
     GF_UNUSED int ret = 0;
 
     ec = this->private;
 
-    op_ret = -1;
+    op_ret = gf_error;
     for (i = 0; i < ec->nodes; i++) {
         snprintf(key, sizeof(key), "%d-%d-status", xl_id, i);
 
@@ -599,10 +599,10 @@ ec_heal_op(xlator_t *this, dict_t *output, gf_xl_afr_op_t op, int xl_id)
             } else if (op == GF_SHD_OP_HEAL_INDEX) {
                 ec_shd_index_healer_spawn(this, i);
             }
-            op_ret = 0;
+            op_ret = gf_success;
         }
     }
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 int

--- a/xlators/cluster/ec/src/ec-inode-read.c
+++ b/xlators/cluster/ec/src/ec-inode-read.c
@@ -19,8 +19,8 @@
 /* FOP: access */
 
 int32_t
-ec_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, dict_t *xdata)
+ec_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -34,7 +34,7 @@ ec_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_ACCESS, idx, op_ret,
                                op_errno);
@@ -105,8 +105,8 @@ ec_manager_access(ec_fop_data_t *fop, int32_t state)
         case -EC_STATE_PREPARE_ANSWER:
         case -EC_STATE_REPORT:
             if (fop->cbks.access != NULL) {
-                fop->cbks.access(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL);
+                fop->cbks.access(fop->req_frame, fop, fop->xl, gf_error,
+                                 fop->error, NULL);
             }
             return EC_STATE_LOCK_REUSE;
 
@@ -179,7 +179,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }
 
@@ -201,7 +201,8 @@ ec_combine_getxattr(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 
 int32_t
 ec_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -215,12 +216,12 @@ ec_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_GETXATTR, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (dict != NULL) {
                 cbk->dict = dict_ref(dict);
                 if (cbk->dict == NULL) {
@@ -271,10 +272,10 @@ ec_handle_special_xattrs(ec_fop_data_t *fop)
     /* Stime may not be available on all the bricks, so even if some of the
      * subvols succeed the operation, treat it as answer.*/
     if (fop->str[0] && fnmatch(GF_XATTR_STIME_PATTERN, fop->str[0], 0) == 0) {
-        if (!fop->answer || (fop->answer->op_ret < 0)) {
+        if (!fop->answer || IS_ERROR(fop->answer->op_ret)) {
             list_for_each_entry(cbk, &fop->cbk_list, list)
             {
-                if (cbk->op_ret >= 0) {
+                if (IS_SUCCESS(cbk->op_ret)) {
                     fop->answer = cbk;
                     break;
                 }
@@ -361,8 +362,8 @@ ec_manager_getxattr(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.getxattr != NULL) {
-                fop->cbks.getxattr(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                   NULL, NULL);
+                fop->cbks.getxattr(fop->req_frame, fop, fop->xl, gf_error,
+                                   fop->error, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -389,7 +390,7 @@ ec_manager_getxattr(ec_fop_data_t *fop, int32_t state)
 
 int32_t
 ec_getxattr_heal_cbk(call_frame_t *frame, void *cookie, xlator_t *xl,
-                     int32_t op_ret, int32_t op_errno, uintptr_t mask,
+                     gf_return_t op_ret, int32_t op_errno, uintptr_t mask,
                      uintptr_t good, uintptr_t bad, uint32_t pending,
                      dict_t *xdata)
 {
@@ -418,10 +419,10 @@ ec_getxattr_heal_cbk(call_frame_t *frame, void *cookie, xlator_t *xl,
         }
     }
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         dict = dict_new();
         if (dict == NULL) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
         } else {
             if (gf_asprintf(&str, "Good: %s, Bad: %s",
@@ -431,7 +432,7 @@ ec_getxattr_heal_cbk(call_frame_t *frame, void *cookie, xlator_t *xl,
                 dict_unref(dict);
                 dict = NULL;
 
-                op_ret = -1;
+                op_ret = gf_error;
                 op_errno = ENOMEM;
 
                 goto out;
@@ -442,7 +443,7 @@ ec_getxattr_heal_cbk(call_frame_t *frame, void *cookie, xlator_t *xl,
                 dict_unref(dict);
                 dict = NULL;
 
-                op_ret = -1;
+                op_ret = gf_error;
                 op_errno = ENOMEM;
 
                 goto out;
@@ -534,7 +535,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }
 
@@ -542,7 +543,8 @@ out:
 
 int32_t
 ec_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                 dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -556,12 +558,12 @@ ec_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_FGETXATTR, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (dict != NULL) {
                 cbk->dict = dict_ref(dict);
                 if (cbk->dict == NULL) {
@@ -665,7 +667,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }
 
@@ -687,8 +689,8 @@ ec_combine_open(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 }
 
 int32_t
-ec_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, fd_t *fd, dict_t *xdata)
+ec_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -702,12 +704,12 @@ ec_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_OPEN, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (fd != NULL) {
                 cbk->fd = fd_ref(fd);
                 if (cbk->fd == NULL) {
@@ -756,14 +758,14 @@ ec_wind_open(ec_t *ec, ec_fop_data_t *fop, int32_t idx)
 
 int32_t
 ec_open_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     ec_fop_data_t *fop = cookie;
     int32_t error = 0;
 
     fop = fop->data;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         fop->answer->iatt[0] = *postbuf;
     } else {
         error = op_errno;
@@ -875,8 +877,8 @@ ec_manager_open(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.open != NULL) {
-                fop->cbks.open(fop->req_frame, fop, fop->xl, -1, fop->error,
-                               NULL, NULL);
+                fop->cbks.open(fop->req_frame, fop, fop->xl, gf_error,
+                               fop->error, NULL, NULL);
             }
 
             return EC_STATE_END;
@@ -948,7 +950,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }
 
@@ -970,7 +972,7 @@ ec_combine_readlink(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 
 int32_t
 ec_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, const char *path,
+                gf_return_t op_ret, int32_t op_errno, const char *path,
                 struct iatt *buf, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
@@ -985,7 +987,7 @@ ec_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, fop->id, idx, op_ret,
                                op_errno);
@@ -993,7 +995,7 @@ ec_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         if (xdata)
             cbk->xdata = dict_ref(xdata);
 
-        if (cbk->op_ret >= 0) {
+        if (IS_SUCCESS(cbk->op_ret)) {
             cbk->iatt[0] = *buf;
             cbk->str = gf_strdup(path);
             if (!cbk->str) {
@@ -1043,7 +1045,7 @@ ec_manager_readlink(ec_fop_data_t *fop, int32_t state)
                 return EC_STATE_DISPATCH;
             }
 
-            if ((cbk != NULL) && (cbk->op_ret >= 0)) {
+            if ((cbk != NULL) && IS_SUCCESS(cbk->op_ret)) {
                 ec_iatt_rebuild(fop->xl->private, &cbk->iatt[0], 1, 1);
             }
 
@@ -1066,8 +1068,8 @@ ec_manager_readlink(ec_fop_data_t *fop, int32_t state)
         case -EC_STATE_PREPARE_ANSWER:
         case -EC_STATE_REPORT:
             if (fop->cbks.readlink != NULL) {
-                fop->cbks.readlink(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                   NULL, NULL, NULL);
+                fop->cbks.readlink(fop->req_frame, fop, fop->xl, gf_error,
+                                   fop->error, NULL, NULL, NULL);
             }
             return EC_STATE_LOCK_REUSE;
 
@@ -1139,7 +1141,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -1155,7 +1157,7 @@ ec_readv_rebuild(ec_t *ec, ec_fop_data_t *fop, ec_cbk_data_t *cbk)
     uint64_t fsize = 0, size = 0, max = 0;
     int32_t pos, err = -ENOMEM;
 
-    if (cbk->op_ret < 0) {
+    if (IS_ERROR(cbk->op_ret)) {
         err = -cbk->op_errno;
 
         goto out;
@@ -1164,11 +1166,11 @@ ec_readv_rebuild(ec_t *ec, ec_fop_data_t *fop, ec_cbk_data_t *cbk)
     /* This shouldn't fail because we have the inode locked. */
     GF_ASSERT(ec_get_inode_size(fop, fop->fd->inode, &cbk->iatt[0].ia_size));
 
-    if (cbk->op_ret > 0) {
+    if (IS_SUCCESS(cbk->op_ret)) {
         void *blocks[cbk->count];
         uint32_t values[cbk->count];
 
-        fsize = cbk->op_ret;
+        fsize = GET_RET(cbk->op_ret);
         size = fsize * ec->fragments;
         for (ans = cbk; ans != NULL; ans = ans->next) {
             pos = gf_bits_count(cbk->mask & ((1 << ans->idx) - 1));
@@ -1216,7 +1218,7 @@ ec_readv_rebuild(ec_t *ec, ec_fop_data_t *fop, ec_cbk_data_t *cbk)
             size = max;
         }
 
-        cbk->op_ret = size;
+        SET_RET(cbk->op_ret, size);
         cbk->int32 = 1;
 
         iobref_unref(cbk->buffers);
@@ -1262,9 +1264,10 @@ ec_combine_readv(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 }
 
 int32_t
-ec_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iovec *vector, int32_t count,
-             struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
+ec_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
+             int32_t count, struct iatt *stbuf, struct iobref *iobref,
+             dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -1279,12 +1282,12 @@ ec_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_READ, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             cbk->int32 = count;
 
             if (count > 0) {
@@ -1323,7 +1326,8 @@ ec_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
             }
         }
 
-        if ((op_ret > 0) && ((op_ret % ec->fragment_size) != 0)) {
+        if (IS_SUCCESS((op_ret)) &&
+            ((GET_RET(op_ret) % ec->fragment_size) != 0)) {
             ec_cbk_set_error(cbk, EIO, _gf_true);
         }
 
@@ -1415,8 +1419,8 @@ ec_manager_readv(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.readv != NULL) {
-                fop->cbks.readv(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                NULL, 0, NULL, NULL, NULL);
+                fop->cbks.readv(fop->req_frame, fop, fop->xl, gf_error,
+                                fop->error, NULL, 0, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -1496,15 +1500,15 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, 0, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, 0, NULL, NULL, NULL);
     }
 }
 
 /* FOP: seek */
 
 int32_t
-ec_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, off_t offset, dict_t *xdata)
+ec_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -1519,20 +1523,20 @@ ec_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_SEEK, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             cbk->offset = offset;
         }
         if (xdata != NULL) {
             cbk->xdata = dict_ref(xdata);
         }
 
-        if ((op_ret > 0) && ((cbk->offset % ec->fragment_size) != 0)) {
-            cbk->op_ret = -1;
+        if (IS_SUCCESS(op_ret) && ((cbk->offset % ec->fragment_size) != 0)) {
+            cbk->op_ret = gf_error;
             cbk->op_errno = EIO;
         }
 
@@ -1597,7 +1601,7 @@ ec_manager_seek(ec_fop_data_t *fop, int32_t state)
             if (ec_dispatch_one_retry(fop, &cbk)) {
                 return EC_STATE_DISPATCH;
             }
-            if ((cbk != NULL) && (cbk->op_ret >= 0)) {
+            if ((cbk != NULL) && IS_SUCCESS(cbk->op_ret)) {
                 ec_t *ec = fop->xl->private;
 
                 /* This shouldn't fail because we have the inode locked. */
@@ -1635,8 +1639,8 @@ ec_manager_seek(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.seek != NULL) {
-                fop->cbks.seek(fop->req_frame, fop, fop->xl, -1, fop->error, 0,
-                               NULL);
+                fop->cbks.seek(fop->req_frame, fop, fop->xl, gf_error,
+                               fop->error, 0, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -1701,7 +1705,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, EIO, 0, NULL);
+        func(frame, NULL, this, gf_error, EIO, 0, NULL);
     }
 }
 
@@ -1722,8 +1726,9 @@ ec_combine_stat(ec_fop_data_t *fop, ec_cbk_data_t *dst, ec_cbk_data_t *src)
 }
 
 int32_t
-ec_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, struct iatt *buf, dict_t *xdata)
+ec_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+            dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -1737,12 +1742,12 @@ ec_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_STAT, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (buf != NULL) {
                 cbk->iatt[0] = *buf;
             }
@@ -1847,12 +1852,12 @@ ec_manager_stat(ec_fop_data_t *fop, int32_t state)
 
             if (fop->id == GF_FOP_STAT) {
                 if (fop->cbks.stat != NULL) {
-                    fop->cbks.stat(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                   NULL, NULL);
+                    fop->cbks.stat(fop->req_frame, fop, fop->xl, gf_error,
+                                   fop->error, NULL, NULL);
                 }
             } else {
                 if (fop->cbks.fstat != NULL) {
-                    fop->cbks.fstat(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.fstat(fop->req_frame, fop, fop->xl, gf_error,
                                     fop->error, NULL, NULL);
                 }
             }
@@ -1926,15 +1931,16 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }
 
 /* FOP: fstat */
 
 int32_t
-ec_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iatt *buf, dict_t *xdata)
+ec_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+             dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -1948,12 +1954,12 @@ ec_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_FSTAT, idx, op_ret,
                                op_errno);
     if (cbk != NULL) {
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             if (buf != NULL) {
                 cbk->iatt[0] = *buf;
             }
@@ -2041,6 +2047,6 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL);
     }
 }

--- a/xlators/cluster/ec/src/ec-inode-write.c
+++ b/xlators/cluster/ec/src/ec-inode-write.c
@@ -18,7 +18,7 @@
 
 int32_t
 ec_update_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     ec_fop_data_t *fop = cookie;
@@ -27,9 +27,9 @@ ec_update_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int i = 0;
 
     ec_trace("UPDATE_WRITEV_CBK", cookie, "ret=%d, errno=%d, parent-fop=%s",
-             op_ret, op_errno, ec_fop_name(parent->id));
+             GET_RET(op_ret), op_errno, ec_fop_name(parent->id));
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         ec_fop_set_error(parent, op_errno);
         goto out;
     }
@@ -109,7 +109,7 @@ out:
 
 int
 ec_inode_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie,
-                   int op_ret, int op_errno, struct iatt *prestat,
+                   gf_return_t op_ret, int op_errno, struct iatt *prestat,
                    struct iatt *poststat, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
@@ -126,14 +126,14 @@ ec_inode_write_cbk(call_frame_t *frame, xlator_t *this, void *cookie,
     idx = (int32_t)(uintptr_t)cookie;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, fop->id, idx, op_ret,
                                op_errno);
     if (!cbk)
         goto out;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     if (xdata)
@@ -157,7 +157,7 @@ out:
 
 int32_t
 ec_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, NULL, NULL,
                               xdata);
@@ -174,8 +174,8 @@ ec_wind_removexattr(ec_t *ec, ec_fop_data_t *fop, int32_t idx)
 }
 
 void
-ec_xattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, dict_t *xdata)
+ec_xattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     ec_fop_data_t *fop = cookie;
     switch (fop->id) {
@@ -253,7 +253,8 @@ ec_manager_xattr(ec_fop_data_t *fop, int32_t state)
         case -EC_STATE_REPORT:
             GF_ASSERT(fop->error != 0);
 
-            ec_xattr_cbk(fop->req_frame, fop, fop->xl, -1, fop->error, NULL);
+            ec_xattr_cbk(fop->req_frame, fop, fop->xl, gf_error, fop->error,
+                         NULL);
 
             return EC_STATE_LOCK_REUSE;
 
@@ -333,7 +334,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }
 
@@ -341,7 +342,7 @@ out:
 
 int32_t
 ec_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, NULL, NULL,
                               xdata);
@@ -417,7 +418,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }
 
@@ -425,7 +426,7 @@ out:
 
 int32_t
 ec_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *prestat,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *prestat,
                struct iatt *poststat, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, prestat,
@@ -513,12 +514,12 @@ ec_manager_setattr(ec_fop_data_t *fop, int32_t state)
 
             if (fop->id == GF_FOP_SETATTR) {
                 if (fop->cbks.setattr != NULL) {
-                    fop->cbks.setattr(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.setattr(fop->req_frame, fop, fop->xl, gf_error,
                                       fop->error, NULL, NULL, NULL);
                 }
             } else {
                 if (fop->cbks.fsetattr != NULL) {
-                    fop->cbks.fsetattr(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.fsetattr(fop->req_frame, fop, fop->xl, gf_error,
                                        fop->error, NULL, NULL, NULL);
                 }
             }
@@ -597,7 +598,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -605,7 +606,7 @@ out:
 
 int32_t
 ec_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prestat,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prestat,
                 struct iatt *poststat, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, prestat,
@@ -678,7 +679,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -686,7 +687,7 @@ out:
 
 int32_t
 ec_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, NULL, NULL,
                               xdata);
@@ -761,7 +762,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }
 
@@ -769,7 +770,7 @@ out:
 
 int32_t
 ec_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     ec_fop_data_t *fop = NULL;
     ec_cbk_data_t *cbk = NULL;
@@ -783,7 +784,7 @@ ec_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop = frame->local;
 
     ec_trace("CBK", fop, "idx=%d, frame=%p, op_ret=%d, op_errno=%d", idx, frame,
-             op_ret, op_errno);
+             GET_RET(op_ret), op_errno);
 
     cbk = ec_cbk_data_allocate(frame, this, fop, GF_FOP_FSETXATTR, idx, op_ret,
                                op_errno);
@@ -883,7 +884,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL);
+        func(frame, NULL, this, gf_error, error, NULL);
     }
 }
 
@@ -895,7 +896,7 @@ out:
 
 int32_t
 ec_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, prebuf,
@@ -1004,7 +1005,7 @@ ec_manager_fallocate(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.fallocate != NULL) {
-                fop->cbks.fallocate(fop->req_frame, fop, fop->xl, -1,
+                fop->cbks.fallocate(fop->req_frame, fop, fop->xl, gf_error,
                                     fop->error, NULL, NULL, NULL);
             }
 
@@ -1083,7 +1084,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -1147,7 +1148,7 @@ ec_discard_adjust_offset_size(ec_fop_data_t *fop)
 
 int32_t
 ec_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                struct iatt *postbuf, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, prebuf,
@@ -1215,7 +1216,7 @@ ec_manager_discard(ec_fop_data_t *fop, int32_t state)
         case EC_STATE_DELAYED_START:
 
             if (fop->size) {
-                if (fop->answer && fop->answer->op_ret == 0)
+                if (fop->answer && IS_SUCCESS(fop->answer->op_ret))
                     ec_update_discard_write(fop, fop->answer->mask);
             } else {
                 ec_update_discard_write(fop, fop->mask);
@@ -1258,8 +1259,8 @@ ec_manager_discard(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.discard != NULL) {
-                fop->cbks.discard(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                  NULL, NULL, NULL);
+                fop->cbks.discard(fop->req_frame, fop, fop->xl, gf_error,
+                                  fop->error, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -1324,7 +1325,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -1344,13 +1345,14 @@ ec_update_truncate_write(ec_fop_data_t *fop, uintptr_t mask)
 
 int32_t
 ec_truncate_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                     dict_t *xdata)
 {
     ec_fop_data_t *fop = cookie;
     int32_t err;
 
     fop->parent->good &= fop->good;
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         fd_bind(fd);
         err = ec_update_truncate_write(fop->parent, fop->answer->mask);
         if (err != 0) {
@@ -1381,7 +1383,7 @@ ec_truncate_clean(ec_fop_data_t *fop)
 
 int32_t
 ec_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prestat,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prestat,
                 struct iatt *poststat, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, prestat,
@@ -1495,12 +1497,12 @@ ec_manager_truncate(ec_fop_data_t *fop, int32_t state)
 
             if (fop->id == GF_FOP_TRUNCATE) {
                 if (fop->cbks.truncate != NULL) {
-                    fop->cbks.truncate(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.truncate(fop->req_frame, fop, fop->xl, gf_error,
                                        fop->error, NULL, NULL, NULL);
                 }
             } else {
                 if (fop->cbks.ftruncate != NULL) {
-                    fop->cbks.ftruncate(fop->req_frame, fop, fop->xl, -1,
+                    fop->cbks.ftruncate(fop->req_frame, fop, fop->xl, gf_error,
                                         fop->error, NULL, NULL, NULL);
                 }
             }
@@ -1576,7 +1578,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -1584,7 +1586,7 @@ out:
 
 int32_t
 ec_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prestat,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prestat,
                  struct iatt *poststat, dict_t *xdata)
 {
     return ec_inode_write_cbk(frame, this, cookie, op_ret, op_errno, prestat,
@@ -1654,7 +1656,7 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }
 
@@ -1732,7 +1734,7 @@ out:
 
 int32_t
 ec_writev_merge_tail(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                     gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                      int32_t count, struct iatt *stbuf, struct iobref *iobref,
                      dict_t *xdata)
 {
@@ -1740,12 +1742,12 @@ ec_writev_merge_tail(call_frame_t *frame, void *cookie, xlator_t *this,
     ec_fop_data_t *fop = frame->local;
     uint64_t size, base, tmp;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         tmp = 0;
         size = fop->size - fop->user_size - fop->head;
         base = ec->stripe_size - size;
-        if (op_ret > base) {
-            tmp = min(op_ret - base, size);
+        if (GET_RET(op_ret) > base) {
+            tmp = min(GET_RET(op_ret) - base, size);
             ec_iov_copy_to(fop->vector[0].iov_base + fop->size - size, vector,
                            count, base, tmp);
 
@@ -1765,7 +1767,7 @@ ec_writev_merge_tail(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 ec_writev_merge_head(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                     gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                      int32_t count, struct iatt *stbuf, struct iobref *iobref,
                      dict_t *xdata)
 {
@@ -1773,12 +1775,12 @@ ec_writev_merge_head(call_frame_t *frame, void *cookie, xlator_t *this,
     ec_fop_data_t *fop = frame->local;
     uint64_t size, base;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         size = fop->head;
         base = 0;
 
-        if (op_ret > 0) {
-            base = min(op_ret, size);
+        if (IS_SUCCESS(op_ret)) {
+            base = min(GET_RET(op_ret), size);
             ec_iov_copy_to(fop->vector[0].iov_base, vector, count, 0, base);
 
             size -= base;
@@ -2087,15 +2089,16 @@ failed:
 }
 
 int32_t
-ec_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *prestat, struct iatt *poststat,
-              dict_t *xdata)
+ec_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *prestat,
+              struct iatt *poststat, dict_t *xdata)
 {
     ec_t *ec = NULL;
     if (this && this->private) {
         ec = this->private;
-        if ((op_ret > 0) && ((op_ret % ec->fragment_size) != 0)) {
-            op_ret = -1;
+        if (IS_SUCCESS(op_ret) &&
+            ((GET_RET(op_ret) % ec->fragment_size) != 0)) {
+            op_ret = gf_error;
             op_errno = EIO;
         }
     }
@@ -2218,14 +2221,17 @@ ec_manager_writev(ec_fop_data_t *fop, int32_t state)
                 UNLOCK(&fop->fd->inode->lock);
 
                 if (fop->error == 0) {
-                    cbk->op_ret *= ec->fragments;
-                    if (cbk->op_ret < fop->head) {
-                        cbk->op_ret = 0;
+                    int32_t temp = GET_RET(cbk->op_ret);
+                    temp *= ec->fragments;
+                    if (temp < fop->head) {
+                        cbk->op_ret = gf_success;
+                        temp = 0;
                     } else {
-                        cbk->op_ret -= fop->head;
+                        temp -= fop->head;
+                        SET_RET(cbk->op_ret, temp);
                     }
-                    if (cbk->op_ret > fop->user_size) {
-                        cbk->op_ret = fop->user_size;
+                    if (temp > fop->user_size) {
+                        SET_RET(cbk->op_ret, fop->user_size);
                     }
                 }
             }
@@ -2261,8 +2267,8 @@ ec_manager_writev(ec_fop_data_t *fop, int32_t state)
             GF_ASSERT(fop->error != 0);
 
             if (fop->cbks.writev != NULL) {
-                fop->cbks.writev(fop->req_frame, fop, fop->xl, -1, fop->error,
-                                 NULL, NULL, NULL);
+                fop->cbks.writev(fop->req_frame, fop, fop->xl, gf_error,
+                                 fop->error, NULL, NULL, NULL);
             }
 
             return EC_STATE_LOCK_REUSE;
@@ -2364,6 +2370,6 @@ out:
     if (fop != NULL) {
         ec_manager(fop, error);
     } else {
-        func(frame, NULL, this, -1, error, NULL, NULL, NULL);
+        func(frame, NULL, this, gf_error, error, NULL, NULL, NULL);
     }
 }

--- a/xlators/cluster/ec/src/ec-types.h
+++ b/xlators/cluster/ec/src/ec-types.h
@@ -189,12 +189,12 @@ struct _ec_inode {
     uint64_t bad_version;
 };
 
-typedef int32_t (*fop_heal_cbk_t)(call_frame_t *, void *, xlator_t *, int32_t,
-                                  int32_t, uintptr_t, uintptr_t, uintptr_t,
-                                  uint32_t, dict_t *);
-typedef int32_t (*fop_fheal_cbk_t)(call_frame_t *, void *, xlator_t *, int32_t,
-                                   int32_t, uintptr_t, uintptr_t, uintptr_t,
-                                   uint32_t, dict_t *);
+typedef int32_t (*fop_heal_cbk_t)(call_frame_t *, void *, xlator_t *,
+                                  gf_return_t, int32_t, uintptr_t, uintptr_t,
+                                  uintptr_t, uint32_t, dict_t *);
+typedef int32_t (*fop_fheal_cbk_t)(call_frame_t *, void *, xlator_t *,
+                                   gf_return_t, int32_t, uintptr_t, uintptr_t,
+                                   uintptr_t, uint32_t, dict_t *);
 
 union _ec_cbk {
     fop_access_cbk_t access;
@@ -399,7 +399,7 @@ struct _ec_cbk_data {
     ec_fop_data_t *fop;
     ec_cbk_data_t *next; /* next answer in the same group */
     uint32_t idx;
-    int32_t op_ret;
+    gf_return_t op_ret;
     int32_t op_errno;
     int32_t count;
     uintptr_t mask;

--- a/xlators/cluster/ec/src/ec.c
+++ b/xlators/cluster/ec/src/ec.c
@@ -1039,7 +1039,7 @@ ec_handle_heal_commands(call_frame_t *frame, xlator_t *this, loc_t *loc,
                         const char *name, dict_t *xdata)
 {
     dict_t *dict_rsp = NULL;
-    int op_ret = -1;
+    gf_return_t op_ret = {-1};
     int op_errno = ENOMEM;
 
     if (!name || strcmp(name, GF_HEAL_INFO))
@@ -1047,7 +1047,8 @@ ec_handle_heal_commands(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     op_errno = -ec_get_heal_info(this, loc, &dict_rsp);
     if (op_errno <= 0) {
-        op_errno = op_ret = 0;
+        op_errno = 0;
+        op_ret = gf_success;
     }
 
     STACK_UNWIND_STRICT(getxattr, frame, op_ret, op_errno, dict_rsp, NULL);
@@ -1086,7 +1087,7 @@ ec_gf_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     return 0;
 out:
     error = ENODATA;
-    STACK_UNWIND_STRICT(getxattr, frame, -1, error, NULL, NULL);
+    STACK_UNWIND_STRICT(getxattr, frame, gf_error, error, NULL, NULL);
     return 0;
 }
 
@@ -1103,7 +1104,7 @@ ec_gf_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
     return 0;
 out:
     error = ENODATA;
-    STACK_UNWIND_STRICT(fgetxattr, frame, -1, error, NULL, NULL);
+    STACK_UNWIND_STRICT(fgetxattr, frame, gf_error, error, NULL, NULL);
     return 0;
 }
 
@@ -1262,7 +1263,7 @@ ec_gf_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     return 0;
 out:
-    STACK_UNWIND_STRICT(removexattr, frame, -1, error, NULL);
+    STACK_UNWIND_STRICT(removexattr, frame, gf_error, error, NULL);
     return 0;
 }
 
@@ -1279,7 +1280,7 @@ ec_gf_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     return 0;
 out:
-    STACK_UNWIND_STRICT(fremovexattr, frame, -1, error, NULL);
+    STACK_UNWIND_STRICT(fremovexattr, frame, gf_error, error, NULL);
     return 0;
 }
 
@@ -1336,7 +1337,7 @@ ec_gf_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
 
     return 0;
 out:
-    STACK_UNWIND_STRICT(setxattr, frame, -1, error, NULL);
+    STACK_UNWIND_STRICT(setxattr, frame, gf_error, error, NULL);
     return 0;
 }
 
@@ -1353,7 +1354,7 @@ ec_gf_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
 
     return 0;
 out:
-    STACK_UNWIND_STRICT(fsetxattr, frame, -1, error, NULL);
+    STACK_UNWIND_STRICT(fsetxattr, frame, gf_error, error, NULL);
     return 0;
 }
 

--- a/xlators/debug/error-gen/src/error-gen.c
+++ b/xlators/debug/error-gen/src/error-gen.c
@@ -293,8 +293,8 @@ error_gen_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         op_errno = error_gen(this, GF_FOP_LOOKUP);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(lookup, frame, -1, op_errno, NULL, NULL, NULL,
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(lookup, frame, gf_error, op_errno, NULL, NULL, NULL,
                             NULL);
         return 0;
     }
@@ -318,8 +318,8 @@ error_gen_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         op_errno = error_gen(this, GF_FOP_STAT);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(stat, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(stat, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -343,8 +343,9 @@ error_gen_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         op_errno = error_gen(this, GF_FOP_SETATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(setattr, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(setattr, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -368,8 +369,9 @@ error_gen_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
         op_errno = error_gen(this, GF_FOP_FSETATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fsetattr, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fsetattr, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -393,8 +395,9 @@ error_gen_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc,
         op_errno = error_gen(this, GF_FOP_TRUNCATE);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(truncate, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(truncate, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -418,8 +421,9 @@ error_gen_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         op_errno = error_gen(this, GF_FOP_FTRUNCATE);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(ftruncate, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(ftruncate, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -443,8 +447,8 @@ error_gen_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t mask,
         op_errno = error_gen(this, GF_FOP_ACCESS);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(access, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(access, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -468,8 +472,9 @@ error_gen_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
         op_errno = error_gen(this, GF_FOP_READLINK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(readlink, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(readlink, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -493,9 +498,9 @@ error_gen_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
         op_errno = error_gen(this, GF_FOP_MKNOD);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                            xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(mknod, frame, gf_error, op_errno, NULL, NULL, NULL,
+                            NULL, xdata);
         return 0;
     }
 
@@ -519,9 +524,9 @@ error_gen_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
         op_errno = error_gen(this, GF_FOP_MKDIR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                            xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL,
+                            NULL, xdata);
         return 0;
     }
 
@@ -545,8 +550,9 @@ error_gen_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
         op_errno = error_gen(this, GF_FOP_UNLINK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(unlink, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(unlink, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -570,8 +576,9 @@ error_gen_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
         op_errno = error_gen(this, GF_FOP_RMDIR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(rmdir, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(rmdir, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -595,9 +602,9 @@ error_gen_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
         op_errno = error_gen(this, GF_FOP_SYMLINK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(symlink, frame, -1, op_errno, NULL, NULL, NULL,
-                            NULL, NULL); /* pre & post parent attr */
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(symlink, frame, gf_error, op_errno, NULL, NULL,
+                            NULL, NULL, NULL); /* pre & post parent attr */
         return 0;
     }
 
@@ -621,9 +628,9 @@ error_gen_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
         op_errno = error_gen(this, GF_FOP_RENAME);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(rename, frame, gf_error, op_errno, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
         return 0;
     }
 
@@ -647,9 +654,9 @@ error_gen_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
         op_errno = error_gen(this, GF_FOP_LINK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                            NULL);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(link, frame, gf_error, op_errno, NULL, NULL, NULL,
+                            NULL, NULL);
         return 0;
     }
 
@@ -673,9 +680,9 @@ error_gen_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
         op_errno = error_gen(this, GF_FOP_CREATE);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(create, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(create, frame, gf_error, op_errno, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
         return 0;
     }
 
@@ -699,8 +706,8 @@ error_gen_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
         op_errno = error_gen(this, GF_FOP_OPEN);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(open, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(open, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -724,9 +731,9 @@ error_gen_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         op_errno = error_gen(this, GF_FOP_READ);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(readv, frame, -1, op_errno, NULL, 0, NULL, NULL,
-                            xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(readv, frame, gf_error, op_errno, NULL, 0, NULL,
+                            NULL, xdata);
         return 0;
     }
 
@@ -762,8 +769,9 @@ error_gen_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
         count = 1;
         goto wind;
     } else if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(writev, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(writev, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 wind:
@@ -790,8 +798,8 @@ error_gen_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
         op_errno = error_gen(this, GF_FOP_FLUSH);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(flush, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(flush, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -815,8 +823,9 @@ error_gen_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
         op_errno = error_gen(this, GF_FOP_FSYNC);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fsync, frame, -1, op_errno, NULL, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fsync, frame, gf_error, op_errno, NULL, NULL,
+                            xdata);
         return 0;
     }
 
@@ -839,8 +848,8 @@ error_gen_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
         op_errno = error_gen(this, GF_FOP_FSTAT);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fstat, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fstat, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -864,8 +873,8 @@ error_gen_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
         op_errno = error_gen(this, GF_FOP_OPENDIR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(opendir, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(opendir, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -889,8 +898,8 @@ error_gen_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
         op_errno = error_gen(this, GF_FOP_FSYNCDIR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fsyncdir, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fsyncdir, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -913,8 +922,8 @@ error_gen_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         op_errno = error_gen(this, GF_FOP_STATFS);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(statfs, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(statfs, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -938,8 +947,8 @@ error_gen_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         op_errno = error_gen(this, GF_FOP_SETXATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(setxattr, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(setxattr, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -963,8 +972,8 @@ error_gen_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         op_errno = error_gen(this, GF_FOP_GETXATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(getxattr, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(getxattr, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -988,8 +997,8 @@ error_gen_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
         op_errno = error_gen(this, GF_FOP_FSETXATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fsetxattr, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fsetxattr, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1013,8 +1022,8 @@ error_gen_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
         op_errno = error_gen(this, GF_FOP_FGETXATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fgetxattr, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fgetxattr, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -1038,8 +1047,8 @@ error_gen_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc,
         op_errno = error_gen(this, GF_FOP_XATTROP);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(xattrop, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(xattrop, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -1063,8 +1072,8 @@ error_gen_fxattrop(call_frame_t *frame, xlator_t *this, fd_t *fd,
         op_errno = error_gen(this, GF_FOP_FXATTROP);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fxattrop, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fxattrop, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -1088,8 +1097,8 @@ error_gen_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         op_errno = error_gen(this, GF_FOP_REMOVEXATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(removexattr, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(removexattr, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1113,8 +1122,8 @@ error_gen_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
         op_errno = error_gen(this, GF_FOP_FREMOVEXATTR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fremovexattr, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fremovexattr, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1138,8 +1147,8 @@ error_gen_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
         op_errno = error_gen(this, GF_FOP_LK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(lk, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(lk, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -1163,8 +1172,8 @@ error_gen_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
         op_errno = error_gen(this, GF_FOP_INODELK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(inodelk, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(inodelk, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1188,8 +1197,8 @@ error_gen_finodelk(call_frame_t *frame, xlator_t *this, const char *volume,
         op_errno = error_gen(this, GF_FOP_FINODELK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(finodelk, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(finodelk, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1214,8 +1223,8 @@ error_gen_entrylk(call_frame_t *frame, xlator_t *this, const char *volume,
         op_errno = error_gen(this, GF_FOP_ENTRYLK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(entrylk, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(entrylk, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1240,8 +1249,8 @@ error_gen_fentrylk(call_frame_t *frame, xlator_t *this, const char *volume,
         op_errno = error_gen(this, GF_FOP_FENTRYLK);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(fentrylk, frame, -1, op_errno, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(fentrylk, frame, gf_error, op_errno, xdata);
         return 0;
     }
 
@@ -1265,8 +1274,8 @@ error_gen_getspec(call_frame_t *frame, xlator_t *this, const char *key,
         op_errno = error_gen(this, GF_FOP_GETSPEC);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(getspec, frame, -1, op_errno, NULL);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(getspec, frame, gf_error, op_errno, NULL);
         return 0;
     }
 
@@ -1290,8 +1299,8 @@ error_gen_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         op_errno = error_gen(this, GF_FOP_READDIR);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(readdir, frame, -1, op_errno, NULL, xdata);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(readdir, frame, gf_error, op_errno, NULL, xdata);
         return 0;
     }
 
@@ -1315,8 +1324,8 @@ error_gen_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
         op_errno = error_gen(this, GF_FOP_READDIRP);
 
     if (op_errno) {
-        GF_ERROR(this, "unwind(-1, %s)", strerror(op_errno));
-        STACK_UNWIND_STRICT(readdirp, frame, -1, op_errno, NULL, NULL);
+        GF_ERROR(this, "unwind(gf_error, %s)", strerror(op_errno));
+        STACK_UNWIND_STRICT(readdirp, frame, gf_error, op_errno, NULL, NULL);
         return 0;
     }
 

--- a/xlators/debug/io-stats/src/io-stats.c
+++ b/xlators/debug/io-stats/src/io-stats.c
@@ -293,7 +293,7 @@ is_fop_latency_started(call_frame_t *frame)
         end = &frame->end;                                                     \
                                                                                \
         elapsed = gf_tsdiff(begin, end) / 1000.0;                              \
-        throughput = op_ret / elapsed;                                         \
+        throughput = GET_RET(op_ret) / elapsed;                                \
                                                                                \
         conf = this->private;                                                  \
         gettimeofday(&tv, NULL);                                               \
@@ -1912,8 +1912,8 @@ out:
 
 int
 io_stats_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                    struct iatt *buf, struct iatt *preparent,
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    inode_t *inode, struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
     struct ios_fd *iosfd = NULL;
@@ -1929,7 +1929,7 @@ io_stats_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!path)
         goto unwind;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         GF_FREE(path);
         goto unwind;
     }
@@ -1967,7 +1967,7 @@ unwind:
 
 int
 io_stats_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     struct ios_fd *iosfd = NULL;
     char *path = NULL;
@@ -1982,7 +1982,7 @@ io_stats_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!path)
         goto unwind;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         GF_FREE(path);
         goto unwind;
     }
@@ -2031,7 +2031,7 @@ unwind:
 
 int
 io_stats_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, STAT);
@@ -2041,7 +2041,7 @@ io_stats_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                   gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                    int32_t count, struct iatt *buf, struct iobref *iobref,
                    dict_t *xdata)
 {
@@ -2052,7 +2052,7 @@ io_stats_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fd = frame->local;
     frame->local = NULL;
 
-    if (op_ret > 0) {
+    if (IS_SUCCESS(op_ret)) {
         len = iov_length(vector, count);
         ios_bump_read(this, fd, len);
     }
@@ -2073,7 +2073,7 @@ io_stats_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     struct ios_stat *iosstat = NULL;
@@ -2099,7 +2099,7 @@ io_stats_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              struct iatt *stbuf, struct iatt *prebuf_dst,
                              struct iatt *postbuf_dst, dict_t *xdata)
 {
@@ -2112,7 +2112,7 @@ io_stats_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, gf_dirent_t *buf,
+                      gf_return_t op_ret, int32_t op_errno, gf_dirent_t *buf,
                       dict_t *xdata)
 {
     struct ios_stat *iosstat = NULL;
@@ -2135,7 +2135,7 @@ io_stats_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, gf_dirent_t *buf,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *buf,
                      dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, READDIR);
@@ -2145,7 +2145,7 @@ io_stats_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FSYNC);
@@ -2155,7 +2155,7 @@ io_stats_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *preop,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *preop,
                      struct iatt *postop, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, SETATTR);
@@ -2165,8 +2165,9 @@ io_stats_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, UNLINK);
     STACK_UNWIND_STRICT(unlink, frame, op_ret, op_errno, preparent, postparent,
@@ -2176,7 +2177,7 @@ io_stats_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                     struct iatt *preoldparent, struct iatt *postoldparent,
                     struct iatt *prenewparent, struct iatt *postnewparent,
                     dict_t *xdata)
@@ -2189,7 +2190,7 @@ io_stats_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, const char *buf,
+                      gf_return_t op_ret, int32_t op_errno, const char *buf,
                       struct iatt *sbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, READLINK);
@@ -2199,7 +2200,7 @@ io_stats_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     UPDATE_PROFILE_STATS(frame, LOOKUP);
@@ -2210,7 +2211,7 @@ io_stats_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, inode_t *inode,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                      struct iatt *buf, struct iatt *preparent,
                      struct iatt *postparent, dict_t *xdata)
 {
@@ -2222,7 +2223,7 @@ io_stats_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -2234,7 +2235,7 @@ io_stats_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -2244,7 +2245,7 @@ io_stats_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto unwind;
 
     UPDATE_PROFILE_STATS(frame, MKDIR);
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     /* allocate a struct ios_stat and set the inode ctx */
@@ -2261,7 +2262,7 @@ unwind:
 
 int
 io_stats_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
@@ -2273,7 +2274,7 @@ io_stats_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FLUSH);
     STACK_UNWIND_STRICT(flush, frame, op_ret, op_errno, xdata);
@@ -2282,13 +2283,14 @@ io_stats_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                     dict_t *xdata)
 {
     struct ios_stat *iosstat = NULL;
     int ret = -1;
 
     UPDATE_PROFILE_STATS(frame, OPENDIR);
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     ios_fd_ctx_set(fd, this, 0);
@@ -2304,7 +2306,7 @@ unwind:
 
 int
 io_stats_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, RMDIR);
@@ -2316,7 +2318,7 @@ io_stats_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, TRUNCATE);
@@ -2327,7 +2329,7 @@ io_stats_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                    gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                     dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, STATFS);
@@ -2337,7 +2339,7 @@ io_stats_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, SETXATTR);
     STACK_UNWIND_STRICT(setxattr, frame, op_ret, op_errno, xdata);
@@ -2346,7 +2348,7 @@ io_stats_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                       dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, GETXATTR);
@@ -2356,7 +2358,7 @@ io_stats_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, REMOVEXATTR);
     STACK_UNWIND_STRICT(removexattr, frame, op_ret, op_errno, xdata);
@@ -2365,7 +2367,7 @@ io_stats_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FSETXATTR);
     STACK_UNWIND_STRICT(fsetxattr, frame, op_ret, op_errno, xdata);
@@ -2374,7 +2376,7 @@ io_stats_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *dict,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                        dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FGETXATTR);
@@ -2384,7 +2386,7 @@ io_stats_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FREMOVEXATTR);
     STACK_UNWIND_STRICT(fremovexattr, frame, op_ret, op_errno, xdata);
@@ -2393,7 +2395,7 @@ io_stats_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FSYNCDIR);
     STACK_UNWIND_STRICT(fsyncdir, frame, op_ret, op_errno, xdata);
@@ -2402,7 +2404,7 @@ io_stats_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, ACCESS);
     STACK_UNWIND_STRICT(access, frame, op_ret, op_errno, xdata);
@@ -2411,8 +2413,8 @@ io_stats_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                       struct iatt *postbuf, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *prebuf, struct iatt *postbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FTRUNCATE);
     STACK_UNWIND_STRICT(ftruncate, frame, op_ret, op_errno, prebuf, postbuf,
@@ -2422,7 +2424,7 @@ io_stats_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                    dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FSTAT);
@@ -2432,8 +2434,8 @@ io_stats_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                       struct iatt *postbuf, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *prebuf, struct iatt *postbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FALLOCATE);
     STACK_UNWIND_STRICT(fallocate, frame, op_ret, op_errno, prebuf, postbuf,
@@ -2443,7 +2445,7 @@ io_stats_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, DISCARD);
@@ -2454,7 +2456,7 @@ io_stats_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, ZEROFILL);
@@ -2465,7 +2467,7 @@ io_stats_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 io_stats_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, IPC);
     STACK_UNWIND_STRICT(ipc, frame, op_ret, op_errno, xdata);
@@ -2474,7 +2476,7 @@ io_stats_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+                gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                 dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, LK);
@@ -2484,7 +2486,7 @@ io_stats_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, ENTRYLK);
     STACK_UNWIND_STRICT(entrylk, frame, op_ret, op_errno, xdata);
@@ -2493,7 +2495,7 @@ io_stats_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FENTRYLK);
     STACK_UNWIND_STRICT(fentrylk, frame, op_ret, op_errno, xdata);
@@ -2502,8 +2504,9 @@ io_stats_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                       uint8_t *strong_checksum, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       uint32_t weak_checksum, uint8_t *strong_checksum,
+                       dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, RCHECKSUM);
     STACK_UNWIND_STRICT(rchecksum, frame, op_ret, op_errno, weak_checksum,
@@ -2513,7 +2516,8 @@ io_stats_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, off_t offset,
+                  dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, SEEK);
     STACK_UNWIND_STRICT(seek, frame, op_ret, op_errno, offset, xdata);
@@ -2522,7 +2526,7 @@ io_stats_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct gf_lease *lease,
+                   gf_return_t op_ret, int32_t op_errno, struct gf_lease *lease,
                    dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, LEASE);
@@ -2532,7 +2536,7 @@ io_stats_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno,
+                         gf_return_t op_ret, int32_t op_errno,
                          lock_migration_info_t *locklist, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, GETACTIVELK);
@@ -2542,7 +2546,7 @@ io_stats_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, SETACTIVELK);
     STACK_UNWIND_STRICT(setactivelk, frame, op_ret, op_errno, xdata);
@@ -2551,7 +2555,7 @@ io_stats_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_compound_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, void *data,
+                      gf_return_t op_ret, int32_t op_errno, void *data,
                       dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, COMPOUND);
@@ -2561,7 +2565,7 @@ io_stats_compound_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, XATTROP);
@@ -2571,7 +2575,7 @@ io_stats_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                       dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FXATTROP);
@@ -2581,7 +2585,7 @@ io_stats_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 io_stats_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, INODELK);
     STACK_UNWIND_STRICT(inodelk, frame, op_ret, op_errno, xdata);
@@ -2628,7 +2632,7 @@ io_stats_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
 
 int
 io_stats_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     UPDATE_PROFILE_STATS(frame, FINODELK);
     STACK_UNWIND_STRICT(finodelk, frame, op_ret, op_errno, xdata);

--- a/xlators/debug/sink/src/sink.c
+++ b/xlators/debug/sink/src/sink.c
@@ -65,8 +65,8 @@ sink_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     /* the root of the volume always need to be a directory */
     stbuf.ia_type = IA_IFDIR;
 
-    STACK_UNWIND_STRICT(lookup, frame, 0, 0, loc ? loc->inode : NULL, &stbuf,
-                        xdata, &postparent);
+    STACK_UNWIND_STRICT(lookup, frame, gf_success, 0, loc ? loc->inode : NULL,
+                        &stbuf, xdata, &postparent);
 
     return 0;
 }

--- a/xlators/debug/trace/src/trace.c
+++ b/xlators/debug/trace/src/trace.c
@@ -82,7 +82,7 @@ dump_history_trace(circular_buffer_t *cb, void *data)
 
 int
 trace_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -105,7 +105,7 @@ trace_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
@@ -115,15 +115,15 @@ trace_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      ": gfid=%s (op_ret=%d, fd=%p"
                      "*stbuf {%s}, *preparent {%s}, "
                      "*postparent = {%s})",
-                     frame->root->unique, uuid_utoa(inode->gfid), op_ret, fd,
-                     statstr, preparentstr, postparentstr);
+                     frame->root->unique, uuid_utoa(inode->gfid),
+                     GET_RET(op_ret), fd, statstr, preparentstr, postparentstr);
 
             /* for 'release' log */
             fd_ctx_set(fd, this, 0);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64 ": (op_ret=%d, op_errno=%d)",
-                     frame->root->unique, op_ret, op_errno);
+                     frame->root->unique, GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -135,7 +135,7 @@ out:
 
 int
 trace_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -151,15 +151,15 @@ trace_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "%" PRId64
                  ": gfid=%s op_ret=%d, op_errno=%d, "
                  "*fd=%p",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret, op_errno,
-                 fd);
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
+                 op_errno, fd);
 
         LOG_ELEMENT(conf, string);
     }
 
 out:
     /* for 'release' log */
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         fd_ctx_set(fd, this, 0);
 
     TRACE_STACK_UNWIND(open, frame, op_ret, op_errno, fd, xdata);
@@ -168,7 +168,7 @@ out:
 
 int
 trace_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *buf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                dict_t *xdata)
 {
     char statstr[1024] = {
@@ -184,18 +184,19 @@ trace_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
-            (void)snprintf(
-                string, sizeof(string), "%" PRId64 ": gfid=%s op_ret=%d buf=%s",
-                frame->root->unique, uuid_utoa(frame->local), op_ret, statstr);
+            (void)snprintf(string, sizeof(string),
+                           "%" PRId64 ": gfid=%s op_ret=%d buf=%s",
+                           frame->root->unique, uuid_utoa(frame->local),
+                           GET_RET(op_ret), statstr);
         } else {
             (void)snprintf(string, sizeof(string),
                            "%" PRId64
                            ": gfid=%s op_ret=%d, "
                            "op_errno=%d)",
-                           frame->root->unique, uuid_utoa(frame->local), op_ret,
-                           op_errno);
+                           frame->root->unique, uuid_utoa(frame->local),
+                           GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -206,7 +207,7 @@ out:
 
 int
 trace_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                 int32_t count, struct iatt *buf, struct iobref *iobref,
                 dict_t *xdata)
 {
@@ -223,18 +224,19 @@ trace_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
-            snprintf(
-                string, sizeof(string), "%" PRId64 ": gfid=%s op_ret=%d buf=%s",
-                frame->root->unique, uuid_utoa(frame->local), op_ret, statstr);
+            snprintf(string, sizeof(string),
+                     "%" PRId64 ": gfid=%s op_ret=%d buf=%s",
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), statstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d)",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -246,7 +248,7 @@ out:
 
 int
 trace_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     char preopstr[1024] = {
@@ -265,7 +267,7 @@ trace_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret >= 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(prebuf, preopstr);
             TRACE_STAT_TO_STR(postbuf, postopstr);
 
@@ -273,14 +275,14 @@ trace_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": (op_ret=%d, "
                      "*prebuf = {%s}, *postbuf = {%s})",
-                     frame->root->unique, op_ret, preopstr, postopstr);
+                     frame->root->unique, GET_RET(op_ret), preopstr, postopstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -291,7 +293,7 @@ out:
 
 int
 trace_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, gf_dirent_t *buf,
+                  gf_return_t op_ret, int32_t op_errno, gf_dirent_t *buf,
                   dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
@@ -306,7 +308,7 @@ trace_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 " : gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -319,7 +321,7 @@ out:
 
 int
 trace_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, gf_dirent_t *buf,
+                   gf_return_t op_ret, int32_t op_errno, gf_dirent_t *buf,
                    dict_t *xdata)
 {
     int count = 0;
@@ -339,12 +341,12 @@ trace_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (trace_fop_names[GF_FOP_READDIRP].enabled) {
         snprintf(string, sizeof(string),
                  "%" PRId64 " : gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
     }
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     list_for_each_entry(entry, &buf->list, list)
@@ -365,7 +367,7 @@ out:
 
 int
 trace_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                 struct iatt *postbuf, dict_t *xdata)
 {
     char preopstr[1024] = {
@@ -384,7 +386,7 @@ trace_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(prebuf, preopstr);
             TRACE_STAT_TO_STR(postbuf, postopstr);
 
@@ -392,14 +394,14 @@ trace_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": (op_ret=%d, "
                      "*prebuf = {%s}, *postbuf = {%s}",
-                     frame->root->unique, op_ret, preopstr, postopstr);
+                     frame->root->unique, GET_RET(op_ret), preopstr, postopstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -411,7 +413,7 @@ out:
 
 int
 trace_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                   struct iatt *statpost, dict_t *xdata)
 {
     char preopstr[1024] = {
@@ -430,7 +432,7 @@ trace_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(statpre, preopstr);
             TRACE_STAT_TO_STR(statpost, postopstr);
 
@@ -438,14 +440,14 @@ trace_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": (op_ret=%d, "
                      "*prebuf = {%s}, *postbuf = {%s})",
-                     frame->root->unique, op_ret, preopstr, postopstr);
+                     frame->root->unique, GET_RET(op_ret), preopstr, postopstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d)",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -457,7 +459,7 @@ out:
 
 int
 trace_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                    struct iatt *statpost, dict_t *xdata)
 {
     char preopstr[1024] = {
@@ -476,7 +478,7 @@ trace_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(statpre, preopstr);
             TRACE_STAT_TO_STR(statpost, postopstr);
 
@@ -484,12 +486,12 @@ trace_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": (op_ret=%d, "
                      "*prebuf = {%s}, *postbuf = {%s})",
-                     frame->root->unique, op_ret, preopstr, postopstr);
+                     frame->root->unique, GET_RET(op_ret), preopstr, postopstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d)",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -501,7 +503,7 @@ out:
 
 int
 trace_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
     char preparentstr[1024] = {
@@ -520,7 +522,7 @@ trace_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
 
@@ -529,15 +531,15 @@ trace_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      ": gfid=%s op_ret=%d, "
                      " *preparent = {%s}, "
                      "*postparent = {%s})",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     preparentstr, postparentstr);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), preparentstr, postparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d)",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -549,7 +551,7 @@ out:
 
 int
 trace_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                  struct iatt *preoldparent, struct iatt *postoldparent,
                  struct iatt *prenewparent, struct iatt *postnewparent,
                  dict_t *xdata)
@@ -579,7 +581,7 @@ trace_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[6044] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(preoldparent, preoldparentstr);
             TRACE_STAT_TO_STR(postoldparent, postoldparentstr);
@@ -593,15 +595,16 @@ trace_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      " *postoldparent = {%s}"
                      " *prenewparent = {%s}, "
                      "*postnewparent = {%s})",
-                     frame->root->unique, op_ret, statstr, preoldparentstr,
-                     postoldparentstr, prenewparentstr, postnewparentstr);
+                     frame->root->unique, GET_RET(op_ret), statstr,
+                     preoldparentstr, postoldparentstr, prenewparentstr,
+                     postnewparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -613,7 +616,7 @@ out:
 
 int
 trace_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, const char *buf,
+                   gf_return_t op_ret, int32_t op_errno, const char *buf,
                    struct iatt *stbuf, dict_t *xdata)
 {
     char statstr[1024] = {
@@ -629,20 +632,21 @@ trace_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(stbuf, statstr);
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": (op_ret=%d, op_errno=%d,"
                      "buf=%s, stbuf = { %s })",
-                     frame->root->unique, op_ret, op_errno, buf, statstr);
+                     frame->root->unique, GET_RET(op_ret), op_errno, buf,
+                     statstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
 
         LOG_ELEMENT(conf, string);
@@ -654,7 +658,7 @@ out:
 
 int
 trace_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     char statstr[1024] = {
@@ -673,7 +677,7 @@ trace_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
             /* print buf->ia_gfid instead of inode->gfid,
@@ -685,8 +689,8 @@ trace_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": gfid=%s (op_ret=%d "
                      "*buf {%s}, *postparent {%s}",
-                     frame->root->unique, uuid_utoa(buf->ia_gfid), op_ret,
-                     statstr, postparentstr);
+                     frame->root->unique, uuid_utoa(buf->ia_gfid),
+                     GET_RET(op_ret), statstr, postparentstr);
 
             /* For 'forget' */
             inode_ctx_put(inode, this, 0);
@@ -695,8 +699,8 @@ trace_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d)",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -708,7 +712,7 @@ out:
 
 int
 trace_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
@@ -731,7 +735,7 @@ trace_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
@@ -741,12 +745,12 @@ trace_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      ": gfid=%s (op_ret=%d "
                      "*stbuf = {%s}, *preparent = {%s}, "
                      "*postparent = {%s})",
-                     frame->root->unique, uuid_utoa(inode->gfid), op_ret,
-                     statstr, preparentstr, postparentstr);
+                     frame->root->unique, uuid_utoa(inode->gfid),
+                     GET_RET(op_ret), statstr, preparentstr, postparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64 ": op_ret=%d, op_errno=%d", frame->root->unique,
-                     op_ret, op_errno);
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -758,7 +762,7 @@ out:
 
 int
 trace_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -781,7 +785,7 @@ trace_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
     if (trace_fop_names[GF_FOP_MKNOD].enabled) {
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
@@ -791,12 +795,12 @@ trace_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      ": gfid=%s (op_ret=%d "
                      "*stbuf = {%s}, *preparent = {%s}, "
                      "*postparent = {%s})",
-                     frame->root->unique, uuid_utoa(inode->gfid), op_ret,
-                     statstr, preparentstr, postparentstr);
+                     frame->root->unique, uuid_utoa(inode->gfid),
+                     GET_RET(op_ret), statstr, preparentstr, postparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64 ": (op_ret=%d, op_errno=%d)",
-                     frame->root->unique, op_ret, op_errno);
+                     frame->root->unique, GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -808,7 +812,7 @@ out:
 
 int
 trace_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -831,7 +835,7 @@ trace_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
@@ -841,12 +845,12 @@ trace_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      ": gfid=%s (op_ret=%d "
                      ", *stbuf = {%s}, *prebuf = {%s}, "
                      "*postbuf = {%s} )",
-                     frame->root->unique, uuid_utoa(inode->gfid), op_ret,
-                     statstr, preparentstr, postparentstr);
+                     frame->root->unique, uuid_utoa(inode->gfid),
+                     GET_RET(op_ret), statstr, preparentstr, postparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64 ": (op_ret=%d, op_errno=%d)",
-                     frame->root->unique, op_ret, op_errno);
+                     frame->root->unique, GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -858,7 +862,7 @@ out:
 
 int
 trace_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *buf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -881,7 +885,7 @@ trace_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
     if (trace_fop_names[GF_FOP_LINK].enabled) {
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
@@ -891,15 +895,15 @@ trace_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      ": (op_ret=%d, "
                      "*stbuf = {%s},  *prebuf = {%s},"
                      " *postbuf = {%s})",
-                     frame->root->unique, op_ret, statstr, preparentstr,
-                     postparentstr);
+                     frame->root->unique, GET_RET(op_ret), statstr,
+                     preparentstr, postparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -911,7 +915,7 @@ out:
 
 int
 trace_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -925,7 +929,7 @@ trace_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (trace_fop_names[GF_FOP_FLUSH].enabled) {
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -937,7 +941,7 @@ out:
 
 int
 trace_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -953,14 +957,14 @@ trace_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "%" PRId64
                  ": gfid=%s op_ret=%d, op_errno=%d,"
                  " fd=%p",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret, op_errno,
-                 fd);
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
+                 op_errno, fd);
 
         LOG_ELEMENT(conf, string);
     }
 out:
     /* for 'releasedir' log */
-    if (op_ret >= 0)
+    if (IS_SUCCESS(op_ret))
         fd_ctx_set(fd, this, 0);
 
     TRACE_STACK_UNWIND(opendir, frame, op_ret, op_errno, fd, xdata);
@@ -969,7 +973,7 @@ out:
 
 int
 trace_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
     char preparentstr[1024] = {
@@ -988,7 +992,7 @@ trace_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(preparent, preparentstr);
             TRACE_STAT_TO_STR(postparent, postparentstr);
 
@@ -996,15 +1000,15 @@ trace_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "*prebuf={%s},  *postbuf={%s}",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     preparentstr, postparentstr);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), preparentstr, postparentstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -1016,7 +1020,7 @@ out:
 
 int
 trace_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     char preopstr[1024] = {
@@ -1035,7 +1039,7 @@ trace_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(prebuf, preopstr);
             TRACE_STAT_TO_STR(postbuf, postopstr);
 
@@ -1043,14 +1047,14 @@ trace_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": (op_ret=%d, "
                      "*prebuf = {%s}, *postbuf = {%s} )",
-                     frame->root->unique, op_ret, preopstr, postopstr);
+                     frame->root->unique, GET_RET(op_ret), preopstr, postopstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -1062,7 +1066,7 @@ out:
 
 int
 trace_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                  dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
@@ -1075,7 +1079,7 @@ trace_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": ({f_bsize=%lu, "
@@ -1095,13 +1099,13 @@ trace_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      frame->root->unique, buf->f_bsize, buf->f_frsize,
                      buf->f_blocks, buf->f_bfree, buf->f_bavail, buf->f_files,
                      buf->f_ffree, buf->f_favail, buf->f_fsid, buf->f_flag,
-                     buf->f_namemax, op_ret);
+                     buf->f_namemax, GET_RET(op_ret));
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": (op_ret=%d, "
                      "op_errno=%d)",
-                     frame->root->unique, op_ret, op_errno);
+                     frame->root->unique, GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -1112,7 +1116,7 @@ out:
 
 int
 trace_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1126,7 +1130,7 @@ trace_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1138,7 +1142,7 @@ out:
 
 int
 trace_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *dict,
+                   gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                    dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
@@ -1155,8 +1159,8 @@ trace_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "%" PRId64
                  ": gfid=%s op_ret=%d, op_errno=%d,"
                  " dict=%p",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret, op_errno,
-                 dict);
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
+                 op_errno, dict);
 
         LOG_ELEMENT(conf, string);
     }
@@ -1168,7 +1172,7 @@ out:
 
 int
 trace_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1182,7 +1186,7 @@ trace_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1194,7 +1198,7 @@ out:
 
 int
 trace_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
@@ -1211,8 +1215,8 @@ trace_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "%" PRId64
                  ": gfid=%s op_ret=%d, op_errno=%d,"
                  " dict=%p",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret, op_errno,
-                 dict);
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
+                 op_errno, dict);
 
         LOG_ELEMENT(conf, string);
     }
@@ -1224,7 +1228,7 @@ out:
 
 int
 trace_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1238,7 +1242,7 @@ trace_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1251,7 +1255,7 @@ out:
 
 int
 trace_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1265,7 +1269,7 @@ trace_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1277,7 +1281,7 @@ out:
 
 int
 trace_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1293,7 +1297,7 @@ trace_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "%" PRId64
                  ": gfid=%s op_ret=%d, "
                  "op_errno=%d)",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1305,7 +1309,7 @@ out:
 
 int
 trace_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     char prebufstr[1024] = {
@@ -1324,7 +1328,7 @@ trace_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(prebuf, prebufstr);
             TRACE_STAT_TO_STR(postbuf, postbufstr);
 
@@ -1332,14 +1336,15 @@ trace_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                      "%" PRId64
                      ": op_ret=%d, "
                      "*prebuf = {%s}, *postbuf = {%s} )",
-                     frame->root->unique, op_ret, prebufstr, postbufstr);
+                     frame->root->unique, GET_RET(op_ret), prebufstr,
+                     postbufstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -1351,7 +1356,7 @@ out:
 
 int
 trace_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                 dict_t *xdata)
 {
     char statstr[1024] = {
@@ -1365,21 +1370,21 @@ trace_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     if (trace_fop_names[GF_FOP_FSTAT].enabled) {
         char string[4096] = {0.};
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             TRACE_STAT_TO_STR(buf, statstr);
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d "
                      "buf=%s",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     statstr);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), statstr);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
         LOG_ELEMENT(conf, string);
     }
@@ -1389,8 +1394,9 @@ out:
 }
 
 int
-trace_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
+trace_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
+             dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1402,7 +1408,7 @@ trace_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
         char string[4096] = {
             0,
         };
-        if (op_ret == 0) {
+        if (IS_SUCCESS(op_ret)) {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
@@ -1410,16 +1416,16 @@ trace_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
                      "l_start=%" PRId64
                      ", "
                      "l_len=%" PRId64 ", l_pid=%u})",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     lock->l_type, lock->l_whence, lock->l_start, lock->l_len,
-                     lock->l_pid);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), lock->l_type, lock->l_whence,
+                     lock->l_start, lock->l_len, lock->l_pid);
         } else {
             snprintf(string, sizeof(string),
                      "%" PRId64
                      ": gfid=%s op_ret=%d, "
                      "op_errno=%d)",
-                     frame->root->unique, uuid_utoa(frame->local), op_ret,
-                     op_errno);
+                     frame->root->unique, uuid_utoa(frame->local),
+                     GET_RET(op_ret), op_errno);
         }
 
         LOG_ELEMENT(conf, string);
@@ -1431,7 +1437,7 @@ out:
 
 int
 trace_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1445,7 +1451,7 @@ trace_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1457,7 +1463,7 @@ out:
 
 int
 trace_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1471,7 +1477,7 @@ trace_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1483,7 +1489,8 @@ out:
 
 int
 trace_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                  dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1497,7 +1504,7 @@ trace_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1509,7 +1516,7 @@ out:
 
 int
 trace_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *dict,
+                   gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                    dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
@@ -1524,7 +1531,7 @@ trace_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1536,7 +1543,7 @@ out:
 
 int
 trace_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1550,7 +1557,7 @@ trace_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1562,7 +1569,7 @@ out:
 
 int
 trace_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1576,7 +1583,7 @@ trace_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d, op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -1588,8 +1595,9 @@ out:
 
 int
 trace_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                    uint8_t *strong_checksum, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno,
+                    uint32_t weak_checksum, uint8_t *strong_checksum,
+                    dict_t *xdata)
 {
     trace_conf_t *conf = NULL;
 
@@ -1603,7 +1611,7 @@ trace_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         };
         snprintf(string, sizeof(string),
                  "%" PRId64 ": gfid=%s op_ret=%d op_errno=%d",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret,
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
                  op_errno);
 
         LOG_ELEMENT(conf, string);
@@ -2343,7 +2351,8 @@ out:
 
 static int
 trace_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, off_t offset,
+               dict_t *xdata)
 {
     trace_conf_t *conf = this->private;
 
@@ -2357,8 +2366,8 @@ trace_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  "%" PRId64
                  ": gfid=%s op_ret=%d op_errno=%d, "
                  "offset=%" PRId64 "",
-                 frame->root->unique, uuid_utoa(frame->local), op_ret, op_errno,
-                 offset);
+                 frame->root->unique, uuid_utoa(frame->local), GET_RET(op_ret),
+                 op_errno, offset);
         LOG_ELEMENT(conf, string);
     }
 out:

--- a/xlators/features/arbiter/src/arbiter.c
+++ b/xlators/features/arbiter/src/arbiter.c
@@ -59,16 +59,16 @@ arbiter_inode_ctx_get(inode_t *inode, xlator_t *this)
 
 int32_t
 arbiter_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     arbiter_inode_ctx_t *ctx = NULL;
 
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
     ctx = arbiter_inode_ctx_get(inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -94,12 +94,12 @@ arbiter_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
 {
     arbiter_inode_ctx_t *ctx = NULL;
     struct iatt *buf = NULL;
-    int32_t op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int32_t op_errno = 0;
 
     ctx = arbiter_inode_ctx_get(loc->inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -116,12 +116,12 @@ arbiter_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 {
     arbiter_inode_ctx_t *ctx = NULL;
     struct iatt *buf = NULL;
-    int32_t op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int32_t op_errno = 0;
 
     ctx = arbiter_inode_ctx_get(fd->inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -178,17 +178,17 @@ arbiter_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
     arbiter_inode_ctx_t *ctx = NULL;
     struct iatt *buf = NULL;
     dict_t *rsp_xdata = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = 0;
 
     ctx = arbiter_inode_ctx_get(fd->inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
     buf = &ctx->iattbuf;
-    op_ret = iov_length(vector, count);
+    SET_RET(op_ret, iov_length(vector, count));
     rsp_xdata = arbiter_fill_writev_xdata(fd, xdata, this);
 unwind:
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, buf, buf, rsp_xdata);
@@ -203,12 +203,12 @@ arbiter_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd,
 {
     arbiter_inode_ctx_t *ctx = NULL;
     struct iatt *buf = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = 0;
 
     ctx = arbiter_inode_ctx_get(fd->inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -224,12 +224,12 @@ arbiter_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 {
     arbiter_inode_ctx_t *ctx = NULL;
     struct iatt *buf = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = 0;
 
     ctx = arbiter_inode_ctx_get(fd->inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -245,12 +245,12 @@ arbiter_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 {
     arbiter_inode_ctx_t *ctx = NULL;
     struct iatt *buf = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = 0;
 
     ctx = arbiter_inode_ctx_get(fd->inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -264,7 +264,8 @@ static int32_t
 arbiter_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
               off_t offset, uint32_t flags, dict_t *xdata)
 {
-    STACK_UNWIND_STRICT(readv, frame, -1, ENOSYS, NULL, 0, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(readv, frame, gf_error, ENOSYS, NULL, 0, NULL, NULL,
+                        NULL);
     return 0;
 }
 
@@ -272,7 +273,7 @@ static int32_t
 arbiter_seek(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
              gf_seek_what_t what, dict_t *xdata)
 {
-    STACK_UNWIND_STRICT(seek, frame, -1, ENOSYS, 0, xdata);
+    STACK_UNWIND_STRICT(seek, frame, gf_error, ENOSYS, 0, xdata);
     return 0;
 }
 

--- a/xlators/features/barrier/src/barrier.c
+++ b/xlators/features/barrier/src/barrier.c
@@ -41,7 +41,7 @@ barrier_local_free_gfid(call_frame_t *frame)
 
 int32_t
 barrier_truncate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             struct iatt *prebuf, struct iatt *postbuf,
                             dict_t *xdata)
 {
@@ -53,7 +53,7 @@ barrier_truncate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_ftruncate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              struct iatt *prebuf, struct iatt *postbuf,
                              dict_t *xdata)
 {
@@ -65,7 +65,7 @@ barrier_ftruncate_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_unlink_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno,
+                          gf_return_t op_ret, int32_t op_errno,
                           struct iatt *preparent, struct iatt *postparent,
                           dict_t *xdata)
 {
@@ -77,7 +77,7 @@ barrier_unlink_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_rmdir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno,
+                         gf_return_t op_ret, int32_t op_errno,
                          struct iatt *preparent, struct iatt *postparent,
                          dict_t *xdata)
 {
@@ -89,10 +89,10 @@ barrier_rmdir_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_rename_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *buf,
-                          struct iatt *preoldparent, struct iatt *postoldparent,
-                          struct iatt *prenewparent, struct iatt *postnewparent,
-                          dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *buf, struct iatt *preoldparent,
+                          struct iatt *postoldparent, struct iatt *prenewparent,
+                          struct iatt *postnewparent, dict_t *xdata)
 {
     barrier_local_free_gfid(frame);
     STACK_UNWIND_STRICT(rename, frame, op_ret, op_errno, buf, preoldparent,
@@ -102,8 +102,9 @@ barrier_rename_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_writev_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                          struct iatt *postbuf, dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *prebuf, struct iatt *postbuf,
+                          dict_t *xdata)
 {
     barrier_local_free_gfid(frame);
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, prebuf, postbuf,
@@ -113,8 +114,9 @@ barrier_writev_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_fsync_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                         struct iatt *postbuf, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno,
+                         struct iatt *prebuf, struct iatt *postbuf,
+                         dict_t *xdata)
 {
     barrier_local_free_gfid(frame);
     STACK_UNWIND_STRICT(fsync, frame, op_ret, op_errno, prebuf, postbuf, xdata);
@@ -123,8 +125,8 @@ barrier_fsync_cbk_resume(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 barrier_removexattr_cbk_resume(call_frame_t *frame, void *cookie,
-                               xlator_t *this, int32_t op_ret, int32_t op_errno,
-                               dict_t *xdata)
+                               xlator_t *this, gf_return_t op_ret,
+                               int32_t op_errno, dict_t *xdata)
 {
     barrier_local_free_gfid(frame);
     STACK_UNWIND_STRICT(removexattr, frame, op_ret, op_errno, xdata);
@@ -133,7 +135,7 @@ barrier_removexattr_cbk_resume(call_frame_t *frame, void *cookie,
 
 int32_t
 barrier_fremovexattr_cbk_resume(call_frame_t *frame, void *cookie,
-                                xlator_t *this, int32_t op_ret,
+                                xlator_t *this, gf_return_t op_ret,
                                 int32_t op_errno, dict_t *xdata)
 {
     barrier_local_free_gfid(frame);
@@ -143,7 +145,7 @@ barrier_fremovexattr_cbk_resume(call_frame_t *frame, void *cookie,
 
 int32_t
 barrier_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     BARRIER_FOP_CBK(writev, out, frame, this, op_ret, op_errno, prebuf, postbuf,
@@ -154,7 +156,7 @@ out:
 
 int32_t
 barrier_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     BARRIER_FOP_CBK(fremovexattr, out, frame, this, op_ret, op_errno, xdata);
 out:
@@ -163,7 +165,7 @@ out:
 
 int32_t
 barrier_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     BARRIER_FOP_CBK(removexattr, out, frame, this, op_ret, op_errno, xdata);
 out:
@@ -172,7 +174,7 @@ out:
 
 int32_t
 barrier_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     BARRIER_FOP_CBK(truncate, out, frame, this, op_ret, op_errno, prebuf,
@@ -183,7 +185,7 @@ out:
 
 int32_t
 barrier_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     BARRIER_FOP_CBK(ftruncate, out, frame, this, op_ret, op_errno, prebuf,
@@ -194,7 +196,7 @@ out:
 
 int32_t
 barrier_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                    struct iatt *preoldparent, struct iatt *postoldparent,
                    struct iatt *prenewparent, struct iatt *postnewparent,
                    dict_t *xdata)
@@ -208,7 +210,7 @@ out:
 
 int32_t
 barrier_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     BARRIER_FOP_CBK(rmdir, out, frame, this, op_ret, op_errno, preparent,
@@ -219,7 +221,7 @@ out:
 
 int32_t
 barrier_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     BARRIER_FOP_CBK(unlink, out, frame, this, op_ret, op_errno, preparent,
@@ -230,7 +232,7 @@ out:
 
 int32_t
 barrier_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     BARRIER_FOP_CBK(fsync, out, frame, this, op_ret, op_errno, prebuf, postbuf,

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub-helpers.c
@@ -352,7 +352,7 @@ br_stub_lookup_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
     struct stat lstatbuf = {0};
     int ret = 0;
     int32_t op_errno = EINVAL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     struct iatt stbuf = {
         0,
     };
@@ -388,10 +388,11 @@ br_stub_lookup_wrapper(call_frame_t *frame, xlator_t *this, loc_t *loc,
     iatt_from_stat(&stbuf, &lstatbuf);
     gf_uuid_copy(stbuf.ia_gfid, priv->bad_object_dir_gfid);
 
-    op_ret = op_errno = 0;
+    op_errno = 0;
+    op_ret = gf_success;
     xattr = dict_new();
     if (!xattr) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
     }
 
@@ -561,7 +562,7 @@ br_stub_readdir_wrapper(call_frame_t *frame, xlator_t *this, fd_t *fd,
     br_stub_fd_t *fctx = NULL;
     DIR *dir = NULL;
     int ret = -1;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = 0;
     int count = 0;
     gf_dirent_t entries;
@@ -591,7 +592,7 @@ br_stub_readdir_wrapper(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     /* pick ENOENT to indicate EOF */
     op_errno = errno;
-    op_ret = count;
+    SET_RET(op_ret, count);
 
     dict = xdata;
     (void)br_stub_bad_objects_path(this, fd, &entries, &dict);

--- a/xlators/features/bit-rot/src/stub/bit-rot-stub.h
+++ b/xlators/features/bit-rot/src/stub/bit-rot-stub.h
@@ -69,8 +69,8 @@
             frame->local = NULL;                                               \
     } while (0)
 
-typedef int(br_stub_version_cbk)(call_frame_t *, void *, xlator_t *, int32_t,
-                                 int32_t, dict_t *);
+typedef int(br_stub_version_cbk)(call_frame_t *, void *, xlator_t *,
+                                 gf_return_t, int32_t, dict_t *);
 
 typedef struct br_stub_inode_ctx {
     int need_writeback;           /* does the inode need

--- a/xlators/features/changelog/src/changelog.c
+++ b/xlators/features/changelog/src/changelog.c
@@ -52,8 +52,9 @@ changelog_init(xlator_t *this, changelog_priv_t *priv);
 
 int32_t
 changelog_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -61,7 +62,7 @@ changelog_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -173,8 +174,9 @@ out:
 
 int32_t
 changelog_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *preparent,
-                     struct iatt *postparent, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno,
+                     struct iatt *preparent, struct iatt *postparent,
+                     dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -182,7 +184,7 @@ changelog_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -321,7 +323,7 @@ out:
 
 int32_t
 changelog_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                      struct iatt *preoldparent, struct iatt *postoldparent,
                      struct iatt *prenewparent, struct iatt *postnewparent,
                      dict_t *xdata)
@@ -331,7 +333,7 @@ changelog_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     priv = this->private;
     local = frame->local;
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 unwind:
     changelog_dec_fop_cnt(this, priv, local);
@@ -439,7 +441,7 @@ out:
 
 int32_t
 changelog_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -449,7 +451,7 @@ changelog_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -549,7 +551,7 @@ out:
 
 int32_t
 changelog_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -559,7 +561,7 @@ changelog_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -678,7 +680,7 @@ out:
 
 int32_t
 changelog_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, inode_t *inode,
+                      gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                       struct iatt *buf, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata)
 {
@@ -688,7 +690,7 @@ changelog_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -799,7 +801,7 @@ out:
 
 int32_t
 changelog_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -809,7 +811,7 @@ changelog_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_ENTRY);
 
@@ -945,8 +947,8 @@ out:
 
 int32_t
 changelog_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                     struct iatt *buf, struct iatt *preparent,
+                     gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                     inode_t *inode, struct iatt *buf, struct iatt *preparent,
                      struct iatt *postparent, dict_t *xdata)
 {
     int32_t ret = 0;
@@ -959,7 +961,7 @@ changelog_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     /* fill the event structure.. similar to open() */
     ev.ev_type = CHANGELOG_OP_TYPE_CREATE;
@@ -1105,7 +1107,7 @@ out:
 
 int32_t
 changelog_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno,
+                       gf_return_t op_ret, int32_t op_errno,
                        struct iatt *preop_stbuf, struct iatt *postop_stbuf,
                        dict_t *xdata)
 {
@@ -1115,7 +1117,7 @@ changelog_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA);
 
@@ -1161,7 +1163,7 @@ wind:
 
 int32_t
 changelog_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno,
+                      gf_return_t op_ret, int32_t op_errno,
                       struct iatt *preop_stbuf, struct iatt *postop_stbuf,
                       dict_t *xdata)
 {
@@ -1171,7 +1173,7 @@ changelog_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA);
 
@@ -1230,7 +1232,7 @@ wind:
 
 int32_t
 changelog_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                           gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -1238,7 +1240,7 @@ changelog_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1281,7 +1283,7 @@ wind:
 
 int32_t
 changelog_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -1289,7 +1291,7 @@ changelog_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1334,7 +1336,7 @@ wind:
 
 int32_t
 changelog_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -1342,7 +1344,7 @@ changelog_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1398,10 +1400,10 @@ changelog_handle_virtual_xattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         /* Assign local to prev_entry, so unwind will take
          * care of cleanup. */
         ((changelog_local_t *)(frame->local))->prev_entry = local;
-        CHANGELOG_STACK_UNWIND(setxattr, frame, 0, 0, NULL);
+        CHANGELOG_STACK_UNWIND(setxattr, frame, gf_success, 0, NULL);
         return;
     } else {
-        CHANGELOG_STACK_UNWIND(setxattr, frame, -1, ENOTSUP, NULL);
+        CHANGELOG_STACK_UNWIND(setxattr, frame, gf_error, ENOTSUP, NULL);
         return;
     }
 }
@@ -1447,7 +1449,7 @@ wind:
 
 int32_t
 changelog_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -1455,7 +1457,7 @@ changelog_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1499,7 +1501,7 @@ wind:
 
 int32_t
 changelog_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xattr,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
                       dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
@@ -1508,7 +1510,7 @@ changelog_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA);
 
@@ -1556,7 +1558,7 @@ wind:
 
 int32_t
 changelog_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xattr,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
                        dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
@@ -1565,7 +1567,7 @@ changelog_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_METADATA_XATTR);
 
@@ -1620,8 +1622,8 @@ wind:
 
 int32_t
 changelog_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                       struct iatt *postbuf, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *prebuf, struct iatt *postbuf, dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -1629,7 +1631,7 @@ changelog_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_DATA);
 
@@ -1668,8 +1670,9 @@ wind:
 
 int32_t
 changelog_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                        struct iatt *postbuf, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno,
+                        struct iatt *prebuf, struct iatt *postbuf,
+                        dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
     changelog_local_t *local = NULL;
@@ -1677,7 +1680,7 @@ changelog_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_DATA);
 
@@ -1718,7 +1721,7 @@ wind:
 
 int32_t
 changelog_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     changelog_priv_t *priv = NULL;
@@ -1727,7 +1730,7 @@ changelog_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     local = frame->local;
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret <= 0) || !local), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR(op_ret) || !local), unwind);
 
     changelog_update(this, priv, local, CHANGELOG_TYPE_DATA);
 
@@ -1774,7 +1777,7 @@ wind:
 
 int
 changelog_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, fd_t *fd, dict_t *xdata)
+                   gf_return_t op_ret, int op_errno, fd_t *fd, dict_t *xdata)
 {
     int ret = 0;
     changelog_priv_t *priv = NULL;
@@ -1789,7 +1792,7 @@ changelog_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         logopen = _gf_true;
     }
 
-    CHANGELOG_COND_GOTO(priv, ((op_ret < 0) || !logopen), unwind);
+    CHANGELOG_COND_GOTO(priv, (IS_ERROR((op_ret)) || !logopen), unwind);
 
     /* fill the event structure */
     ev.ev_type = CHANGELOG_OP_TYPE_OPEN;
@@ -1862,7 +1865,7 @@ changelog_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
     if (xdata)
         (void)dict_foreach(xdata, _changelog_generic_dispatcher, this);
 
-    STACK_UNWIND_STRICT(ipc, frame, 0, 0, NULL);
+    STACK_UNWIND_STRICT(ipc, frame, gf_success, 0, NULL);
     return 0;
 
 wind:
@@ -2105,7 +2108,7 @@ notify(xlator_t *this, int event, void *data, ...)
                         ret = -1;
                 }
                 UNLOCK(&priv->lock);
-                /* If ret = -1, then changelog barrier is already
+                /* If ret = gf_error, then changelog barrier is already
                  * disabled because of error or timeout.
                  */
                 if (ret == 0) {

--- a/xlators/features/cloudsync/src/cloudsync-common.h
+++ b/xlators/features/cloudsync/src/cloudsync-common.h
@@ -37,7 +37,7 @@ typedef struct cs_local {
     call_stub_t *stub;
     call_frame_t *main_frame;
     int op_errno;
-    int op_ret;
+    gf_return_t op_ret;
     fd_t *dlfd;
     off_t dloffset;
     struct iatt stbuf;

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.c
@@ -331,13 +331,13 @@ aws_sign_request(char *const str, char *awssekey)
 }
 
 int
-aws_dlwritev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                 dict_t *xdata)
+aws_dlwritev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                 struct iatt *postbuf, dict_t *xdata)
 {
     aws_private_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, op_errno,
                "write failed "
                ". Aborting Download");
@@ -352,7 +352,7 @@ aws_dlwritev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     CS_STACK_DESTROY(frame);
 
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 size_t

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.h
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cloudsyncs3/src/libcloudsyncs3.h
@@ -28,9 +28,9 @@ int
 aws_download_s3(call_frame_t *frame, void *config);
 
 int
-aws_dlwritev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                 dict_t *xdata);
+aws_dlwritev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                 struct iatt *postbuf, dict_t *xdata);
 
 void *
 aws_init(xlator_t *this);

--- a/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/libcvlt.h
+++ b/xlators/features/cloudsync/src/cloudsync-plugins/src/cvlt/src/libcvlt.h
@@ -41,7 +41,7 @@ struct _cvlt_request {
     struct iobref *iobref;
     call_frame_t *frame;
     cvlt_op_t op_type;
-    int32_t op_ret;
+    int64_t op_ret;
     int32_t op_errno;
     xlator_t *this;
     sem_t sem;

--- a/xlators/features/cloudsync/src/cloudsync.h
+++ b/xlators/features/cloudsync/src/cloudsync.h
@@ -53,7 +53,7 @@ cs_resume_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 int32_t
 cs_inodelk_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 size_t
 cs_write_callback(void *lcurlbuf, size_t size, size_t nitems, void *frame);
@@ -66,13 +66,13 @@ cs_is_file_remote(struct iatt *stbuf, dict_t *xattr);
 
 int32_t
 cs_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 int
 cs_build_loc(loc_t *loc, call_frame_t *frame);
 
 int
 cs_blocking_inodelk_cbk(call_frame_t *lock_frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata);
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata);
 
 int
 cs_read_authinfo(xlator_t *this);
@@ -97,16 +97,17 @@ cs_resume_postprocess(xlator_t *this, call_frame_t *frame, inode_t *inode);
 
 int32_t
 cs_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                 struct iatt *postbuf, dict_t *xdata);
 int32_t
 cs_resume_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc,
                    off_t offset, dict_t *xattr_req);
 
 int32_t
-cs_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iovec *vector, int32_t count,
-             struct iatt *stbuf, struct iobref *iobref, dict_t *xdata);
+cs_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
+             int32_t count, struct iatt *stbuf, struct iobref *iobref,
+             dict_t *xdata);
 int32_t
 cs_resume_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
                 off_t offset, uint32_t flags, dict_t *xdata);

--- a/xlators/features/compress/src/cdc.c
+++ b/xlators/features/compress/src/cdc.c
@@ -25,9 +25,10 @@ cdc_cleanup_iobref(cdc_info_t *ci)
 }
 
 int32_t
-cdc_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iovec *vector, int32_t count,
-              struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
+cdc_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
+              int32_t count, struct iatt *stbuf, struct iobref *iobref,
+              dict_t *xdata)
 {
     int ret = -1;
     cdc_priv_t *priv = NULL;
@@ -40,14 +41,14 @@ cdc_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     priv = this->private;
 
-    if (op_ret <= 0)
+    if (IS_ERROR(op_ret))
         goto default_out;
 
-    if ((priv->min_file_size != 0) && (op_ret < priv->min_file_size))
+    if ((priv->min_file_size != 0) && (GET_RET(op_ret) < priv->min_file_size))
         goto default_out;
 
     ci.count = count;
-    ci.ibytes = op_ret;
+    ci.ibytes = GET_RET(op_ret);
     ci.vector = vector;
     ci.buf = NULL;
     ci.iobref = NULL;
@@ -69,7 +70,8 @@ cdc_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (ret)
         goto default_out;
 
-    STACK_UNWIND_STRICT(readv, frame, ci.nbytes, op_errno, ci.vec, ci.ncount,
+    SET_RET(op_ret, ci.nbytes);
+    STACK_UNWIND_STRICT(readv, frame, op_ret, op_errno, ci.vec, ci.ncount,
                         stbuf, iobref, xdata);
     cdc_cleanup_iobref(&ci);
     return 0;
@@ -98,7 +100,7 @@ cdc_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
 int32_t
 cdc_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                struct iatt *postbuf, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, prebuf, postbuf,
@@ -168,7 +170,7 @@ default_out:
                flags, iobref, xdata);
     return 0;
 err:
-    STACK_UNWIND_STRICT(writev, frame, -1, EINVAL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(writev, frame, gf_error, EINVAL, NULL, NULL, NULL);
     return 0;
 }
 

--- a/xlators/features/leases/src/leases.c
+++ b/xlators/features/leases/src/leases.c
@@ -17,7 +17,7 @@
 
 int32_t
 leases_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(open, frame, op_ret, op_errno, fd, xdata);
 
@@ -85,14 +85,14 @@ err:
         GF_FREE(fd_ctx);
     }
 
-    STACK_UNWIND_STRICT(open, frame, -1, op_errno, NULL, NULL);
+    STACK_UNWIND_STRICT(open, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
 int32_t
-leases_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                  dict_t *xdata)
+leases_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                  struct iatt *postbuf, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
@@ -135,14 +135,15 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(writev, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(writev, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
-leases_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, struct iovec *vector, int count,
-                 struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
+leases_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, struct iovec *vector,
+                 int count, struct iatt *stbuf, struct iobref *iobref,
+                 dict_t *xdata)
 {
     STACK_UNWIND_STRICT(readv, frame, op_ret, op_errno, vector, count, stbuf,
                         iobref, xdata);
@@ -183,13 +184,15 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(readv, frame, -1, errno, NULL, 0, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(readv, frame, gf_error, errno, NULL, 0, NULL, NULL,
+                        NULL);
     return 0;
 }
 
 int32_t
-leases_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
+leases_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
+              dict_t *xdata)
 {
     STACK_UNWIND_STRICT(lk, frame, op_ret, op_errno, lock, xdata);
 
@@ -228,7 +231,7 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(lk, frame, -1, errno, NULL, NULL);
+    STACK_UNWIND_STRICT(lk, frame, gf_error, errno, NULL, NULL);
     return 0;
 }
 
@@ -241,7 +244,7 @@ leases_lease(call_frame_t *frame, xlator_t *this, loc_t *loc,
     struct gf_lease nullease = {
         0,
     };
-    int32_t op_ret = 0;
+    gf_return_t op_ret = gf_success;
 
     EXIT_IF_LEASES_OFF(this, out);
     EXIT_IF_INTERNAL_FOP(frame, xdata, out);
@@ -249,7 +252,7 @@ leases_lease(call_frame_t *frame, xlator_t *this, loc_t *loc,
     ret = process_lease_req(frame, this, loc->inode, lease);
     if (ret < 0) {
         op_errno = -ret;
-        op_ret = -1;
+        op_ret = gf_error;
     }
     goto unwind;
 
@@ -259,7 +262,7 @@ out:
            "You need to enable it for proper functioning of your "
            "application");
     op_errno = ENOSYS;
-    op_ret = -1;
+    op_ret = gf_error;
 
 unwind:
     STACK_UNWIND_STRICT(lease, frame, op_ret, op_errno,
@@ -269,7 +272,7 @@ unwind:
 
 int32_t
 leases_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(truncate, frame, op_ret, op_errno, prebuf, postbuf,
@@ -310,13 +313,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(truncate, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(truncate, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, struct iatt *statpre,
+                   gf_return_t op_ret, int op_errno, struct iatt *statpre,
                    struct iatt *statpost, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(setattr, frame, op_ret, op_errno, statpre, statpost,
@@ -357,13 +360,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(setattr, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(setattr, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                   struct iatt *preoldparent, struct iatt *postoldparent,
                   struct iatt *prenewparent, struct iatt *postnewparent,
                   dict_t *xdata)
@@ -407,15 +410,15 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(rename, frame, -1, errno, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(rename, frame, gf_error, errno, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 
 int32_t
-leases_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, struct iatt *preparent, struct iatt *postparent,
-                  dict_t *xdata)
+leases_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, struct iatt *preparent,
+                  struct iatt *postparent, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(unlink, frame, op_ret, op_errno, preparent, postparent,
                         xdata);
@@ -455,14 +458,15 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(unlink, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(unlink, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
-leases_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, inode_t *inode, struct iatt *stbuf,
-                struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+leases_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, inode_t *inode,
+                struct iatt *stbuf, struct iatt *preparent,
+                struct iatt *postparent, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(link, frame, op_ret, op_errno, inode, stbuf, preparent,
                         postparent, xdata);
@@ -501,15 +505,16 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(link, frame, -1, errno, NULL, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(link, frame, gf_error, errno, NULL, NULL, NULL, NULL,
+                        NULL);
     return 0;
 }
 
 int32_t
-leases_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                  int op_errno, fd_t *fd, inode_t *inode, struct iatt *stbuf,
-                  struct iatt *preparent, struct iatt *postparent,
-                  dict_t *xdata)
+leases_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                  gf_return_t op_ret, int op_errno, fd_t *fd, inode_t *inode,
+                  struct iatt *stbuf, struct iatt *preparent,
+                  struct iatt *postparent, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(create, frame, op_ret, op_errno, fd, inode, stbuf,
                         preparent, postparent, xdata);
@@ -551,14 +556,14 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(create, frame, -1, errno, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(create, frame, gf_error, errno, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(fsync, frame, op_ret, op_errno, prebuf, postbuf, xdata);
@@ -596,13 +601,13 @@ out:
                FIRST_CHILD(this)->fops->fsync, fd, flags, xdata);
     return 0;
 err:
-    STACK_UNWIND_STRICT(fsync, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(fsync, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(ftruncate, frame, op_ret, op_errno, prebuf, postbuf,
@@ -642,13 +647,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(ftruncate, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(ftruncate, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(fsetattr, frame, op_ret, op_errno, statpre, statpost,
@@ -688,13 +693,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(fsetattr, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(fsetattr, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                      struct iatt *post, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(fallocate, frame, op_ret, op_errno, pre, post, xdata);
@@ -736,13 +741,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(fallocate, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(fallocate, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                    struct iatt *post, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(discard, frame, op_ret, op_errno, pre, post, xdata);
@@ -782,13 +787,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(discard, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(discard, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 leases_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                     struct iatt *post, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(zerofill, frame, op_ret, op_errno, pre, post, xdata);
@@ -828,13 +833,13 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(zerofill, frame, -1, errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(zerofill, frame, gf_error, errno, NULL, NULL, NULL);
     return 0;
 }
 
 int
 leases_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(flush, frame, op_ret, op_errno, xdata);
 
@@ -894,8 +899,8 @@ out:
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(create, frame, -1, errno, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(create, frame, gf_error, errno, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 

--- a/xlators/features/locks/src/clear.c
+++ b/xlators/features/locks/src/clear.c
@@ -181,9 +181,9 @@ clrlk_clear_posixlk(xlator_t *this, pl_inode_t *pl_inode, clrlk_args *args,
             if (plock->blocked) {
                 bcount++;
                 pl_trace_out(this, plock->frame, NULL, NULL, F_SETLKW,
-                             &plock->user_flock, -1, EINTR, NULL);
+                             &plock->user_flock, gf_error, EINTR, NULL);
 
-                STACK_UNWIND_STRICT(lk, plock->frame, -1, EINTR,
+                STACK_UNWIND_STRICT(lk, plock->frame, gf_error, EINTR,
                                     &plock->user_flock, NULL);
 
             } else {
@@ -265,8 +265,8 @@ blkd:
         {
             list_del_init(&ilock->blocked_locks);
             pl_trace_out(this, ilock->frame, NULL, NULL, F_SETLKW,
-                         &ilock->user_flock, -1, EAGAIN, ilock->volume);
-            STACK_UNWIND_STRICT(inodelk, ilock->frame, -1, EAGAIN, NULL);
+                         &ilock->user_flock, gf_error, EAGAIN, ilock->volume);
+            STACK_UNWIND_STRICT(inodelk, ilock->frame, gf_error, EAGAIN, NULL);
             // No need to take lock as the locks are only in one list
             __pl_inodelk_unref(ilock);
         }
@@ -370,9 +370,9 @@ blkd:
         {
             list_del_init(&elock->blocked_locks);
             entrylk_trace_out(this, elock->frame, elock->volume, NULL, NULL,
-                              elock->basename, ENTRYLK_LOCK, elock->type, -1,
-                              EAGAIN);
-            STACK_UNWIND_STRICT(entrylk, elock->frame, -1, EAGAIN, NULL);
+                              elock->basename, ENTRYLK_LOCK, elock->type,
+                              gf_error, EAGAIN);
+            STACK_UNWIND_STRICT(entrylk, elock->frame, gf_error, EAGAIN, NULL);
 
             __pl_entrylk_unref(elock);
         }

--- a/xlators/features/locks/src/common.h
+++ b/xlators/features/locks/src/common.h
@@ -140,7 +140,7 @@ pl_trace_in(xlator_t *this, call_frame_t *frame, fd_t *fd, loc_t *loc, int cmd,
 
 void
 pl_trace_out(xlator_t *this, call_frame_t *frame, fd_t *fd, loc_t *loc, int cmd,
-             struct gf_flock *flock, int op_ret, int op_errno,
+             struct gf_flock *flock, gf_return_t op_ret, int op_errno,
              const char *domain);
 
 void
@@ -158,7 +158,7 @@ entrylk_trace_in(xlator_t *this, call_frame_t *frame, const char *volume,
 void
 entrylk_trace_out(xlator_t *this, call_frame_t *frame, const char *volume,
                   fd_t *fd, loc_t *loc, const char *basename, entrylk_cmd cmd,
-                  entrylk_type type, int op_ret, int op_errno);
+                  entrylk_type type, gf_return_t op_ret, int op_errno);
 
 void
 entrylk_trace_block(xlator_t *this, call_frame_t *frame, const char *volume,
@@ -166,7 +166,7 @@ entrylk_trace_block(xlator_t *this, call_frame_t *frame, const char *volume,
                     entrylk_type type);
 
 void
-pl_print_verdict(char *str, int size, int op_ret, int op_errno);
+pl_print_verdict(char *str, int size, int32_t op_ret, int op_errno);
 
 void
 pl_print_lockee(char *str, int size, fd_t *fd, loc_t *loc);

--- a/xlators/features/locks/src/posix.c
+++ b/xlators/features/locks/src/posix.c
@@ -70,7 +70,7 @@ fetch_pathinfo(xlator_t *, inode_t *, int32_t *, char **);
         dict_t *__unref = NULL;                                                \
         int __i = 0;                                                           \
         __local = frame->local;                                                \
-        if (op_ret >= 0 && pl_needs_xdata_response(frame->local)) {            \
+        if (IS_SUCCESS(op_ret) && pl_needs_xdata_response(frame->local)) {     \
             if (xdata)                                                         \
                 dict_ref(xdata);                                               \
             else                                                               \
@@ -122,13 +122,13 @@ fetch_pathinfo(xlator_t *, inode_t *, int32_t *, char **);
             inode_t *__inode = (loc ? loc->inode : fd->inode);                 \
             pl_inode_t *__pl_inode = pl_inode_get(this, __inode, NULL);        \
             if (__pl_inode == NULL) {                                          \
-                op_ret = -1;                                                   \
+                op_ret = gf_error;                                             \
                 op_errno = ENOMEM;                                             \
                 goto unwind;                                                   \
             }                                                                  \
             if (!pl_is_mandatory_locking_enabled(__pl_inode) ||                \
                 !priv->mlock_enforced) {                                       \
-                op_ret = -1;                                                   \
+                op_ret = gf_error;                                             \
                 gf_msg(this->name, GF_LOG_DEBUG, EINVAL, 0,                    \
                        "option %s would need mandatory lock to be enabled "    \
                        "and feature.enforce-mandatory-lock option to be set "  \
@@ -138,8 +138,8 @@ fetch_pathinfo(xlator_t *, inode_t *, int32_t *, char **);
                 goto unwind;                                                   \
             }                                                                  \
                                                                                \
-            op_ret = pl_local_init(frame, this, loc, fd);                      \
-            if (op_ret) {                                                      \
+            if (pl_local_init(frame, this, loc, fd)) {                         \
+                op_ret = gf_error;                                             \
                 op_errno = ENOMEM;                                             \
                 goto unwind;                                                   \
             }                                                                  \
@@ -638,7 +638,7 @@ out:
 
 int32_t
 pl_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                struct iatt *postbuf, dict_t *xdata)
 {
     pl_track_io_fop_count(frame->local, this, DECREMENT);
@@ -674,7 +674,7 @@ pl_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     };
     gf_boolean_t enabled = _gf_false;
     gf_boolean_t can_block = _gf_true;
-    int op_ret = 0;
+    gf_return_t op_ret = {0};
     int op_errno = 0;
     int allowed = 1;
 
@@ -682,7 +682,7 @@ pl_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     local = mem_get0(this->local_pool);
     if (!local) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -693,7 +693,7 @@ pl_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     pl_inode = pl_inode_get(this, fd->inode, local);
     if (!pl_inode) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -723,14 +723,14 @@ pl_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
                 goto unlock;
             } else if (!can_block) {
                 op_errno = EAGAIN;
-                op_ret = -1;
+                op_ret = gf_error;
                 goto unlock;
             }
 
             rw = GF_MALLOC(sizeof(*rw), gf_locks_mt_pl_rw_req_t);
             if (!rw) {
                 op_errno = ENOMEM;
-                op_ret = -1;
+                op_ret = gf_error;
                 goto unlock;
             }
 
@@ -738,7 +738,7 @@ pl_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
                                         xdata);
             if (!rw->stub) {
                 op_errno = ENOMEM;
-                op_ret = -1;
+                op_ret = gf_error;
                 GF_FREE(rw);
                 goto unlock;
             }
@@ -755,7 +755,7 @@ pl_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         STACK_WIND(frame, pl_discard_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->discard, fd, offset, len, xdata);
 unwind:
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         PL_STACK_UNWIND(discard, xdata, frame, op_ret, op_errno, NULL, NULL,
                         NULL);
 
@@ -764,7 +764,7 @@ unwind:
 
 int32_t
 pl_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                 struct iatt *postbuf, dict_t *xdata)
 {
     pl_track_io_fop_count(frame->local, this, DECREMENT);
@@ -800,7 +800,7 @@ pl_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     };
     gf_boolean_t enabled = _gf_false;
     gf_boolean_t can_block = _gf_true;
-    int op_ret = 0;
+    gf_return_t op_ret = {0};
     int op_errno = 0;
     int allowed = 1;
 
@@ -808,7 +808,7 @@ pl_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     local = mem_get0(this->local_pool);
     if (!local) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -819,7 +819,7 @@ pl_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     pl_inode = pl_inode_get(this, fd->inode, local);
     if (!pl_inode) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -849,14 +849,14 @@ pl_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
                 goto unlock;
             } else if (!can_block) {
                 op_errno = EAGAIN;
-                op_ret = -1;
+                op_ret = gf_error;
                 goto unlock;
             }
 
             rw = GF_MALLOC(sizeof(*rw), gf_locks_mt_pl_rw_req_t);
             if (!rw) {
                 op_errno = ENOMEM;
-                op_ret = -1;
+                op_ret = gf_error;
                 goto unlock;
             }
 
@@ -864,7 +864,7 @@ pl_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
                                          len, xdata);
             if (!rw->stub) {
                 op_errno = ENOMEM;
-                op_ret = -1;
+                op_ret = gf_error;
                 GF_FREE(rw);
                 goto unlock;
             }
@@ -881,7 +881,7 @@ pl_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         STACK_WIND(frame, pl_zerofill_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->zerofill, fd, offset, len, xdata);
 unwind:
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         PL_STACK_UNWIND(zerofill, xdata, frame, op_ret, op_errno, NULL, NULL,
                         NULL);
 
@@ -890,7 +890,7 @@ unwind:
 
 int
 pl_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                 struct iatt *postbuf, dict_t *xdata)
 {
     pl_local_t *local = frame->local;
@@ -930,7 +930,7 @@ pl_truncate_cont(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
 
 static int
 truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   dict_t *xdata)
 {
     pl_local_t *local = frame->local;
@@ -949,7 +949,7 @@ truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     GF_VALIDATE_OR_GOTO("locks", this, unwind);
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_ERROR,
                "got error (errno=%d, stderror=%s) from child", op_errno,
                strerror(op_errno));
@@ -965,7 +965,7 @@ truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     pl_inode = pl_inode_get(this, inode, local);
     if (!pl_inode) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -995,14 +995,14 @@ truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 goto unlock;
             } else if (!can_block) {
                 op_errno = EAGAIN;
-                op_ret = -1;
+                op_ret = gf_error;
                 goto unlock;
             }
 
             rw = GF_MALLOC(sizeof(*rw), gf_locks_mt_pl_rw_req_t);
             if (!rw) {
                 op_errno = ENOMEM;
-                op_ret = -1;
+                op_ret = gf_error;
                 goto unlock;
             }
 
@@ -1016,7 +1016,7 @@ truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                               local->xdata);
             if (!rw->stub) {
                 op_errno = ENOMEM;
-                op_ret = -1;
+                op_ret = gf_error;
                 GF_FREE(rw);
                 goto unlock;
             }
@@ -1046,11 +1046,11 @@ truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 unwind:
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this ? this->name : "locks", GF_LOG_ERROR,
                "truncate failed with "
                "ret: %d, error: %s",
-               op_ret, strerror(op_errno));
+               GET_RET(op_ret), strerror(op_errno));
 
         switch (local->op) {
             case GF_FOP_TRUNCATE:
@@ -1098,7 +1098,8 @@ unwind:
                "truncate on %s failed with"
                " ret: %d, error: %s",
                loc->path, -1, strerror(ENOMEM));
-        STACK_UNWIND_STRICT(truncate, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(truncate, frame, gf_error, ENOMEM, NULL, NULL,
+                            NULL);
     }
     return 0;
 }
@@ -1128,10 +1129,10 @@ pl_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 unwind:
     if (ret == -1) {
         gf_log(this ? this->name : "locks", GF_LOG_ERROR,
-               "ftruncate failed with"
-               " ret: %d, error: %s",
-               -1, strerror(ENOMEM));
-        STACK_UNWIND_STRICT(ftruncate, frame, -1, ENOMEM, NULL, NULL, NULL);
+               "ftruncate failed with ret: %d, error: %s", -1,
+               strerror(ENOMEM));
+        STACK_UNWIND_STRICT(ftruncate, frame, gf_error, ENOMEM, NULL, NULL,
+                            NULL);
     }
     return 0;
 }
@@ -1185,7 +1186,8 @@ delete_locks_of_fd(xlator_t *this, pl_inode_t *pl_inode, fd_t *fd)
     list_for_each_entry_safe(l, tmp, &blocked_list, list)
     {
         list_del_init(&l->list);
-        STACK_UNWIND_STRICT(lk, l->frame, -1, EAGAIN, &l->user_flock, NULL);
+        STACK_UNWIND_STRICT(lk, l->frame, gf_error, EAGAIN, &l->user_flock,
+                            NULL);
         __destroy_lock(l);
     }
 
@@ -1226,7 +1228,8 @@ __delete_locks_of_owner(pl_inode_t *pl_inode, client_t *client,
 
 int32_t
 pl_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                dict_t *xdata)
 {
     STACK_UNWIND_STRICT(getxattr, frame, op_ret, op_errno, dict, xdata);
     return 0;
@@ -1245,7 +1248,7 @@ pl_getxattr_clrlk(xlator_t *this, const char *name, inode_t *inode,
         0,
     };
     char *brickname = NULL;
-    int32_t op_ret = -1;
+    int ret = -1;
 
     *op_errno = EINVAL;
 
@@ -1269,18 +1272,18 @@ pl_getxattr_clrlk(xlator_t *this, const char *name, inode_t *inode,
     switch (args.type) {
         case CLRLK_INODE:
         case CLRLK_ENTRY:
-            op_ret = clrlk_clear_lks_in_all_domains(this, pl_inode, &args,
-                                                    &bcount, &gcount, op_errno);
+            ret = clrlk_clear_lks_in_all_domains(this, pl_inode, &args, &bcount,
+                                                 &gcount, op_errno);
             break;
         case CLRLK_POSIX:
-            op_ret = clrlk_clear_posixlk(this, pl_inode, &args, &bcount,
-                                         &gcount, op_errno);
+            ret = clrlk_clear_posixlk(this, pl_inode, &args, &bcount, &gcount,
+                                      op_errno);
             break;
         default:
-            op_ret = -1;
+            ret = -1;
             *op_errno = EINVAL;
     }
-    if (op_ret) {
+    if (ret) {
         if (args.type >= CLRLK_TYPE_MAX) {
             gf_log(this->name, GF_LOG_ERROR,
                    "clear locks: invalid lock type %d", args.type);
@@ -1293,12 +1296,12 @@ pl_getxattr_clrlk(xlator_t *this, const char *name, inode_t *inode,
         goto out;
     }
 
-    op_ret = fetch_pathinfo(this, inode, op_errno, &brickname);
-    if (op_ret) {
+    ret = fetch_pathinfo(this, inode, op_errno, &brickname);
+    if (ret) {
         gf_log(this->name, GF_LOG_WARNING, "Couldn't get brickname");
     } else {
-        op_ret = format_brickname(brickname);
-        if (op_ret) {
+        ret = format_brickname(brickname);
+        if (ret) {
             gf_log(this->name, GF_LOG_WARNING, "Couldn't format brickname");
             GF_FREE(brickname);
             brickname = NULL;
@@ -1307,7 +1310,7 @@ pl_getxattr_clrlk(xlator_t *this, const char *name, inode_t *inode,
 
     if (!gcount && !bcount) {
         if (gf_asprintf(&lk_summary, "No locks cleared.") == -1) {
-            op_ret = -1;
+            ret = -1;
             *op_errno = ENOMEM;
             goto out;
         }
@@ -1316,7 +1319,7 @@ pl_getxattr_clrlk(xlator_t *this, const char *name, inode_t *inode,
                            "granted locks=%d",
                            (brickname == NULL) ? this->name : brickname,
                            clrlk_type_names[args.type], bcount, gcount) == -1) {
-        op_ret = -1;
+        ret = -1;
         *op_errno = ENOMEM;
         goto out;
     }
@@ -1324,26 +1327,26 @@ pl_getxattr_clrlk(xlator_t *this, const char *name, inode_t *inode,
 
     key = gf_strdup(name);
     if (!key) {
-        op_ret = -1;
+        ret = -1;
         goto out;
     }
     if (dict_set_dynstr(*dict, key, lk_summary)) {
-        op_ret = -1;
+        ret = -1;
         *op_errno = ENOMEM;
         goto out;
     }
 
-    op_ret = 0;
+    ret = 0;
 
 out:
     GF_FREE(brickname);
     GF_FREE(args.opts);
     GF_FREE(key);
-    if (op_ret) {
+    if (ret) {
         GF_FREE(lk_summary);
     }
 
-    return op_ret;
+    return ret;
 }
 
 int32_t
@@ -1351,7 +1354,8 @@ pl_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
             dict_t *xdata)
 {
     int32_t op_errno = EINVAL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret;
+    int ret;
     dict_t *dict = NULL;
 
     if (!name)
@@ -1360,8 +1364,9 @@ pl_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
     if (strncmp(name, GF_XATTR_CLRLK_CMD, SLEN(GF_XATTR_CLRLK_CMD)))
         goto usual;
 
-    op_ret = pl_getxattr_clrlk(this, name, loc->inode, &dict, &op_errno);
+    ret = pl_getxattr_clrlk(this, name, loc->inode, &dict, &op_errno);
 
+    SET_RET(op_ret, ret);
     STACK_UNWIND_STRICT(getxattr, frame, op_ret, op_errno, dict, xdata);
 
     if (dict)
@@ -1594,6 +1599,7 @@ pl_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
 {
     int32_t op_ret = 0, op_errno = 0;
     dict_t *dict = NULL;
+    gf_return_t fin_ret;
 
     if (!name) {
         goto usual;
@@ -1626,7 +1632,8 @@ pl_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
     }
 
 unwind:
-    STACK_UNWIND_STRICT(fgetxattr, frame, op_ret, op_errno, dict, NULL);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(fgetxattr, frame, fin_ret, op_errno, dict, NULL);
     if (dict != NULL) {
         dict_unref(dict);
     }
@@ -1723,16 +1730,16 @@ out:
 
 int32_t
 pl_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     pl_local_t *local = NULL;
     pl_inode_t *pl_inode = NULL;
 
     local = frame->local;
-    if (local && local->update_mlock_enforced_flag && op_ret != -1) {
+    if (local && local->update_mlock_enforced_flag && IS_SUCCESS(op_ret)) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unwind;
         }
@@ -1760,16 +1767,15 @@ pl_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
     int len = 0;
     char *name = NULL;
     posix_locks_private_t *priv = this->private;
-
-    int32_t op_ret = dict_get_ptr_and_len(dict, GF_XATTR_LOCKINFO_KEY,
-                                          &lockinfo_buf, &len);
+    gf_return_t op_ret = {0};
+    int32_t ret = dict_get_ptr_and_len(dict, GF_XATTR_LOCKINFO_KEY,
+                                       &lockinfo_buf, &len);
     if (lockinfo_buf == NULL) {
         goto usual;
     }
 
-    op_ret = pl_fsetxattr_handle_lockinfo(frame, fd, lockinfo_buf, len,
-                                          &op_errno);
-    if (op_ret < 0) {
+    ret = pl_fsetxattr_handle_lockinfo(frame, fd, lockinfo_buf, len, &op_errno);
+    if (ret < 0) {
         goto unwind;
     }
 
@@ -1784,6 +1790,7 @@ usual:
     return 0;
 
 unwind:
+    SET_RET(op_ret, ret);
     PL_STACK_UNWIND_FOR_CLIENT(fsetxattr, xdata, frame, op_ret, op_errno, NULL);
 
     return 0;
@@ -1791,17 +1798,17 @@ unwind:
 
 int32_t
 pl_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     pl_fdctx_t *fdctx = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     fdctx = pl_check_n_create_fdctx(this, fd);
     if (!fdctx) {
         op_errno = ENOMEM;
-        op_ret = -1;
+        op_ret = gf_error;
         goto unwind;
     }
 
@@ -1822,8 +1829,8 @@ pl_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
 }
 
 int
-pl_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, dict_t *xdata)
+pl_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(flush, xdata, frame, op_ret, op_errno, xdata);
 
@@ -1836,7 +1843,7 @@ pl_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     pl_inode_t *pl_inode = pl_inode_get(this, fd->inode, NULL);
     if (!pl_inode) {
         gf_log(this->name, GF_LOG_DEBUG, "Could not get inode.");
-        STACK_UNWIND_STRICT(flush, frame, -1, EBADFD, NULL);
+        STACK_UNWIND_STRICT(flush, frame, gf_error, EBADFD, NULL);
         return 0;
     }
 
@@ -1844,7 +1851,7 @@ pl_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     {
         if (pl_inode->migrated) {
             pthread_mutex_unlock(&pl_inode->mutex);
-            STACK_UNWIND_STRICT(flush, frame, -1, EREMOTE, NULL);
+            STACK_UNWIND_STRICT(flush, frame, gf_error, EREMOTE, NULL);
             return 0;
         }
     }
@@ -1880,18 +1887,18 @@ wind:
 }
 
 int
-pl_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, fd_t *fd, dict_t *xdata)
+pl_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     pl_fdctx_t *fdctx = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     fdctx = pl_check_n_create_fdctx(this, fd);
     if (!fdctx) {
         op_errno = ENOMEM;
-        op_ret = -1;
+        op_ret = gf_error;
         goto unwind;
     }
 
@@ -1905,19 +1912,17 @@ int
 pl_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
         fd_t *fd, dict_t *xdata)
 {
-    int op_ret = -1;
+    gf_return_t op_ret = {0};
     int op_errno = EINVAL;
     pl_inode_t *pl_inode = NULL;
     posix_lock_t *l = NULL;
     posix_locks_private_t *priv = this->private;
 
-    GF_VALIDATE_OR_GOTO("locks", this, unwind);
-
-    op_ret = 0, op_errno = 0;
+    op_errno = 0;
     pl_inode = pl_inode_get(this, fd->inode, NULL);
     if (!pl_inode) {
         gf_msg(this->name, GF_LOG_ERROR, 0, ENOMEM, "Could not get inode");
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -1935,7 +1940,7 @@ pl_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
             pthread_mutex_lock(&pl_inode->mutex);
             {
                 if (!list_empty(&pl_inode->ext_list)) {
-                    op_ret = -1;
+                    op_ret = gf_error;
                     op_errno = EAGAIN;
                 }
             }
@@ -1948,7 +1953,7 @@ pl_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
                 list_for_each_entry(l, &pl_inode->ext_list, list)
                 {
                     if ((l->lk_flags & GF_LK_MANDATORY)) {
-                        op_ret = -1;
+                        op_ret = gf_error;
                         op_errno = EAGAIN;
                         break;
                     }
@@ -1959,7 +1964,7 @@ pl_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     }
 
 unwind:
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         STACK_UNWIND_STRICT(open, frame, op_ret, op_errno, NULL, NULL);
     else
         STACK_WIND(frame, pl_open_cbk, FIRST_CHILD(this),
@@ -1968,19 +1973,20 @@ unwind:
 }
 
 int
-pl_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, fd_t *fd, inode_t *inode, struct iatt *buf,
-              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+pl_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
+              struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+              dict_t *xdata)
 {
     pl_fdctx_t *fdctx = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     fdctx = pl_check_n_create_fdctx(this, fd);
     if (!fdctx) {
         op_errno = ENOMEM;
-        op_ret = -1;
+        op_ret = gf_error;
         goto unwind;
     }
 
@@ -2004,9 +2010,10 @@ pl_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 }
 
 int
-pl_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iovec *vector, int32_t count,
-             struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
+pl_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
+             int32_t count, struct iatt *stbuf, struct iobref *iobref,
+             dict_t *xdata)
 {
     pl_track_io_fop_count(frame->local, this, DECREMENT);
 
@@ -2017,9 +2024,9 @@ pl_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 }
 
 int
-pl_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
-              dict_t *xdata)
+pl_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
+              struct iatt *postbuf, dict_t *xdata)
 {
     pl_track_io_fop_count(frame->local, this, DECREMENT);
 
@@ -2172,7 +2179,7 @@ pl_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     };
     gf_boolean_t enabled = _gf_false;
     gf_boolean_t can_block = _gf_true;
-    int op_ret = 0;
+    gf_return_t op_ret = {0};
     int op_errno = 0;
     int allowed = 1;
 
@@ -2189,7 +2196,7 @@ pl_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     pl_inode = pl_inode_get(this, fd->inode, local);
     if (!pl_inode) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -2219,14 +2226,14 @@ pl_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
                 goto unlock;
             } else if (!can_block) {
                 op_errno = EAGAIN;
-                op_ret = -1;
+                op_ret = gf_error;
                 goto unlock;
             }
 
             rw = GF_MALLOC(sizeof(*rw), gf_locks_mt_pl_rw_req_t);
             if (!rw) {
                 op_errno = ENOMEM;
-                op_ret = -1;
+                op_ret = gf_error;
                 goto unlock;
             }
 
@@ -2234,7 +2241,7 @@ pl_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
                                       flags, xdata);
             if (!rw->stub) {
                 op_errno = ENOMEM;
-                op_ret = -1;
+                op_ret = gf_error;
                 GF_FREE(rw);
                 goto unlock;
             }
@@ -2253,7 +2260,7 @@ pl_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
                    xdata);
     }
 unwind:
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         PL_STACK_UNWIND(readv, xdata, frame, op_ret, op_errno, NULL, 0, NULL,
                         NULL, NULL);
 
@@ -2290,7 +2297,7 @@ pl_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
     };
     gf_boolean_t enabled = _gf_false;
     gf_boolean_t can_block = _gf_true;
-    int op_ret = 0;
+    gf_return_t op_ret = {0};
     int op_errno = 0;
     int allowed = 1;
 
@@ -2307,7 +2314,7 @@ pl_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
 
     pl_inode = pl_inode_get(this, fd->inode, local);
     if (!pl_inode) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -2342,14 +2349,14 @@ pl_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
                     op_errno = EAGAIN;
                 }
 
-                op_ret = -1;
+                op_ret = gf_error;
                 goto unlock;
             }
 
             rw = GF_MALLOC(sizeof(*rw), gf_locks_mt_pl_rw_req_t);
             if (!rw) {
                 op_errno = ENOMEM;
-                op_ret = -1;
+                op_ret = gf_error;
                 goto unlock;
             }
 
@@ -2357,7 +2364,7 @@ pl_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
                                        offset, flags, iobref, xdata);
             if (!rw->stub) {
                 op_errno = ENOMEM;
-                op_ret = -1;
+                op_ret = gf_error;
                 GF_FREE(rw);
                 goto unlock;
             }
@@ -2376,7 +2383,7 @@ pl_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
                    flags, iobref, xdata);
     }
 unwind:
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         PL_STACK_UNWIND(writev, xdata, frame, op_ret, op_errno, NULL, NULL,
                         NULL);
 
@@ -2565,7 +2572,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
       struct gf_flock *flock, dict_t *xdata)
 {
     pl_inode_t *pl_inode = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = {0};
     int op_errno = 0;
     int can_block = 0;
     posix_lock_t *reqlock = NULL;
@@ -2589,7 +2596,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
     }
 
     if ((flock->l_start < 0) || ((flock->l_start + flock->l_len) < 0)) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto unwind;
     }
@@ -2606,7 +2613,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 
     local = mem_get0(this->local_pool);
     if (!local) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     } else {
@@ -2616,7 +2623,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 
     pl_inode = pl_inode_get(this, fd->inode, local);
     if (!pl_inode) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -2626,7 +2633,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
                              &op_errno);
 
     if (!reqlock) {
-        op_ret = -1;
+        op_ret = gf_error;
         goto unwind;
     }
 
@@ -2646,7 +2653,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
                 if (can_block)
                     goto out;
 
-                op_ret = -1;
+                op_ret = gf_error;
                 op_errno = -ret;
                 __destroy_lock(reqlock);
                 goto unwind;
@@ -2662,7 +2669,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
             reqlock->this = this;
             ret = pl_reserve_unlock(this, pl_inode, reqlock);
             if (ret < 0) {
-                op_ret = -1;
+                op_ret = gf_error;
                 op_errno = -ret;
             }
             __destroy_lock(reqlock);
@@ -2679,7 +2686,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
             ret = pl_getlk_fd(this, pl_inode, fd, reqlock);
             if (ret < 0) {
                 gf_log(this->name, GF_LOG_DEBUG, "getting locks on fd failed");
-                op_ret = -1;
+                op_ret = gf_error;
                 op_errno = ENOLCK;
                 goto unwind;
             }
@@ -2725,7 +2732,8 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
                 if (pl_inode->migrated) {
                     op_errno = EREMOTE;
                     pthread_mutex_unlock(&pl_inode->mutex);
-                    STACK_UNWIND_STRICT(lk, frame, -1, op_errno, flock, xdata);
+                    STACK_UNWIND_STRICT(lk, frame, gf_error, op_errno, flock,
+                                        xdata);
 
                     __destroy_lock(reqlock);
                     goto out;
@@ -2744,7 +2752,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
                 ret = pl_lock_preempt(pl_inode, reqlock);
                 if (ret == -1) {
                     gf_log(this->name, GF_LOG_ERROR, "lock preempt failed");
-                    op_ret = -1;
+                    op_ret = gf_error;
                     op_errno = EAGAIN;
                     __destroy_lock(reqlock);
                     goto out;
@@ -2760,7 +2768,7 @@ pl_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
                     goto out;
                 }
                 gf_log(this->name, GF_LOG_DEBUG, "returning EAGAIN");
-                op_ret = -1;
+                op_ret = gf_error;
                 op_errno = EAGAIN;
                 __destroy_lock(reqlock);
             } else if (ret == -2) {
@@ -2888,8 +2896,8 @@ pl_forget(xlator_t *this, inode_t *inode)
     if (!list_empty(&posixlks_released)) {
         list_for_each_entry_safe(ext_l, ext_tmp, &posixlks_released, list)
         {
-            STACK_UNWIND_STRICT(lk, ext_l->frame, -1, 0, &ext_l->user_flock,
-                                NULL);
+            STACK_UNWIND_STRICT(lk, ext_l->frame, gf_error, 0,
+                                &ext_l->user_flock, NULL);
             __destroy_lock(ext_l);
         }
     }
@@ -2898,7 +2906,7 @@ pl_forget(xlator_t *this, inode_t *inode)
         list_for_each_entry_safe(ino_l, ino_tmp, &inodelks_released,
                                  blocked_locks)
         {
-            STACK_UNWIND_STRICT(inodelk, ino_l->frame, -1, 0, NULL);
+            STACK_UNWIND_STRICT(inodelk, ino_l->frame, gf_error, 0, NULL);
             __pl_inodelk_unref(ino_l);
         }
     }
@@ -2907,7 +2915,7 @@ pl_forget(xlator_t *this, inode_t *inode)
         list_for_each_entry_safe(entry_l, entry_tmp, &entrylks_released,
                                  blocked_locks)
         {
-            STACK_UNWIND_STRICT(entrylk, entry_l->frame, -1, 0, NULL);
+            STACK_UNWIND_STRICT(entrylk, entry_l->frame, gf_error, 0, NULL);
             GF_FREE((char *)entry_l->basename);
             GF_FREE(entry_l->connection_id);
             GF_FREE(entry_l);
@@ -3032,17 +3040,17 @@ pl_check_link_count(dict_t *xdata)
 }
 
 int32_t
-pl_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode, struct iatt *buf, dict_t *xdata,
-              struct iatt *postparent)
+pl_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+              struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     pl_inode_t *pl_inode;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         pl_inode = pl_inode_get(this, inode, NULL);
         if (pl_inode == NULL) {
-            PL_STACK_UNWIND(lookup, xdata, frame, -1, ENOMEM, NULL, NULL, NULL,
-                            NULL);
+            PL_STACK_UNWIND(lookup, xdata, frame, gf_error, ENOMEM, NULL, NULL,
+                            NULL, NULL);
             return 0;
         }
 
@@ -3081,14 +3089,16 @@ pl_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
                    FIRST_CHILD(this)->fops->lookup, loc, xdata);
         dict_unref(xdata);
     } else {
-        STACK_UNWIND_STRICT(lookup, frame, -1, error, NULL, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(lookup, frame, gf_error, error, NULL, NULL, NULL,
+                            NULL);
     }
     return 0;
 }
 
 int32_t
-pl_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iatt *buf, dict_t *xdata)
+pl_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+             dict_t *xdata)
 {
     PL_STACK_UNWIND(fstat, xdata, frame, op_ret, op_errno, buf, xdata);
     return 0;
@@ -3104,13 +3114,14 @@ pl_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 }
 
 int
-pl_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, gf_dirent_t *entries, dict_t *xdata)
+pl_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
+                dict_t *xdata)
 {
     pl_local_t *local = NULL;
     gf_dirent_t *entry = NULL;
 
-    if (op_ret <= 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -3205,7 +3216,7 @@ pl_getactivelk(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 {
     pl_inode_t *pl_inode = NULL;
     lock_migration_info_t locks;
-    int op_ret = 0;
+    gf_return_t op_ret = {0};
     int op_errno = 0;
     int count = 0;
 
@@ -3215,14 +3226,14 @@ pl_getactivelk(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     if (!pl_inode) {
         gf_msg(this->name, GF_LOG_ERROR, 0, 0, "pl_inode_get failed");
 
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto out;
     }
 
     count = pl_fill_active_locks(pl_inode, &locks);
 
-    op_ret = count;
+    SET_RET(op_ret, count);
 
 out:
     STACK_UNWIND_STRICT(getactivelk, frame, op_ret, op_errno, &locks, NULL);
@@ -3517,7 +3528,7 @@ out:
     {
         list_del_init(&posix_lock->list);
 
-        STACK_UNWIND_STRICT(lk, posix_lock->frame, -1, EREMOTE,
+        STACK_UNWIND_STRICT(lk, posix_lock->frame, gf_error, EREMOTE,
                             &posix_lock->user_flock, NULL);
 
         __destroy_lock(posix_lock);
@@ -3528,15 +3539,15 @@ out:
 
 int32_t
 pl_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     pl_local_t *local = NULL;
     pl_inode_t *pl_inode = NULL;
     local = frame->local;
-    if (local && local->update_mlock_enforced_flag && op_ret != -1) {
+    if (local && local->update_mlock_enforced_flag && IS_SUCCESS(op_ret)) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unwind;
         }
@@ -3566,7 +3577,8 @@ int32_t
 pl_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
             int flags, dict_t *xdata)
 {
-    int op_ret = 0;
+    gf_return_t op_ret = {0};
+    int ret;
     int op_errno = EINVAL;
     dict_t *xdata_rsp = NULL;
     char *name = NULL;
@@ -3575,14 +3587,14 @@ pl_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
     PL_LOCAL_GET_REQUESTS(frame, this, xdata, ((fd_t *)NULL), loc, NULL);
 
     if (dict_get_sizen(dict, GF_META_LOCK_KEY)) {
-        op_ret = pl_metalk(frame, this, loc->inode);
+        ret = pl_metalk(frame, this, loc->inode);
 
     } else if (dict_get_sizen(dict, GF_META_UNLOCK_KEY)) {
-        op_ret = pl_metaunlock(frame, this, loc->inode, dict);
+        ret = pl_metaunlock(frame, this, loc->inode, dict);
     } else {
         goto usual;
     }
-
+    SET_RET(op_ret, ret);
     PL_STACK_UNWIND_FOR_CLIENT(setxattr, xdata_rsp, frame, op_ret, op_errno,
                                xdata_rsp);
     return 0;
@@ -4031,7 +4043,7 @@ unlock:
     {
         list_del_init(&posix_lock->list);
 
-        STACK_UNWIND_STRICT(lk, posix_lock->frame, -1, EREMOTE,
+        STACK_UNWIND_STRICT(lk, posix_lock->frame, gf_error, EREMOTE,
                             &posix_lock->user_flock, NULL);
 
         __destroy_lock(posix_lock);
@@ -4240,12 +4252,13 @@ pl_fentrylk(call_frame_t *frame, xlator_t *this, const char *volume, fd_t *fd,
             dict_t *xdata);
 
 int32_t
-pl_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *buf, struct iatt *preoldparent,
-              struct iatt *postoldparent, struct iatt *prenewparent,
-              struct iatt *postnewparent, dict_t *xdata)
+pl_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+              struct iatt *preoldparent, struct iatt *postoldparent,
+              struct iatt *prenewparent, struct iatt *postnewparent,
+              dict_t *xdata)
 {
-    pl_inode_remove_cbk(this, cookie, op_ret < 0 ? op_errno : 0);
+    pl_inode_remove_cbk(this, cookie, IS_ERROR(op_ret) ? op_errno : 0);
 
     PL_STACK_UNWIND(rename, xdata, frame, op_ret, op_errno, buf, preoldparent,
                     postoldparent, prenewparent, postnewparent, xdata);
@@ -4262,8 +4275,8 @@ pl_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     error = PL_INODE_REMOVE(rename, frame, this, oldloc, newloc, pl_rename,
                             pl_rename_cbk, oldloc, newloc, xdata);
     if (error > 0) {
-        STACK_UNWIND_STRICT(rename, frame, -1, error, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(rename, frame, gf_error, error, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
     }
 
     return 0;
@@ -4362,7 +4375,7 @@ static int
 pl_setactivelk(call_frame_t *frame, xlator_t *this, loc_t *loc,
                lock_migration_info_t *locklist, dict_t *xdata)
 {
-    int op_ret = 0;
+    gf_return_t op_ret = {0};
     int op_errno = 0;
     int ret = 0;
 
@@ -4370,13 +4383,13 @@ pl_setactivelk(call_frame_t *frame, xlator_t *this, loc_t *loc,
     if (!pl_inode) {
         gf_msg(this->name, GF_LOG_ERROR, 0, 0, "pl_inode_get failed");
 
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto out;
     }
     ret = pl_write_active_locks(frame, pl_inode, locklist);
 
-    op_ret = ret;
+    SET_RET(op_ret, ret);
 
 out:
     STACK_UNWIND_STRICT(setactivelk, frame, op_ret, op_errno, NULL);
@@ -4385,11 +4398,11 @@ out:
 }
 
 int32_t
-pl_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *preparent, struct iatt *postparent,
-              dict_t *xdata)
+pl_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
+              struct iatt *postparent, dict_t *xdata)
 {
-    pl_inode_remove_cbk(this, cookie, op_ret < 0 ? op_errno : 0);
+    pl_inode_remove_cbk(this, cookie, IS_ERROR(op_ret) ? op_errno : 0);
 
     PL_STACK_UNWIND(unlink, xdata, frame, op_ret, op_errno, preparent,
                     postparent, xdata);
@@ -4406,16 +4419,17 @@ pl_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     error = PL_INODE_REMOVE(unlink, frame, this, loc, NULL, pl_unlink,
                             pl_unlink_cbk, loc, xflag, xdata);
     if (error > 0) {
-        STACK_UNWIND_STRICT(unlink, frame, -1, error, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(unlink, frame, gf_error, error, NULL, NULL, NULL);
     }
 
     return 0;
 }
 
 int32_t
-pl_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, inode_t *inode, struct iatt *buf,
-             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+pl_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+             struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+             dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(mkdir, xdata, frame, op_ret, op_errno, inode,
                                buf, preparent, postparent, xdata);
@@ -4433,8 +4447,9 @@ pl_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 }
 
 int32_t
-pl_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, struct iatt *buf, dict_t *xdata)
+pl_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+            dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(stat, xdata, frame, op_ret, op_errno, buf,
                                xdata);
@@ -4451,9 +4466,10 @@ pl_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 }
 
 int32_t
-pl_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, inode_t *inode, struct iatt *buf,
-             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+pl_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+             struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+             dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(mknod, xdata, frame, op_ret, op_errno, inode,
                                buf, preparent, postparent, xdata);
@@ -4471,11 +4487,11 @@ pl_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 }
 
 int32_t
-pl_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iatt *preparent, struct iatt *postparent,
-             dict_t *xdata)
+pl_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
+             struct iatt *postparent, dict_t *xdata)
 {
-    pl_inode_remove_cbk(this, cookie, op_ret < 0 ? op_errno : 0);
+    pl_inode_remove_cbk(this, cookie, IS_ERROR(op_ret) ? op_errno : 0);
 
     PL_STACK_UNWIND_FOR_CLIENT(rmdir, xdata, frame, op_ret, op_errno, preparent,
                                postparent, xdata);
@@ -4492,7 +4508,7 @@ pl_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflags,
     error = PL_INODE_REMOVE(rmdir, frame, this, loc, NULL, pl_rmdir,
                             pl_rmdir_cbk, loc, xflags, xdata);
     if (error > 0) {
-        STACK_UNWIND_STRICT(rmdir, frame, -1, error, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(rmdir, frame, gf_error, error, NULL, NULL, NULL);
     }
 
     return 0;
@@ -4500,7 +4516,7 @@ pl_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflags,
 
 int32_t
 pl_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *buf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -4520,13 +4536,14 @@ pl_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
 }
 
 int32_t
-pl_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, inode_t *inode, struct iatt *buf,
-            struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+pl_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+            struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+            dict_t *xdata)
 {
     pl_inode_t *pl_inode = (pl_inode_t *)cookie;
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         pthread_mutex_lock(&pl_inode->mutex);
 
         /* TODO: can happen pl_inode->links == 0 ? */
@@ -4550,8 +4567,8 @@ pl_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     pl_inode = pl_inode_get(this, oldloc->inode, NULL);
     if (pl_inode == NULL) {
-        STACK_UNWIND_STRICT(link, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(link, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL);
         return 0;
     }
 
@@ -4562,9 +4579,9 @@ pl_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 }
 
 int32_t
-pl_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
-             dict_t *xdata)
+pl_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
+             struct iatt *postbuf, dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(fsync, xdata, frame, op_ret, op_errno, prebuf,
                                postbuf, xdata);
@@ -4583,7 +4600,7 @@ pl_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t datasync,
 
 int32_t
 pl_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+               gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(readdir, xdata, frame, op_ret, op_errno, entries,
@@ -4603,7 +4620,7 @@ pl_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
 int32_t
 pl_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(fsyncdir, xdata, frame, op_ret, op_errno, xdata);
     return 0;
@@ -4620,8 +4637,9 @@ pl_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t datasync,
 }
 
 int32_t
-pl_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct statvfs *buf, dict_t *xdata)
+pl_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
+              dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(statfs, xdata, frame, op_ret, op_errno, buf,
                                xdata);
@@ -4639,16 +4657,16 @@ pl_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
 int32_t
 pl_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     pl_local_t *local = NULL;
     pl_inode_t *pl_inode = NULL;
 
     local = frame->local;
-    if (local && local->update_mlock_enforced_flag && op_ret != -1) {
+    if (local && local->update_mlock_enforced_flag && IS_SUCCESS(op_ret)) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unwind;
         }
@@ -4672,7 +4690,7 @@ int
 pl_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                const char *name, dict_t *xdata)
 {
-    int op_ret = 0;
+    gf_return_t op_ret = {0};
     int op_errno = EINVAL;
     posix_locks_private_t *priv = this->private;
 
@@ -4694,16 +4712,16 @@ unwind:
 
 int32_t
 pl_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     pl_local_t *local = NULL;
     pl_inode_t *pl_inode = NULL;
 
     local = frame->local;
-    if (local && local->update_mlock_enforced_flag && op_ret != -1) {
+    if (local && local->update_mlock_enforced_flag && IS_SUCCESS(op_ret)) {
         pl_inode = pl_inode_get(this, local->inode, NULL);
         if (!pl_inode) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unwind;
         }
@@ -4726,7 +4744,7 @@ int
 pl_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
                 dict_t *xdata)
 {
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     posix_locks_private_t *priv = this->private;
 
@@ -4747,7 +4765,7 @@ unwind:
 
 int32_t
 pl_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, uint32_t weak_cksum,
+                 gf_return_t op_ret, int32_t op_errno, uint32_t weak_cksum,
                  uint8_t *strong_cksum, dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(rchecksum, xdata, frame, op_ret, op_errno,
@@ -4767,7 +4785,8 @@ pl_rchecksum(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
 int32_t
 pl_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+               dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(xattrop, xdata, frame, op_ret, op_errno, dict,
                                xdata);
@@ -4786,7 +4805,8 @@ pl_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 int32_t
 pl_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(fxattrop, xdata, frame, op_ret, op_errno, dict,
                                xdata);
@@ -4805,7 +4825,7 @@ pl_fxattrop(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
 int32_t
 pl_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                struct iatt *statpost, dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(setattr, xdata, frame, op_ret, op_errno, statpre,
@@ -4825,7 +4845,7 @@ pl_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc, struct iatt *stbuf,
 
 int32_t
 pl_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                 struct iatt *statpost, dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(fsetattr, xdata, frame, op_ret, op_errno,
@@ -4845,7 +4865,7 @@ pl_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iatt *stbuf,
 
 int32_t
 pl_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                  struct iatt *post, dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(fallocate, xdata, frame, op_ret, op_errno, pre,
@@ -4866,7 +4886,7 @@ pl_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t keep_size,
 
 int32_t
 pl_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, const char *path,
+                gf_return_t op_ret, int32_t op_errno, const char *path,
                 struct iatt *buf, dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(readlink, xdata, frame, op_ret, op_errno, path,
@@ -4885,8 +4905,8 @@ pl_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
 }
 
 int32_t
-pl_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, dict_t *xdata)
+pl_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(access, xdata, frame, op_ret, op_errno, xdata);
     return 0;
@@ -4903,8 +4923,8 @@ pl_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t mask,
 }
 
 int32_t
-pl_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, off_t offset, dict_t *xdata)
+pl_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
 {
     PL_STACK_UNWIND_FOR_CLIENT(seek, xdata, frame, op_ret, op_errno, offset,
                                xdata);

--- a/xlators/features/locks/src/reservelk.c
+++ b/xlators/features/locks/src/reservelk.c
@@ -245,7 +245,8 @@ grant_blocked_reserve_locks(xlator_t *this, pl_inode_t *pl_inode)
                lkowner_utoa(&lock->owner), lock->user_flock.l_start,
                lock->user_flock.l_len);
 
-        STACK_UNWIND_STRICT(lk, lock->frame, 0, 0, &lock->user_flock, NULL);
+        STACK_UNWIND_STRICT(lk, lock->frame, gf_success, 0, &lock->user_flock,
+                            NULL);
     }
 }
 
@@ -316,9 +317,9 @@ grant_blocked_lock_calls(xlator_t *this, pl_inode_t *pl_inode)
             } else {
                 gf_log(this->name, GF_LOG_DEBUG, "returning EAGAIN");
                 pl_trace_out(this, lock->frame, fd, NULL, cmd,
-                             &lock->user_flock, -1, EAGAIN, NULL);
+                             &lock->user_flock, gf_error, EAGAIN, NULL);
                 pl_update_refkeeper(this, fd->inode);
-                STACK_UNWIND_STRICT(lk, lock->frame, -1, EAGAIN,
+                STACK_UNWIND_STRICT(lk, lock->frame, gf_error, EAGAIN,
                                     &lock->user_flock, NULL);
                 __destroy_lock(lock);
             }

--- a/xlators/features/marker/src/marker.c
+++ b/xlators/features/marker/src/marker.c
@@ -331,7 +331,7 @@ marker_getxattr_stampfile_cbk(call_frame_t *frame, xlator_t *this,
     dict_t *dict = NULL;
 
     if (vol_mark == NULL) {
-        STACK_UNWIND_STRICT(getxattr, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(getxattr, frame, gf_error, ENOMEM, NULL, NULL);
 
         goto out;
     }
@@ -345,7 +345,7 @@ marker_getxattr_stampfile_cbk(call_frame_t *frame, xlator_t *this,
         gf_log(this->name, GF_LOG_WARNING, "failed to set key %s", name);
     }
 
-    STACK_UNWIND_STRICT(getxattr, frame, 0, 0, dict, xdata);
+    STACK_UNWIND_STRICT(getxattr, frame, gf_success, 0, dict, xdata);
 
     if (dict)
         dict_unref(dict);
@@ -430,16 +430,16 @@ marker_filter_gsyncd_xattrs(call_frame_t *frame, xlator_t *this, dict_t *xattrs)
 
 int32_t
 marker_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata)
 {
     int32_t ret = -1;
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     ret = marker_key_set_ver(this, dict);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -537,7 +537,7 @@ marker_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     return 0;
 out:
-    MARKER_STACK_UNWIND(getxattr, frame, -1, ENOMEM, NULL, NULL);
+    MARKER_STACK_UNWIND(getxattr, frame, gf_error, ENOMEM, NULL, NULL);
     return 0;
 }
 
@@ -559,7 +559,8 @@ marker_setxattr_done(call_frame_t *frame)
 
 int
 marker_specific_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                             gf_return_t op_ret, int32_t op_errno,
+                             dict_t *xdata)
 {
     int32_t ret = 0;
     int32_t done = 1;
@@ -567,7 +568,7 @@ marker_specific_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = (marker_local_t *)frame->local;
 
-    if (op_ret == -1 && op_errno == ENOSPC) {
+    if (IS_ERROR(op_ret) && op_errno == ENOSPC) {
         marker_error_handler(this, local, op_errno);
         goto out;
     }
@@ -702,7 +703,7 @@ out:
 
 int32_t
 marker_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -710,7 +711,7 @@ marker_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "error occurred "
                "while creating directory %s",
@@ -722,14 +723,14 @@ marker_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     priv = this->private;
 
-    if (op_ret >= 0 && inode && (priv->feature_enabled & GF_QUOTA)) {
+    if (IS_SUCCESS(op_ret) && inode && (priv->feature_enabled & GF_QUOTA)) {
         ctx = mq_inode_ctx_new(inode, this);
         if (ctx == NULL) {
             gf_log(this->name, GF_LOG_WARNING,
                    "mq_inode_ctx_new "
                    "failed for %s",
                    uuid_utoa(inode->gfid));
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
         }
     }
@@ -737,7 +738,7 @@ marker_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(mkdir, frame, op_ret, op_errno, inode, buf, preparent,
                         postparent, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     if (gf_uuid_is_null(local->loc.gfid))
@@ -782,22 +783,23 @@ wind:
 
     return 0;
 err:
-    MARKER_STACK_UNWIND(mkdir, frame, -1, ENOMEM, NULL, NULL, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(mkdir, frame, gf_error, ENOMEM, NULL, NULL, NULL, NULL,
+                        NULL);
 
     return 0;
 }
 
 int32_t
 marker_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                  struct iatt *buf, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                  inode_t *inode, struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "error occurred "
                "while creating file %s",
@@ -809,14 +811,14 @@ marker_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     priv = this->private;
 
-    if (op_ret >= 0 && inode && (priv->feature_enabled & GF_QUOTA)) {
+    if (IS_SUCCESS(op_ret) && inode && (priv->feature_enabled & GF_QUOTA)) {
         ctx = mq_inode_ctx_new(inode, this);
         if (ctx == NULL) {
             gf_log(this->name, GF_LOG_WARNING,
                    "mq_inode_ctx_new "
                    "failed for %s",
                    uuid_utoa(inode->gfid));
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
         }
     }
@@ -824,7 +826,7 @@ marker_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(create, frame, op_ret, op_errno, fd, inode, buf,
                         preparent, postparent, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     if (gf_uuid_is_null(local->loc.gfid))
@@ -869,21 +871,21 @@ wind:
                xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(create, frame, -1, ENOMEM, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    MARKER_STACK_UNWIND(create, frame, gf_error, ENOMEM, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
 
     return 0;
 }
 
 int32_t
 marker_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     marker_conf_t *priv = NULL;
     marker_local_t *local = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "error occurred "
                "while write, %s",
@@ -897,7 +899,7 @@ marker_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -942,21 +944,21 @@ wind:
                flags, iobref, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(writev, frame, -1, ENOMEM, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(writev, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     return 0;
 }
 
 int32_t
 marker_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
     marker_conf_t *priv = NULL;
     marker_local_t *local = NULL;
     call_stub_t *stub = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "error occurred "
                "rmdir %s",
@@ -968,7 +970,7 @@ marker_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     priv = this->private;
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     if (priv->feature_enabled & GF_XTIME)
@@ -1030,14 +1032,14 @@ wind:
                FIRST_CHILD(this)->fops->rmdir, loc, flags, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(rmdir, frame, -1, ENOMEM, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(rmdir, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     return 0;
 }
 
 int32_t
 marker_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     marker_conf_t *priv = NULL;
@@ -1046,7 +1048,7 @@ marker_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_UNUSED int32_t ret = 0;
     call_stub_t *stub = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE, "%s occurred in unlink",
                strerror(op_errno));
     }
@@ -1056,7 +1058,7 @@ marker_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     priv = this->private;
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     if (priv->feature_enabled & GF_XTIME)
@@ -1148,7 +1150,7 @@ unlink_wind:
     goto out;
 
 err:
-    MARKER_STACK_UNWIND(unlink, frame, -1, ENOMEM, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(unlink, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
 out:
     if (dict_free)
@@ -1158,14 +1160,14 @@ out:
 
 int32_t
 marker_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred while "
                "linking a file ",
@@ -1179,7 +1181,7 @@ marker_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(link, frame, op_ret, op_errno, inode, buf, preparent,
                         postparent, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -1226,14 +1228,15 @@ wind:
                FIRST_CHILD(this)->fops->link, oldloc, newloc, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(link, frame, -1, ENOMEM, NULL, NULL, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(link, frame, gf_error, ENOMEM, NULL, NULL, NULL, NULL,
+                        NULL);
 
     return 0;
 }
 
 int32_t
 marker_rename_done(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     marker_local_t *local = NULL, *oplocal = NULL;
     loc_t newloc = {
@@ -1248,7 +1251,7 @@ marker_rename_done(call_frame_t *frame, void *cookie, xlator_t *this,
 
     frame->local = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_WARNING,
                "inodelk (UNLOCK) failed on path:%s (gfid:%s) (%s)",
                oplocal->parent_loc.path,
@@ -1330,7 +1333,7 @@ err:
 
 int32_t
 marker_rename_unwind(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     marker_local_t *local = NULL;
     marker_local_t *oplocal = NULL;
@@ -1345,7 +1348,7 @@ marker_rename_unwind(call_frame_t *frame, void *cookie, xlator_t *this,
     if (cookie == (void *)_GF_UID_GID_CHANGED)
         MARKER_RESET_UID_GID(frame, frame->root, local);
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         local->err = op_errno ? op_errno : EINVAL;
 
     if (local->stub != NULL) {
@@ -1366,8 +1369,8 @@ marker_rename_unwind(call_frame_t *frame, void *cookie, xlator_t *this,
         local->stub = NULL;
         local->err = 0;
     } else if (local->err != 0) {
-        STACK_UNWIND_STRICT(rename, frame, -1, local->err, NULL, NULL, NULL,
-                            NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(rename, frame, gf_error, local->err, NULL, NULL,
+                            NULL, NULL, NULL, NULL);
     } else {
         gf_log(this->name, GF_LOG_CRITICAL,
                "continuation stub to unwind the call is absent, hence "
@@ -1387,7 +1390,7 @@ marker_rename_unwind(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 marker_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   struct iatt *preoldparent, struct iatt *postoldparent,
                   struct iatt *prenewparent, struct iatt *postnewparent,
                   dict_t *xdata)
@@ -1412,7 +1415,7 @@ marker_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     priv = this->private;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if (local != NULL) {
             local->err = op_errno;
         }
@@ -1424,7 +1427,7 @@ marker_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     if (priv->feature_enabled & GF_QUOTA) {
-        if ((op_ret < 0) || (local == NULL)) {
+        if (IS_ERROR((op_ret)) || (local == NULL)) {
             goto quota_err;
         }
 
@@ -1474,7 +1477,7 @@ marker_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         STACK_UNWIND_STRICT(rename, frame, op_ret, op_errno, buf, preoldparent,
                             postoldparent, prenewparent, postnewparent, xdata);
 
-        if ((op_ret < 0) || (local == NULL)) {
+        if (IS_ERROR(op_ret) || (local == NULL)) {
             goto out;
         }
 
@@ -1497,13 +1500,14 @@ out:
     return 0;
 
 quota_err:
-    marker_rename_unwind(frame, NULL, this, 0, 0, NULL);
+    marker_rename_unwind(frame, NULL, this, gf_success, 0, NULL);
     return 0;
 }
 
 int32_t
 marker_do_rename(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                 dict_t *xdata)
 {
     marker_local_t *local = NULL;
     marker_local_t *oplocal = NULL;
@@ -1522,7 +1526,7 @@ marker_do_rename(call_frame_t *frame, void *cookie, xlator_t *this,
     if (cookie == (void *)_GF_UID_GID_CHANGED)
         MARKER_RESET_UID_GID(frame, frame->root, local);
 
-    if ((op_ret < 0) && (op_errno != ENOATTR) && (op_errno != ENODATA)) {
+    if (IS_ERROR(op_ret) && (op_errno != ENOATTR) && (op_errno != ENODATA)) {
         local->err = op_errno ? op_errno : EINVAL;
         gf_log(this->name, GF_LOG_WARNING,
                "fetching contribution values from %s (gfid:%s) "
@@ -1547,13 +1551,13 @@ marker_do_rename(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 
 err:
-    marker_rename_unwind(frame, NULL, this, 0, 0, NULL);
+    marker_rename_unwind(frame, NULL, this, gf_success, 0, NULL);
     return 0;
 }
 
 int32_t
 marker_get_oldpath_contribution(call_frame_t *lk_frame, void *cookie,
-                                xlator_t *this, int32_t op_ret,
+                                xlator_t *this, gf_return_t op_ret,
                                 int32_t op_errno, dict_t *xdata)
 {
     call_frame_t *frame = NULL;
@@ -1568,7 +1572,7 @@ marker_get_oldpath_contribution(call_frame_t *lk_frame, void *cookie,
     oplocal = local->oplocal;
     frame = local->frame;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->err = op_errno ? op_errno : EINVAL;
         gf_log(this->name, GF_LOG_WARNING,
                "cannot hold inodelk on %s (gfid:%s) (%s)", oplocal->loc.path,
@@ -1602,7 +1606,7 @@ marker_get_oldpath_contribution(call_frame_t *lk_frame, void *cookie,
 
     return 0;
 err:
-    marker_rename_unwind(frame, NULL, this, 0, 0, NULL);
+    marker_rename_unwind(frame, NULL, this, gf_success, 0, NULL);
     return 0;
 }
 
@@ -1772,8 +1776,8 @@ rename_wind:
 
     return 0;
 err:
-    MARKER_STACK_UNWIND(rename, frame, -1, ENOMEM, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    MARKER_STACK_UNWIND(rename, frame, gf_error, ENOMEM, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     marker_local_unref(oplocal);
 
     return 0;
@@ -1781,13 +1785,13 @@ err:
 
 int32_t
 marker_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred while "
                "truncating a file ",
@@ -1801,7 +1805,7 @@ marker_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(truncate, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -1859,20 +1863,20 @@ wind:
                FIRST_CHILD(this)->fops->truncate, loc, offset, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(truncate, frame, -1, ENOMEM, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(truncate, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     return 0;
 }
 
 int32_t
 marker_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred while "
                "truncating a file ",
@@ -1886,7 +1890,7 @@ marker_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(ftruncate, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -1932,14 +1936,14 @@ wind:
                FIRST_CHILD(this)->fops->ftruncate, fd, offset, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(ftruncate, frame, -1, ENOMEM, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(ftruncate, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     return 0;
 }
 
 int32_t
 marker_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -1947,7 +1951,7 @@ marker_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred while "
                "creating symlinks ",
@@ -1959,14 +1963,14 @@ marker_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     priv = this->private;
 
-    if (op_ret >= 0 && inode && (priv->feature_enabled & GF_QUOTA)) {
+    if (IS_SUCCESS(op_ret) && inode && (priv->feature_enabled & GF_QUOTA)) {
         ctx = mq_inode_ctx_new(inode, this);
         if (ctx == NULL) {
             gf_log(this->name, GF_LOG_WARNING,
                    "mq_inode_ctx_new "
                    "failed for %s",
                    uuid_utoa(inode->gfid));
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
         }
     }
@@ -1974,7 +1978,7 @@ marker_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(symlink, frame, op_ret, op_errno, inode, buf, preparent,
                         postparent, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     if (gf_uuid_is_null(local->loc.gfid))
@@ -2018,15 +2022,15 @@ wind:
                FIRST_CHILD(this)->fops->symlink, linkpath, loc, umask, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(symlink, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                        NULL);
+    MARKER_STACK_UNWIND(symlink, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                        NULL, NULL);
 
     return 0;
 }
 
 int32_t
 marker_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -2034,7 +2038,7 @@ marker_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     marker_conf_t *priv = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred with "
                "mknod ",
@@ -2046,14 +2050,14 @@ marker_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     priv = this->private;
 
-    if (op_ret >= 0 && inode && (priv->feature_enabled & GF_QUOTA)) {
+    if (IS_SUCCESS(op_ret) && inode && (priv->feature_enabled & GF_QUOTA)) {
         ctx = mq_inode_ctx_new(inode, this);
         if (ctx == NULL) {
             gf_log(this->name, GF_LOG_WARNING,
                    "mq_inode_ctx_new "
                    "failed for %s",
                    uuid_utoa(inode->gfid));
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
         }
     }
@@ -2061,7 +2065,7 @@ marker_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(mknod, frame, op_ret, op_errno, inode, buf, preparent,
                         postparent, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     if (gf_uuid_is_null(local->loc.gfid))
@@ -2107,20 +2111,21 @@ wind:
                FIRST_CHILD(this)->fops->mknod, loc, mode, rdev, umask, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(mknod, frame, -1, ENOMEM, NULL, NULL, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(mknod, frame, gf_error, ENOMEM, NULL, NULL, NULL, NULL,
+                        NULL);
 
     return 0;
 }
 
 int32_t
 marker_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred while "
                "fallocating a file ",
@@ -2134,7 +2139,7 @@ marker_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(fallocate, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2177,20 +2182,20 @@ wind:
                xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(fallocate, frame, -1, ENOMEM, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(fallocate, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     return 0;
 }
 
 int32_t
 marker_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE, "%s occurred during discard",
                strerror(op_errno));
     }
@@ -2202,7 +2207,7 @@ marker_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(discard, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2244,20 +2249,20 @@ wind:
                FIRST_CHILD(this)->fops->discard, fd, offset, len, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(discard, frame, -1, ENOMEM, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(discard, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     return 0;
 }
 
 int32_t
 marker_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE, "%s occurred during zerofill",
                strerror(op_errno));
     }
@@ -2269,7 +2274,7 @@ marker_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(zerofill, frame, op_ret, op_errno, prebuf, postbuf,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2311,7 +2316,7 @@ wind:
                FIRST_CHILD(this)->fops->zerofill, fd, offset, len, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(zerofill, frame, -1, ENOMEM, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(zerofill, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     return 0;
 }
@@ -2327,7 +2332,7 @@ call_from_sp_client_to_reset_tmfile(call_frame_t *frame, xlator_t *this,
                                     dict_t *dict)
 {
     int32_t fd = 0;
-    int32_t op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int32_t op_errno = 0;
     data_t *data = NULL;
     marker_conf_t *priv = NULL;
@@ -2342,7 +2347,7 @@ call_from_sp_client_to_reset_tmfile(call_frame_t *frame, xlator_t *this,
         return -1;
 
     if (frame->root->pid != GF_CLIENT_PID_GSYNCD) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EPERM;
 
         goto out;
@@ -2359,14 +2364,14 @@ call_from_sp_client_to_reset_tmfile(call_frame_t *frame, xlator_t *this,
         }
 
         if (fd != -1 || errno == ENOENT) {
-            op_ret = 0;
+            op_ret = gf_success;
             op_errno = 0;
         } else {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = errno;
         }
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
     }
 out:
@@ -2377,12 +2382,12 @@ out:
 
 int32_t
 marker_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred in "
                "setxattr ",
@@ -2395,7 +2400,7 @@ marker_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     STACK_UNWIND_STRICT(setxattr, frame, op_ret, op_errno, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2452,10 +2457,10 @@ int
 quota_xattr_cleaner_cbk(int ret, call_frame_t *frame, void *args)
 {
     dict_t *xdata = args;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = 0;
 
-    op_ret = (ret < 0) ? -1 : 0;
+    op_ret = (ret < 0) ? gf_error : gf_success;
     op_errno = -ret;
 
     MARKER_STACK_UNWIND(setxattr, frame, op_ret, op_errno, xdata);
@@ -2533,7 +2538,7 @@ marker_do_xattr_cleanup(call_frame_t *frame, xlator_t *this, dict_t *xdata,
     ret = 0;
 out:
     if (ret)
-        MARKER_STACK_UNWIND(setxattr, frame, -1, ENOMEM, xdata);
+        MARKER_STACK_UNWIND(setxattr, frame, gf_error, ENOMEM, xdata);
 
     return ret;
 }
@@ -2593,19 +2598,19 @@ wind:
                FIRST_CHILD(this)->fops->setxattr, loc, dict, flags, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(setxattr, frame, -1, op_errno, NULL);
+    MARKER_STACK_UNWIND(setxattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 int32_t
 marker_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred in "
                "fsetxattr",
@@ -2618,7 +2623,7 @@ marker_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     STACK_UNWIND_STRICT(fsetxattr, frame, op_ret, op_errno, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2661,20 +2666,20 @@ wind:
                FIRST_CHILD(this)->fops->fsetxattr, fd, dict, flags, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(fsetxattr, frame, -1, ENOMEM, NULL);
+    MARKER_STACK_UNWIND(fsetxattr, frame, gf_error, ENOMEM, NULL);
 
     return 0;
 }
 
 int32_t
 marker_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata)
 {
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred in "
                "fsetattr ",
@@ -2688,7 +2693,7 @@ marker_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(fsetattr, frame, op_ret, op_errno, statpre, statpost,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2727,14 +2732,14 @@ wind:
                FIRST_CHILD(this)->fops->fsetattr, fd, stbuf, valid, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(fsetattr, frame, -1, ENOMEM, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(fsetattr, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     return 0;
 }
 
 int32_t
 marker_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                    struct iatt *statpost, dict_t *xdata)
 {
     marker_local_t *local = NULL;
@@ -2744,7 +2749,7 @@ marker_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     frame->local = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE, "%s occurred during setattr of %s",
                strerror(op_errno), (local ? local->loc.path : "<nul>"));
     }
@@ -2752,7 +2757,7 @@ marker_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     STACK_UNWIND_STRICT(setattr, frame, op_ret, op_errno, statpre, statpost,
                         xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2791,19 +2796,19 @@ wind:
                FIRST_CHILD(this)->fops->setattr, loc, stbuf, valid, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(setattr, frame, -1, ENOMEM, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(setattr, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     return 0;
 }
 
 int32_t
 marker_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     marker_local_t *local = NULL;
     marker_conf_t *priv = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE,
                "%s occurred while "
                "removing extended attribute",
@@ -2816,7 +2821,7 @@ marker_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     STACK_UNWIND_STRICT(removexattr, frame, op_ret, op_errno, xdata);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     priv = this->private;
@@ -2872,7 +2877,7 @@ wind:
                FIRST_CHILD(this)->fops->removexattr, loc, name, xdata);
     return 0;
 err:
-    MARKER_STACK_UNWIND(removexattr, frame, -1, ENOMEM, NULL);
+    MARKER_STACK_UNWIND(removexattr, frame, gf_error, ENOMEM, NULL);
 
     return 0;
 }
@@ -2889,7 +2894,7 @@ __has_quota_xattrs(dict_t *xattrs)
 
 int32_t
 marker_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, dict_t *dict, struct iatt *postparent)
 {
     marker_conf_t *priv = NULL;
@@ -2902,7 +2907,7 @@ marker_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = (marker_local_t *)frame->local;
     frame->local = NULL;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_TRACE, "lookup failed with %s",
                strerror(op_errno));
         goto unwind;
@@ -2910,7 +2915,7 @@ marker_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     ret = marker_key_set_ver(this, dict);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -2918,7 +2923,7 @@ marker_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (dict && __has_quota_xattrs(dict)) {
         xattrs = dict_copy_with_ref(dict, NULL);
         if (!xattrs) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
         } else {
             marker_filter_internal_xattrs(this, xattrs);
@@ -2927,14 +2932,14 @@ marker_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         xattrs = dict_ref(dict);
     }
 
-    if (op_ret >= 0 && inode && (priv->feature_enabled & GF_QUOTA)) {
+    if (IS_SUCCESS(op_ret) && inode && (priv->feature_enabled & GF_QUOTA)) {
         ctx = mq_inode_ctx_new(inode, this);
         if (ctx == NULL) {
             gf_log(this->name, GF_LOG_WARNING,
                    "mq_inode_ctx_new "
                    "failed for %s",
                    uuid_utoa(inode->gfid));
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
         }
     }
@@ -2943,7 +2948,7 @@ unwind:
     STACK_UNWIND_STRICT(lookup, frame, op_ret, op_errno, inode, buf, xattrs,
                         postparent);
 
-    if (op_ret == -1 || local == NULL)
+    if (IS_ERROR(op_ret) || local == NULL)
         goto out;
 
     /* copy the gfid from the stat structure instead of inode,
@@ -3008,7 +3013,8 @@ wind:
 
     return 0;
 err:
-    MARKER_STACK_UNWIND(lookup, frame, -1, ENOMEM, NULL, NULL, NULL, NULL);
+    MARKER_STACK_UNWIND(lookup, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                        NULL);
 
     if (xattr_req)
         dict_unref(xattr_req);
@@ -3018,14 +3024,14 @@ err:
 
 int
 marker_build_ancestry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int op_ret, int op_errno, gf_dirent_t *entries,
-                          dict_t *xdata)
+                          gf_return_t op_ret, int op_errno,
+                          gf_dirent_t *entries, dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
     quota_inode_ctx_t *ctx = NULL;
     int ret = -1;
 
-    if ((op_ret <= 0) || (entries == NULL)) {
+    if (IS_ERROR(op_ret) || (entries == NULL)) {
         goto out;
     }
 
@@ -3036,7 +3042,7 @@ marker_build_ancestry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         ret = marker_key_set_ver(this, entry->dict);
         if (ret < 0) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             break;
         }
@@ -3056,7 +3062,7 @@ out:
 
 int
 marker_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
                     dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
@@ -3069,7 +3075,7 @@ marker_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     char *resolvedpath = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret <= 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     priv = this->private;
@@ -3112,7 +3118,7 @@ marker_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         ret = marker_key_set_ver(this, entry->dict);
         if (ret < 0) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unwind;
         }
@@ -3166,7 +3172,7 @@ marker_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     dict_unref(dict);
     return 0;
 unwind:
-    MARKER_STACK_UNWIND(readdirp, frame, -1, ENOMEM, NULL, NULL);
+    MARKER_STACK_UNWIND(readdirp, frame, gf_error, ENOMEM, NULL, NULL);
     return 0;
 }
 

--- a/xlators/features/metadisp/src/gen-fops.py
+++ b/xlators/features/metadisp/src/gen-fops.py
@@ -64,7 +64,7 @@ metadisp_@NAME@ (call_frame_t *frame, xlator_t *this,
   return 0;
 
 unwind:
-  STACK_UNWIND_STRICT(lookup, frame, -1, EINVAL, NULL, NULL, NULL, NULL);
+  STACK_UNWIND_STRICT(lookup, frame, gf_error, EINVAL, NULL, NULL, NULL, NULL);
   return 0;
 }
 """

--- a/xlators/features/metadisp/src/metadisp-create.c
+++ b/xlators/features/metadisp/src/metadisp-create.c
@@ -10,7 +10,7 @@
 
 int32_t
 metadisp_create_dentry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, fd_t *fd,
+                           gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                            inode_t *inode, struct iatt *buf,
                            struct iatt *preparent, struct iatt *postparent,
                            dict_t *xdata)
@@ -34,13 +34,13 @@ metadisp_create_resume(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 int32_t
 metadisp_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                    struct iatt *buf, struct iatt *preparent,
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    inode_t *inode, struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
-    METADISP_TRACE("%d %d", op_ret, op_errno);
+    METADISP_TRACE("%d %d", GET_RET(op_ret), op_errno);
     call_stub_t *stub = cookie;
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         STACK_UNWIND_STRICT(create, frame, op_ret, op_errno, fd, inode, buf,
                             preparent, postparent, xdata);
         return 0;
@@ -59,8 +59,8 @@ metadisp_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(create, frame, -1, EINVAL, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(create, frame, gf_error, EINVAL, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 
@@ -93,8 +93,8 @@ metadisp_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(create, frame, -1, EINVAL, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(create, frame, gf_error, EINVAL, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 out:
     return -1;

--- a/xlators/features/metadisp/src/metadisp-fsync.c
+++ b/xlators/features/metadisp/src/metadisp-fsync.c
@@ -13,7 +13,7 @@ metadisp_fsync_resume(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
 int32_t
 metadisp_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -21,7 +21,7 @@ metadisp_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         stub = cookie;
     }
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 

--- a/xlators/features/metadisp/src/metadisp-lookup.c
+++ b/xlators/features/metadisp/src/metadisp-lookup.c
@@ -8,14 +8,14 @@
 
 int32_t
 metadisp_backend_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, inode_t *inode,
-                            struct iatt *buf, dict_t *xdata,
+                            gf_return_t op_ret, int32_t op_errno,
+                            inode_t *inode, struct iatt *buf, dict_t *xdata,
                             struct iatt *postparent)
 {
     METADISP_TRACE("backend_lookup_cbk");
     if (op_errno == ENOENT) {
         op_errno = ENODATA;
-        op_ret = -1;
+        op_ret = gf_error;
     }
     STACK_UNWIND_STRICT(lookup, frame, op_ret, op_errno, inode, buf, xdata,
                         postparent);
@@ -39,20 +39,21 @@ metadisp_backend_lookup_resume(call_frame_t *frame, xlator_t *this, loc_t *loc,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(lookup, frame, -1, EINVAL, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(lookup, frame, gf_error, EINVAL, NULL, NULL, NULL,
+                        NULL);
     return 0;
 }
 
 int32_t
 metadisp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
-    METADISP_TRACE("%d %d", op_ret, op_errno);
+    METADISP_TRACE("%d %d", GET_RET(op_ret), op_errno);
     call_stub_t *stub = NULL;
     stub = cookie;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -69,7 +70,7 @@ metadisp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     call_resume(stub);
     return 0;
 unwind:
-    METADISP_TRACE("unwinding %d %d", op_ret, op_errno);
+    METADISP_TRACE("unwinding %d %d", GET_RET(op_ret), op_errno);
     STACK_UNWIND_STRICT(lookup, frame, op_ret, op_errno, inode, buf, xdata,
                         postparent);
     if (stub) {

--- a/xlators/features/metadisp/src/metadisp-open.c
+++ b/xlators/features/metadisp/src/metadisp-open.c
@@ -3,16 +3,16 @@
 
 int32_t
 metadisp_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
-    METADISP_TRACE("got open results %d %d", op_ret, op_errno);
+    METADISP_TRACE("got open results %d %d", GET_RET(op_ret), op_errno);
 
     call_stub_t *stub = NULL;
     if (cookie) {
         stub = cookie;
     }
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -65,6 +65,6 @@ metadisp_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
                       METADATA_CHILD(this)->fops->open, loc, flags, fd, xdata);
     return 0;
 unwind:
-    STACK_UNWIND_STRICT(open, frame, -1, EINVAL, NULL, NULL);
+    STACK_UNWIND_STRICT(open, frame, gf_error, EINVAL, NULL, NULL);
     return 0;
 }

--- a/xlators/features/metadisp/src/metadisp-setattr.c
+++ b/xlators/features/metadisp/src/metadisp-setattr.c
@@ -3,7 +3,7 @@
 
 int32_t
 metadisp_backend_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                             int32_t op_ret, int32_t op_errno,
+                             gf_return_t op_ret, int32_t op_errno,
                              struct iatt *statpre, struct iatt *statpost,
                              dict_t *xdata)
 
@@ -11,7 +11,7 @@ metadisp_backend_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     METADISP_TRACE("backend_setattr_cbk");
     if (op_errno == ENOENT) {
         op_errno = ENODATA;
-        op_ret = -1;
+        op_ret = gf_error;
     }
     STACK_UNWIND_STRICT(setattr, frame, op_ret, op_errno, statpre, statpost,
                         xdata);
@@ -38,20 +38,20 @@ metadisp_backend_setattr_resume(call_frame_t *frame, xlator_t *this, loc_t *loc,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(setattr, frame, -1, EINVAL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(setattr, frame, gf_error, EINVAL, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 metadisp_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
-    METADISP_TRACE("%d %d", op_ret, op_errno);
+    METADISP_TRACE("%d %d", GET_RET(op_ret), op_errno);
     call_stub_t *stub = NULL;
     stub = cookie;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -66,7 +66,7 @@ metadisp_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     call_resume(stub);
     return 0;
 unwind:
-    METADISP_TRACE("unwinding %d %d", op_ret, op_errno);
+    METADISP_TRACE("unwinding %d %d", GET_RET(op_ret), op_errno);
     STACK_UNWIND_STRICT(setattr, frame, op_ret, op_errno, statpre, statpost,
                         xdata);
     if (stub) {

--- a/xlators/features/metadisp/src/metadisp-stat.c
+++ b/xlators/features/metadisp/src/metadisp-stat.c
@@ -18,12 +18,12 @@
 
 int32_t
 metadisp_stat_backend_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *buf,
-                          dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *buf, dict_t *xdata)
 {
-    METADISP_TRACE("got backend stat results %d %d", op_ret, op_errno);
+    METADISP_TRACE("got backend stat results %d %d", GET_RET(op_ret), op_errno);
     if (op_errno == ENOENT) {
-        STACK_UNWIND_STRICT(open, frame, -1, ENODATA, NULL, NULL);
+        STACK_UNWIND_STRICT(open, frame, gf_error, ENODATA, NULL, NULL);
         return 0;
     }
     STACK_UNWIND_STRICT(stat, frame, op_ret, op_errno, buf, xdata);
@@ -37,7 +37,7 @@ metadisp_stat_resume(call_frame_t *frame, xlator_t *this, loc_t *loc,
     METADISP_TRACE("winding stat to path %s", loc->path);
     if (gf_uuid_is_null(loc->gfid)) {
         METADISP_TRACE("bad object, sending EUCLEAN");
-        STACK_UNWIND_STRICT(open, frame, -1, EUCLEAN, NULL, NULL);
+        STACK_UNWIND_STRICT(open, frame, gf_error, EUCLEAN, NULL, NULL);
         return 0;
     }
 
@@ -48,18 +48,18 @@ metadisp_stat_resume(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 int32_t
 metadisp_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   dict_t *xdata)
 {
     call_stub_t *stub = NULL;
 
-    METADISP_TRACE("got stat results %d %d", op_ret, op_errno);
+    METADISP_TRACE("got stat results %d %d", GET_RET(op_ret), op_errno);
 
     if (cookie) {
         stub = cookie;
     }
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -119,6 +119,6 @@ metadisp_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
                       METADATA_CHILD(this)->fops->stat, loc, xdata);
     return 0;
 unwind:
-    STACK_UNWIND_STRICT(stat, frame, -1, EINVAL, NULL, NULL);
+    STACK_UNWIND_STRICT(stat, frame, gf_error, EINVAL, NULL, NULL);
     return 0;
 }

--- a/xlators/features/namespace/src/namespace.c
+++ b/xlators/features/namespace/src/namespace.c
@@ -195,7 +195,7 @@ out:
  * once we've gotten the namespace hash. */
 int32_t
 get_path_resume_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata)
 {
     path_parse_result_t ret = PATH_PARSE_RESULT_NO_PATH;
@@ -224,7 +224,8 @@ get_path_resume_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     /* If we get a value back for the GET_ANCESTRY_PATH_KEY, then we
      * try to access it and parse it like a path. */
-    if (!op_ret && !dict_get_str(dict, GET_ANCESTRY_PATH_KEY, &path)) {
+    if (IS_SUCCESS(op_ret) &&
+        !dict_get_str(dict, GET_ANCESTRY_PATH_KEY, &path)) {
         gf_log(this->name, GF_LOG_DEBUG, "G>P %s retrieved path %s",
                uuid_utoa(local->loc.gfid), path);
         /* Now let's parse a path, finally. */

--- a/xlators/features/quiesce/src/quiesce.c
+++ b/xlators/features/quiesce/src/quiesce.c
@@ -119,11 +119,11 @@ out:
 
 int32_t
 gf_quiesce_failover_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     quiesce_priv_t *priv = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         /* Failure here doesn't mean the failover to another host didn't
          * succeed, we will know if failover succeeds or not by the
          * CHILD_UP/CHILD_DOWN event. A failure here indicates something
@@ -309,7 +309,7 @@ gf_quiesce_enqueue(xlator_t *this, call_stub_t *stub)
 
 int32_t
 quiesce_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, dict_t *dict, struct iatt *postparent)
 {
     call_stub_t *stub = NULL;
@@ -317,13 +317,13 @@ quiesce_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_lookup_stub(frame, default_lookup_resume, &local->loc,
                                local->dict);
         if (!stub) {
-            STACK_UNWIND_STRICT(lookup, frame, -1, ENOMEM, NULL, NULL, NULL,
-                                NULL);
+            STACK_UNWIND_STRICT(lookup, frame, gf_error, ENOMEM, NULL, NULL,
+                                NULL, NULL);
             goto out;
         }
 
@@ -341,7 +341,7 @@ out:
 
 int32_t
 quiesce_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                  dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -349,11 +349,11 @@ quiesce_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_stat_stub(frame, default_stat_resume, &local->loc, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(stat, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(stat, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -370,19 +370,19 @@ out:
 
 int32_t
 quiesce_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_access_stub(frame, default_access_resume, &local->loc,
                                local->flag, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(access, frame, -1, ENOMEM, NULL);
+            STACK_UNWIND_STRICT(access, frame, gf_error, ENOMEM, NULL);
             goto out;
         }
 
@@ -399,7 +399,7 @@ out:
 
 int32_t
 quiesce_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, const char *path,
+                     gf_return_t op_ret, int32_t op_errno, const char *path,
                      struct iatt *buf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -407,12 +407,13 @@ quiesce_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_readlink_stub(frame, default_readlink_resume, &local->loc,
                                  local->size, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(readlink, frame, -1, ENOMEM, NULL, NULL, NULL);
+            STACK_UNWIND_STRICT(readlink, frame, gf_error, ENOMEM, NULL, NULL,
+                                NULL);
             goto out;
         }
 
@@ -429,19 +430,19 @@ out:
 
 int32_t
 quiesce_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_open_stub(frame, default_open_resume, &local->loc,
                              local->flag, local->fd, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(open, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(open, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -458,7 +459,7 @@ out:
 
 int32_t
 quiesce_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                  gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                   int32_t count, struct iatt *stbuf, struct iobref *iobref,
                   dict_t *xdata)
 {
@@ -467,14 +468,14 @@ quiesce_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_readv_stub(frame, default_readv_resume, local->fd,
                               local->size, local->offset, local->io_flag,
                               xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(readv, frame, -1, ENOMEM, NULL, 0, NULL, NULL,
-                                NULL);
+            STACK_UNWIND_STRICT(readv, frame, gf_error, ENOMEM, NULL, 0, NULL,
+                                NULL, NULL);
             goto out;
         }
 
@@ -492,18 +493,18 @@ out:
 
 int32_t
 quiesce_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_flush_stub(frame, default_flush_resume, local->fd, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(flush, frame, -1, ENOMEM, NULL);
+            STACK_UNWIND_STRICT(flush, frame, gf_error, ENOMEM, NULL);
             goto out;
         }
 
@@ -520,7 +521,7 @@ out:
 
 int32_t
 quiesce_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -528,12 +529,13 @@ quiesce_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_fsync_stub(frame, default_fsync_resume, local->fd,
                               local->flag, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(fsync, frame, -1, ENOMEM, NULL, NULL, NULL);
+            STACK_UNWIND_STRICT(fsync, frame, gf_error, ENOMEM, NULL, NULL,
+                                NULL);
             goto out;
         }
 
@@ -550,7 +552,7 @@ out:
 
 int32_t
 quiesce_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -558,11 +560,11 @@ quiesce_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_fstat_stub(frame, default_fstat_resume, local->fd, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(fstat, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(fstat, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -579,19 +581,20 @@ out:
 
 int32_t
 quiesce_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_opendir_stub(frame, default_opendir_resume, &local->loc,
                                 local->fd, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(opendir, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(opendir, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -608,19 +611,19 @@ out:
 
 int32_t
 quiesce_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_fsyncdir_stub(frame, default_fsyncdir_resume, local->fd,
                                  local->flag, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(fsyncdir, frame, -1, ENOMEM, NULL);
+            STACK_UNWIND_STRICT(fsyncdir, frame, gf_error, ENOMEM, NULL);
             goto out;
         }
 
@@ -637,7 +640,7 @@ out:
 
 int32_t
 quiesce_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                    dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -645,12 +648,12 @@ quiesce_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_statfs_stub(frame, default_statfs_resume, &local->loc,
                                xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(statfs, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(statfs, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -667,7 +670,7 @@ out:
 
 int32_t
 quiesce_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict,
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                       dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -675,12 +678,12 @@ quiesce_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_fgetxattr_stub(frame, default_fgetxattr_resume, local->fd,
                                   local->name, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(fgetxattr, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(fgetxattr, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -697,7 +700,7 @@ out:
 
 int32_t
 quiesce_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -705,12 +708,12 @@ quiesce_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_getxattr_stub(frame, default_getxattr_resume, &local->loc,
                                  local->name, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(getxattr, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(getxattr, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -727,20 +730,22 @@ out:
 
 int32_t
 quiesce_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                      uint8_t *strong_checksum, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno,
+                      uint32_t weak_checksum, uint8_t *strong_checksum,
+                      dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_rchecksum_stub(frame, default_rchecksum_resume, local->fd,
                                   local->offset, local->flag, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(rchecksum, frame, -1, ENOMEM, 0, NULL, NULL);
+            STACK_UNWIND_STRICT(rchecksum, frame, gf_error, ENOMEM, 0, NULL,
+                                NULL);
             goto out;
         }
 
@@ -758,7 +763,7 @@ out:
 
 int32_t
 quiesce_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                     dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -766,12 +771,12 @@ quiesce_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_readdir_stub(frame, default_readdir_resume, local->fd,
                                 local->size, local->offset, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(readdir, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(readdir, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -788,7 +793,7 @@ out:
 
 int32_t
 quiesce_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                      dict_t *xdata)
 {
     call_stub_t *stub = NULL;
@@ -796,12 +801,12 @@ quiesce_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_readdirp_stub(frame, default_readdirp_resume, local->fd,
                                  local->size, local->offset, local->dict);
         if (!stub) {
-            STACK_UNWIND_STRICT(readdirp, frame, -1, ENOMEM, NULL, NULL);
+            STACK_UNWIND_STRICT(readdirp, frame, gf_error, ENOMEM, NULL, NULL);
             goto out;
         }
 
@@ -820,7 +825,7 @@ out:
 
 int32_t
 quiesce_writev_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
@@ -831,14 +836,14 @@ quiesce_writev_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_writev_stub (frame, default_writev_resume,
                                         local->fd, local->vector, local->flag,
                                         local->offset, local->io_flags,
                                         local->iobref, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (writev, frame, -1, ENOMEM,
+                        STACK_UNWIND_STRICT (writev, frame, gf_error, ENOMEM,
                                              NULL, NULL, NULL);
                         goto out;
                 }
@@ -856,7 +861,7 @@ out:
 
 int32_t
 quiesce_xattrop_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -866,13 +871,13 @@ quiesce_xattrop_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_xattrop_stub (frame, default_xattrop_resume,
                                          &local->loc, local->xattrop_flags,
                                          local->dict, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (xattrop, frame, -1, ENOMEM,
+                        STACK_UNWIND_STRICT (xattrop, frame, gf_error, ENOMEM,
                                              NULL, NULL);
                         goto out;
                 }
@@ -890,7 +895,7 @@ out:
 
 int32_t
 quiesce_fxattrop_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -900,13 +905,13 @@ quiesce_fxattrop_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_fxattrop_stub (frame, default_fxattrop_resume,
                                           local->fd, local->xattrop_flags,
                                           local->dict, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (fxattrop, frame, -1, ENOMEM,
+                        STACK_UNWIND_STRICT (fxattrop, frame, gf_error, ENOMEM,
                                              NULL, NULL);
                         goto out;
                 }
@@ -924,7 +929,7 @@ out:
 
 int32_t
 quiesce_lk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -934,12 +939,12 @@ quiesce_lk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_lk_stub (frame, default_lk_resume,
                                     local->fd, local->flag, &local->flock, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (lk, frame, -1, ENOMEM,
+                        STACK_UNWIND_STRICT (lk, frame, gf_error, ENOMEM,
                                              NULL, NULL);
                         goto out;
                 }
@@ -957,7 +962,7 @@ out:
 
 int32_t
 quiesce_inodelk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -967,13 +972,13 @@ quiesce_inodelk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_inodelk_stub (frame, default_inodelk_resume,
                                          local->volname, &local->loc,
                                          local->flag, &local->flock, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (inodelk, frame, -1, ENOMEM, NULL);
+                        STACK_UNWIND_STRICT (inodelk, frame, gf_error, ENOMEM, NULL);
                         goto out;
                 }
 
@@ -991,7 +996,7 @@ out:
 
 int32_t
 quiesce_finodelk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -1001,13 +1006,13 @@ quiesce_finodelk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_finodelk_stub (frame, default_finodelk_resume,
                                          local->volname, local->fd,
                                          local->flag, &local->flock, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (finodelk, frame, -1, ENOMEM, NULL);
+                        STACK_UNWIND_STRICT (finodelk, frame, gf_error, ENOMEM, NULL);
                         goto out;
                 }
 
@@ -1024,7 +1029,7 @@ out:
 
 int32_t
 quiesce_entrylk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -1034,13 +1039,13 @@ quiesce_entrylk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_entrylk_stub (frame, default_entrylk_resume,
                                          local->volname, &local->loc,
                                          local->name, local->cmd, local->type, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (entrylk, frame, -1, ENOMEM, NULL);
+                        STACK_UNWIND_STRICT (entrylk, frame, gf_error, ENOMEM, NULL);
                         goto out;
                 }
 
@@ -1057,7 +1062,7 @@ out:
 
 int32_t
 quiesce_fentrylk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
         call_stub_t    *stub = NULL;
@@ -1067,13 +1072,13 @@ quiesce_fentrylk_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_fentrylk_stub (frame, default_fentrylk_resume,
                                           local->volname, local->fd,
                                           local->name, local->cmd, local->type, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (fentrylk, frame, -1, ENOMEM, NULL);
+                        STACK_UNWIND_STRICT (fentrylk, frame, gf_error, ENOMEM, NULL);
                         goto out;
                 }
 
@@ -1090,7 +1095,7 @@ out:
 
 int32_t
 quiesce_setattr_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
@@ -1101,12 +1106,12 @@ quiesce_setattr_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
 
         local = frame->local;
         frame->local = NULL;
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_setattr_stub (frame, default_setattr_resume,
                                          &local->loc, &local->stbuf, local->flag, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (setattr, frame, -1, ENOMEM,
+                        STACK_UNWIND_STRICT (setattr, frame, gf_error, ENOMEM,
                                              NULL, NULL, NULL);
                         goto out;
                 }
@@ -1125,7 +1130,7 @@ out:
 
 int32_t
 quiesce_fsetattr_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                       struct iatt *statpost, dict_t *xdata)
 {
         quiesce_priv_t *priv = NULL;
@@ -1137,12 +1142,12 @@ quiesce_fsetattr_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
         local = frame->local;
         frame->local = NULL;
 
-        if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+        if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
                 /* Re-transmit (by putting in the queue) */
                 stub = fop_fsetattr_stub (frame, default_fsetattr_resume,
                                           local->fd, &local->stbuf, local->flag, xdata);
                 if (!stub) {
-                        STACK_UNWIND_STRICT (fsetattr, frame, -1, ENOMEM,
+                        STACK_UNWIND_STRICT (fsetattr, frame, gf_error, ENOMEM,
                                              NULL, NULL, NULL);
                         goto out;
                 }
@@ -1183,7 +1188,7 @@ quiesce_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     stub = fop_removexattr_stub(frame, default_removexattr_resume, loc, name,
                                 xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(removexattr, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(removexattr, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1210,7 +1215,7 @@ quiesce_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     stub = fop_fremovexattr_stub(frame, default_fremovexattr_resume, fd, name,
                                  xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fremovexattr, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(fremovexattr, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1237,7 +1242,8 @@ quiesce_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     stub = fop_truncate_stub(frame, default_truncate_resume, loc, offset,
                              xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(truncate, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(truncate, frame, gf_error, ENOMEM, NULL, NULL,
+                            NULL);
         return 0;
     }
 
@@ -1264,7 +1270,7 @@ quiesce_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
     stub = fop_fsetxattr_stub(frame, default_fsetxattr_resume, fd, dict, flags,
                               xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fsetxattr, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(fsetxattr, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1291,7 +1297,7 @@ quiesce_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
     stub = fop_setxattr_stub(frame, default_setxattr_resume, loc, dict, flags,
                              xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(setxattr, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(setxattr, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1321,8 +1327,8 @@ quiesce_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     stub = fop_create_stub(frame, default_create_resume, loc,
                            (flags & ~O_APPEND), mode, umask, fd, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(create, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(create, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
         return 0;
     }
 
@@ -1348,8 +1354,8 @@ quiesce_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     stub = fop_link_stub(frame, default_link_resume, oldloc, newloc, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(link, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(link, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL);
         return 0;
     }
 
@@ -1375,8 +1381,8 @@ quiesce_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
 
     stub = fop_rename_stub(frame, default_rename_resume, oldloc, newloc, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(rename, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(rename, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
         return 0;
     }
 
@@ -1404,8 +1410,8 @@ quiesce_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
     stub = fop_symlink_stub(frame, default_symlink_resume, linkpath, loc, umask,
                             xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(symlink, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(symlink, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL);
         return 0;
     }
 
@@ -1431,7 +1437,7 @@ quiesce_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     stub = fop_rmdir_stub(frame, default_rmdir_resume, loc, flags, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(rmdir, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(rmdir, frame, gf_error, ENOMEM, NULL, NULL, NULL);
         return 0;
     }
 
@@ -1457,7 +1463,7 @@ quiesce_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
 
     stub = fop_unlink_stub(frame, default_unlink_resume, loc, xflag, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(unlink, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(unlink, frame, gf_error, ENOMEM, NULL, NULL, NULL);
         return 0;
     }
 
@@ -1483,8 +1489,8 @@ quiesce_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     stub = fop_mkdir_stub(frame, default_mkdir_resume, loc, mode, umask, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(mkdir, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(mkdir, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL);
         return 0;
     }
 
@@ -1512,8 +1518,8 @@ quiesce_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     stub = fop_mknod_stub(frame, default_mknod_resume, loc, mode, rdev, umask,
                           xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(mknod, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(mknod, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL);
         return 0;
     }
 
@@ -1540,7 +1546,8 @@ quiesce_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     stub = fop_ftruncate_stub(frame, default_ftruncate_resume, fd, offset,
                               xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(ftruncate, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(ftruncate, frame, gf_error, ENOMEM, NULL, NULL,
+                            NULL);
         return 0;
     }
 
@@ -1574,7 +1581,8 @@ quiesce_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
 
     stub = fop_readlink_stub(frame, default_readlink_resume, loc, size, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(readlink, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(readlink, frame, gf_error, ENOMEM, NULL, NULL,
+                            NULL);
         return 0;
     }
 
@@ -1606,7 +1614,7 @@ quiesce_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t mask,
 
     stub = fop_access_stub(frame, default_access_resume, loc, mask, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(access, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(access, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1640,7 +1648,7 @@ quiesce_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     stub = fop_fgetxattr_stub(frame, default_fgetxattr_resume, fd, name, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fgetxattr, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(fgetxattr, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -1670,7 +1678,7 @@ quiesce_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
     stub = fop_statfs_stub(frame, default_statfs_resume, loc, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(statfs, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(statfs, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -1702,7 +1710,7 @@ quiesce_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
 
     stub = fop_fsyncdir_stub(frame, default_fsyncdir_resume, fd, flags, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fsyncdir, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(fsyncdir, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1734,7 +1742,7 @@ quiesce_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
 
     stub = fop_opendir_stub(frame, default_opendir_resume, loc, fd, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(opendir, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(opendir, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -1764,7 +1772,7 @@ quiesce_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 
     stub = fop_fstat_stub(frame, default_fstat_resume, fd, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fstat, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(fstat, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -1796,7 +1804,7 @@ quiesce_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
 
     stub = fop_fsync_stub(frame, default_fsync_resume, fd, flags, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fsync, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(fsync, frame, gf_error, ENOMEM, NULL, NULL, NULL);
         return 0;
     }
 
@@ -1826,7 +1834,7 @@ quiesce_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 
     stub = fop_flush_stub(frame, default_flush_resume, fd, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(flush, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(flush, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -1855,7 +1863,7 @@ quiesce_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
     stub = fop_writev_stub(frame, default_writev_resume, fd, vector, count, off,
                            flags, iobref, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(writev, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(writev, frame, gf_error, ENOMEM, NULL, NULL, NULL);
         return 0;
     }
 
@@ -1891,7 +1899,7 @@ quiesce_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     stub = fop_readv_stub(frame, default_readv_resume, fd, size, offset, flags,
                           xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(readv, frame, -1, ENOMEM, NULL, 0, NULL, NULL,
+        STACK_UNWIND_STRICT(readv, frame, gf_error, ENOMEM, NULL, 0, NULL, NULL,
                             NULL);
         return 0;
     }
@@ -1930,7 +1938,7 @@ quiesce_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     stub = fop_open_stub(frame, default_open_resume, loc, (flags & ~O_APPEND),
                          fd, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(open, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(open, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -1964,7 +1972,7 @@ quiesce_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     stub = fop_getxattr_stub(frame, default_getxattr_resume, loc, name, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(getxattr, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(getxattr, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -1991,7 +1999,7 @@ quiesce_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc,
     stub = fop_xattrop_stub(frame, default_xattrop_resume, loc, flags, dict,
                             xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(xattrop, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(xattrop, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -2018,7 +2026,7 @@ quiesce_fxattrop(call_frame_t *frame, xlator_t *this, fd_t *fd,
     stub = fop_fxattrop_stub(frame, default_fxattrop_resume, fd, flags, dict,
                              xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fxattrop, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(fxattrop, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -2044,7 +2052,7 @@ quiesce_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 
     stub = fop_lk_stub(frame, default_lk_resume, fd, cmd, lock, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(lk, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(lk, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -2072,7 +2080,7 @@ quiesce_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
     stub = fop_inodelk_stub(frame, default_inodelk_resume, volume, loc, cmd,
                             lock, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(inodelk, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(inodelk, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -2100,7 +2108,7 @@ quiesce_finodelk(call_frame_t *frame, xlator_t *this, const char *volume,
     stub = fop_finodelk_stub(frame, default_finodelk_resume, volume, fd, cmd,
                              lock, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(finodelk, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(finodelk, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -2129,7 +2137,7 @@ quiesce_entrylk(call_frame_t *frame, xlator_t *this, const char *volume,
     stub = fop_entrylk_stub(frame, default_entrylk_resume, volume, loc,
                             basename, cmd, type, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(entrylk, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(entrylk, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -2158,7 +2166,7 @@ quiesce_fentrylk(call_frame_t *frame, xlator_t *this, const char *volume,
     stub = fop_fentrylk_stub(frame, default_fentrylk_resume, volume, fd,
                              basename, cmd, type, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fentrylk, frame, -1, ENOMEM, NULL);
+        STACK_UNWIND_STRICT(fentrylk, frame, gf_error, ENOMEM, NULL);
         return 0;
     }
 
@@ -2192,7 +2200,7 @@ quiesce_rchecksum(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     stub = fop_rchecksum_stub(frame, default_rchecksum_resume, fd, offset, len,
                               xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(rchecksum, frame, -1, ENOMEM, 0, NULL, NULL);
+        STACK_UNWIND_STRICT(rchecksum, frame, gf_error, ENOMEM, 0, NULL, NULL);
         return 0;
     }
 
@@ -2226,7 +2234,7 @@ quiesce_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     stub = fop_readdir_stub(frame, default_readdir_resume, fd, size, off,
                             xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(readdir, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(readdir, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -2261,7 +2269,7 @@ quiesce_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     stub = fop_readdirp_stub(frame, default_readdirp_resume, fd, size, off,
                              dict);
     if (!stub) {
-        STACK_UNWIND_STRICT(readdirp, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(readdirp, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -2288,7 +2296,7 @@ quiesce_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     stub = fop_setattr_stub(frame, default_setattr_resume, loc, stbuf, valid,
                             xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(setattr, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(setattr, frame, gf_error, ENOMEM, NULL, NULL, NULL);
         return 0;
     }
 
@@ -2318,7 +2326,7 @@ quiesce_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
     stub = fop_stat_stub(frame, default_stat_resume, loc, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(stat, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(stat, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -2350,7 +2358,8 @@ quiesce_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     stub = fop_lookup_stub(frame, default_lookup_resume, loc, xattr_req);
     if (!stub) {
-        STACK_UNWIND_STRICT(lookup, frame, -1, ENOMEM, NULL, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(lookup, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL);
         return 0;
     }
 
@@ -2377,7 +2386,8 @@ quiesce_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     stub = fop_fsetattr_stub(frame, default_fsetattr_resume, fd, stbuf, valid,
                              xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fsetattr, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(fsetattr, frame, gf_error, ENOMEM, NULL, NULL,
+                            NULL);
         return 0;
     }
 
@@ -2405,7 +2415,8 @@ quiesce_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
     stub = fop_fallocate_stub(frame, default_fallocate_resume, fd, mode, offset,
                               len, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fallocate, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(fallocate, frame, gf_error, ENOMEM, NULL, NULL,
+                            NULL);
         return 0;
     }
 
@@ -2416,19 +2427,20 @@ quiesce_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
 
 int
 quiesce_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, off_t offset,
+                 dict_t *xdata)
 {
     call_stub_t *stub = NULL;
     quiesce_local_t *local = NULL;
 
     local = frame->local;
     frame->local = NULL;
-    if ((op_ret == -1) && (op_errno == ENOTCONN)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTCONN)) {
         /* Re-transmit (by putting in the queue) */
         stub = fop_seek_stub(frame, default_seek_resume, local->fd,
                              local->offset, local->what, xdata);
         if (!stub) {
-            STACK_UNWIND_STRICT(seek, frame, -1, ENOMEM, 0, NULL);
+            STACK_UNWIND_STRICT(seek, frame, gf_error, ENOMEM, 0, NULL);
             goto out;
         }
 
@@ -2468,7 +2480,7 @@ quiesce_seek(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     stub = fop_seek_stub(frame, default_seek_resume, fd, offset, what, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(seek, frame, -1, ENOMEM, 0, NULL);
+        STACK_UNWIND_STRICT(seek, frame, gf_error, ENOMEM, 0, NULL);
         return 0;
     }
 

--- a/xlators/features/quota/src/quota.c
+++ b/xlators/features/quota/src/quota.c
@@ -364,7 +364,7 @@ out:
 
 void
 check_ancestory_continue(struct list_head *parents, inode_t *inode,
-                         int32_t op_ret, int32_t op_errno, void *data)
+                         gf_return_t op_ret, int32_t op_errno, void *data)
 {
     call_frame_t *frame = NULL;
     quota_local_t *local = NULL;
@@ -381,13 +381,13 @@ check_ancestory_continue(struct list_head *parents, inode_t *inode,
                "Hence, failing fop with EIO",
                uuid_utoa(inode->gfid));
         op_errno = EIO;
-        op_ret = -1;
+        op_ret = gf_error;
     }
 
     LOCK(&local->lock);
     {
         link_count = --local->link_count;
-        if (op_ret < 0) {
+        if (IS_ERROR(op_ret)) {
             local->op_ret = op_ret;
             local->op_errno = op_errno;
         }
@@ -418,22 +418,22 @@ check_ancestory(call_frame_t *frame, inode_t *inode)
 
     if (cur_inode) {
         inode_unref(cur_inode);
-        check_ancestory_continue(NULL, NULL, 0, 0, frame);
+        check_ancestory_continue(NULL, NULL, gf_success, 0, frame);
     } else {
-        check_ancestory_continue(NULL, NULL, -1, ESTALE, frame);
+        check_ancestory_continue(NULL, NULL, gf_error, ESTALE, frame);
     }
 }
 
 void
-check_ancestory_2_cbk(struct list_head *parents, inode_t *inode, int32_t op_ret,
-                      int32_t op_errno, void *data)
+check_ancestory_2_cbk(struct list_head *parents, inode_t *inode,
+                      gf_return_t op_ret, int32_t op_errno, void *data)
 {
     inode_t *this_inode = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
     this_inode = data;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     if (parents == NULL || list_empty(parents)) {
@@ -548,7 +548,7 @@ out:
 }
 
 static void
-quota_handle_validate_error(call_frame_t *frame, int32_t op_ret,
+quota_handle_validate_error(call_frame_t *frame, gf_return_t op_ret,
                             int32_t op_errno)
 {
     quota_local_t *local;
@@ -560,7 +560,7 @@ quota_handle_validate_error(call_frame_t *frame, int32_t op_ret,
     if (local == NULL)
         goto out;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         LOCK(&local->lock);
         {
             local->op_ret = op_ret;
@@ -576,7 +576,7 @@ out:
 
 int32_t
 quota_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     quota_local_t *local = NULL;
@@ -589,7 +589,7 @@ quota_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -715,8 +715,8 @@ out:
 
 int32_t
 quota_build_ancestry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
-                         dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno,
+                         gf_dirent_t *entries, dict_t *xdata)
 {
     inode_t *parent = NULL;
     inode_t *tmp_parent = NULL;
@@ -738,10 +738,10 @@ quota_build_ancestry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     frame->local = NULL;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto err;
 
-    if ((op_ret > 0) && (entries != NULL)) {
+    if (IS_SUCCESS(op_ret) && (entries != NULL)) {
         list_for_each_entry(entry, &entries->list, list)
         {
             if (__is_root_gfid(entry->inode->gfid)) {
@@ -832,11 +832,12 @@ quota_build_ancestry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    local->ancestry_cbk(&parents, local->loc.inode, 0, 0, local->ancestry_data);
+    local->ancestry_cbk(&parents, local->loc.inode, gf_success, 0,
+                        local->ancestry_data);
     goto cleanup;
 
 err:
-    local->ancestry_cbk(NULL, NULL, -1, op_errno, local->ancestry_data);
+    local->ancestry_cbk(NULL, NULL, gf_error, op_errno, local->ancestry_data);
 
 cleanup:
     STACK_DESTROY(frame->root);
@@ -865,9 +866,10 @@ quota_build_ancestry(inode_t *inode, quota_ancestry_built_t ancestry_cbk,
     quota_local_t *local = NULL;
     call_frame_t *new_frame = NULL;
     int op_errno = ENOMEM;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     xlator_t *this = NULL;
     dict_t *xdata_req = NULL;
+    int ret = -1;
 
     this = THIS;
 
@@ -893,21 +895,21 @@ quota_build_ancestry(inode_t *inode, quota_ancestry_built_t ancestry_cbk,
     local->ancestry_data = data;
     local->loc.inode = inode_ref(inode);
 
-    op_ret = dict_set_int8(xdata_req, QUOTA_LIMIT_KEY, 1);
-    if (op_ret < 0) {
-        op_errno = -op_ret;
+    ret = dict_set_int8(xdata_req, QUOTA_LIMIT_KEY, 1);
+    if (ret) {
+        op_errno = -ret;
         goto err;
     }
 
-    op_ret = dict_set_int8(xdata_req, QUOTA_LIMIT_OBJECTS_KEY, 1);
-    if (op_ret < 0) {
-        op_errno = -op_ret;
+    ret = dict_set_int8(xdata_req, QUOTA_LIMIT_OBJECTS_KEY, 1);
+    if (ret) {
+        op_errno = -ret;
         goto err;
     }
 
-    op_ret = dict_set_int8(xdata_req, GET_ANCESTRY_DENTRY_KEY, 1);
-    if (op_ret < 0) {
-        op_errno = -op_ret;
+    ret = dict_set_int8(xdata_req, GET_ANCESTRY_DENTRY_KEY, 1);
+    if (ret) {
+        op_errno = -ret;
         goto err;
     }
 
@@ -920,7 +922,7 @@ quota_build_ancestry(inode_t *inode, quota_ancestry_built_t ancestry_cbk,
     STACK_WIND(new_frame, quota_build_ancestry_cbk, FIRST_CHILD(this),
                FIRST_CHILD(this)->fops->readdirp, fd, 0, 0, xdata_req);
 
-    op_ret = 0;
+    ret = 0;
 
 err:
     if (fd)
@@ -929,8 +931,9 @@ err:
     if (xdata_req)
         dict_unref(xdata_req);
 
-    if (op_ret < 0) {
-        ancestry_cbk(NULL, NULL, -1, op_errno, data);
+    SET_RET(op_ret, ret);
+    if (IS_ERROR(op_ret)) {
+        ancestry_cbk(NULL, NULL, op_ret, op_errno, data);
 
         if (new_frame) {
             local = new_frame->local;
@@ -1014,7 +1017,7 @@ err:
 
 void
 quota_check_limit_continuation(struct list_head *parents, inode_t *inode,
-                               int32_t op_ret, int32_t op_errno, void *data)
+                               gf_return_t op_ret, int32_t op_errno, void *data)
 {
     call_frame_t *frame = NULL;
     xlator_t *this = NULL;
@@ -1033,8 +1036,8 @@ quota_check_limit_continuation(struct list_head *parents, inode_t *inode,
     else
         par_local = local;
 
-    if ((op_ret < 0) || list_empty(parents)) {
-        if (op_ret >= 0) {
+    if (IS_ERROR(op_ret) || list_empty(parents)) {
+        if (IS_SUCCESS(op_ret)) {
             gf_msg(this->name, GF_LOG_WARNING, EIO, Q_MSG_ANCESTRY_BUILD_FAILED,
                    "Couldn't build ancestry for inode (gfid:%s). "
                    "Without knowing ancestors till root, quota"
@@ -1044,7 +1047,7 @@ quota_check_limit_continuation(struct list_head *parents, inode_t *inode,
             op_errno = EIO;
         }
 
-        quota_handle_validate_error(frame, -1, op_errno);
+        quota_handle_validate_error(frame, gf_error, op_errno);
         goto out;
     }
 
@@ -1126,7 +1129,7 @@ quota_check_object_limit(call_frame_t *frame, quota_inode_ctx_t *ctx,
         }
 
         if (hard_limit_exceeded) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = EDQUOT;
             *op_errno = EDQUOT;
             goto out;
@@ -1193,7 +1196,7 @@ quota_check_size_limit(call_frame_t *frame, quota_inode_ctx_t *ctx,
         }
 
         if (hard_limit_exceeded) {
-            local->op_ret = -1;
+            local->op_ret = gf_error;
             local->op_errno = EDQUOT;
 
             space_available = ctx->hard_lim - ctx->size;
@@ -1358,7 +1361,7 @@ done:
     return 0;
 
 err:
-    quota_handle_validate_error(frame, -1, op_errno);
+    quota_handle_validate_error(frame, gf_error, op_errno);
 
     inode_unref(_inode);
     return 0;
@@ -1403,7 +1406,7 @@ out:
             /* Caller should decrement link_count, in case parent is
              * NULL
              */
-            quota_handle_validate_error(frame, -1, ENOMEM);
+            quota_handle_validate_error(frame, gf_error, ENOMEM);
         }
 
         if (new_frame) {
@@ -1582,28 +1585,32 @@ out:
 
 int32_t
 quota_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, dict_t *dict, struct iatt *postparent)
 {
     quota_local_t *local = NULL;
     inode_t *this_inode = NULL;
+    int ret;
 
     local = frame->local;
     frame->local = NULL;
 
-    if (op_ret >= 0 && inode) {
+    if (IS_SUCCESS(op_ret) && inode) {
         this_inode = inode_ref(inode);
 
-        op_ret = quota_fill_inodectx(this, inode, dict, &local->loc, buf,
-                                     &op_errno);
-        if (op_ret < 0)
+        ret = quota_fill_inodectx(this, inode, dict, &local->loc, buf,
+                                  &op_errno);
+        if (ret < 0) {
+            op_ret = gf_error;
             op_errno = ENOMEM;
+        }
     }
 
     QUOTA_STACK_UNWIND(lookup, frame, op_ret, op_errno, inode, buf, dict,
                        postparent);
 
-    if (op_ret < 0 || this_inode == NULL || gf_uuid_is_null(this_inode->gfid))
+    if (IS_ERROR(op_ret) || this_inode == NULL ||
+        gf_uuid_is_null(this_inode->gfid))
         goto out;
 
     check_ancestory_2(this, local, this_inode);
@@ -1665,7 +1672,8 @@ err:
         dict_unref(xattr_req);
 
     if (ret < 0) {
-        QUOTA_STACK_UNWIND(lookup, frame, -1, ENOMEM, NULL, NULL, NULL, NULL);
+        QUOTA_STACK_UNWIND(lookup, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                           NULL);
     }
 
     return 0;
@@ -1678,7 +1686,7 @@ off:
 
 int32_t
 quota_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     int32_t ret = 0;
@@ -1688,7 +1696,7 @@ quota_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if ((op_ret < 0) || (local == NULL) || (postbuf == NULL)) {
+    if (IS_ERROR(op_ret) || (local == NULL) || (postbuf == NULL)) {
         goto out;
     }
 
@@ -1738,14 +1746,14 @@ quota_writev_helper(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     GF_VALIDATE_OR_GOTO("quota", local, unwind);
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
 
         if ((op_errno == EDQUOT) && (local->space_available > 0)) {
             new_count = iov_subset(vector, count, 0, local->space_available,
                                    &new_vector, 0);
             if (new_count < 0) {
-                local->op_ret = -1;
+                local->op_ret = gf_error;
                 local->op_errno = ENOMEM;
                 goto unwind;
             }
@@ -1803,7 +1811,7 @@ quota_writev_helper(call_frame_t *frame, xlator_t *this, fd_t *fd,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(writev, frame, -1, op_errno, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(writev, frame, gf_error, op_errno, NULL, NULL, NULL);
     return 0;
 }
 
@@ -1919,7 +1927,7 @@ quota_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(writev, frame, -1, op_errno, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(writev, frame, gf_error, op_errno, NULL, NULL, NULL);
     return 0;
 
 off:
@@ -1930,7 +1938,7 @@ off:
 
 int32_t
 quota_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -1952,7 +1960,7 @@ quota_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     op_errno = local->op_errno;
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         goto unwind;
     }
 
@@ -1962,7 +1970,7 @@ quota_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    QUOTA_STACK_UNWIND(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                        NULL);
     return 0;
 }
@@ -2020,7 +2028,7 @@ quota_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     return 0;
 
 err:
-    QUOTA_STACK_UNWIND(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    QUOTA_STACK_UNWIND(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                        NULL);
 
     return 0;
@@ -2034,7 +2042,7 @@ off:
 
 int32_t
 quota_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -2044,7 +2052,7 @@ quota_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_dentry_t *dentry = NULL;
 
     local = frame->local;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -2054,7 +2062,7 @@ quota_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                "cannot create quota "
                "context in inode(gfid:%s)",
                uuid_utoa(inode->gfid));
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -2070,7 +2078,7 @@ quota_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                    "cannot create a new dentry "
                    "(name:%s) for inode(gfid:%s)",
                    local->loc.name, uuid_utoa(local->loc.inode->gfid));
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unlock;
         }
@@ -2096,7 +2104,7 @@ quota_create_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     GF_VALIDATE_OR_GOTO("quota", local, unwind);
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         goto unwind;
     }
@@ -2107,8 +2115,8 @@ quota_create_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(create, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                       NULL, NULL);
+    QUOTA_STACK_UNWIND(create, frame, gf_error, op_errno, NULL, NULL, NULL,
+                       NULL, NULL, NULL);
     return 0;
 }
 
@@ -2161,8 +2169,8 @@ quota_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     quota_check_limit(frame, loc->parent, this);
     return 0;
 err:
-    QUOTA_STACK_UNWIND(create, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                       NULL, NULL);
+    QUOTA_STACK_UNWIND(create, frame, gf_error, op_errno, NULL, NULL, NULL,
+                       NULL, NULL, NULL);
 
     return 0;
 
@@ -2174,14 +2182,14 @@ off:
 
 int32_t
 quota_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
     uint64_t value = 0;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -2238,7 +2246,7 @@ quota_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
 
 err:
     if (ret == -1) {
-        QUOTA_STACK_UNWIND(unlink, frame, -1, 0, NULL, NULL, NULL);
+        QUOTA_STACK_UNWIND(unlink, frame, gf_error, 0, NULL, NULL, NULL);
     }
 
     return 0;
@@ -2251,7 +2259,7 @@ off:
 
 int32_t
 quota_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *buf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -2261,7 +2269,7 @@ quota_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_dentry_t *dentry = NULL;
     char found = 0;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -2303,7 +2311,7 @@ quota_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                        "cannot create a new dentry (name:%s)"
                        "for inode(gfid:%s)",
                        local->loc.name, uuid_utoa(local->loc.inode->gfid));
-                op_ret = -1;
+                op_ret = gf_error;
                 op_errno = ENOMEM;
                 goto unlock;
             }
@@ -2334,7 +2342,7 @@ quota_link_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
 
     op_errno = local->op_errno;
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         goto unwind;
     }
 
@@ -2343,7 +2351,8 @@ quota_link_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                       NULL);
     return 0;
 }
 
@@ -2362,7 +2371,7 @@ quota_link_continue(call_frame_t *frame)
     local = frame->local;
     this = THIS;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         goto err;
     }
@@ -2427,7 +2436,8 @@ quota_link_continue(call_frame_t *frame)
     return;
 
 err:
-    QUOTA_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                       NULL);
     return;
 
 wind:
@@ -2516,7 +2526,8 @@ quota_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     return 0;
 
 err:
-    QUOTA_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                       NULL);
     return 0;
 
 off:
@@ -2532,7 +2543,7 @@ wind:
 
 int32_t
 quota_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                  struct iatt *preoldparent, struct iatt *postoldparent,
                  struct iatt *prenewparent, struct iatt *postnewparent,
                  dict_t *xdata)
@@ -2543,7 +2554,7 @@ quota_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_dentry_t *old_dentry = NULL, *dentry = NULL;
     char new_dentry_found = 0;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -2608,7 +2619,7 @@ quota_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                        "for inode(gfid:%s)",
                        local->newloc.name,
                        uuid_utoa(local->newloc.inode->gfid));
-                op_ret = -1;
+                op_ret = gf_error;
                 op_errno = ENOMEM;
                 goto unlock;
             }
@@ -2639,7 +2650,7 @@ quota_rename_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
 
     op_errno = local->op_errno;
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         goto unwind;
     }
 
@@ -2649,14 +2660,14 @@ quota_rename_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                       NULL, NULL);
+    QUOTA_STACK_UNWIND(rename, frame, gf_error, op_errno, NULL, NULL, NULL,
+                       NULL, NULL, NULL);
     return 0;
 }
 
 static int32_t
 quota_rename_get_size_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, inode_t *inode,
+                          gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                           struct iatt *buf, dict_t *xdata,
                           struct iatt *postparent)
 {
@@ -2671,7 +2682,7 @@ quota_rename_get_size_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_ASSERT(local);
     local->link_count = 1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     ret = dict_get_bin(xdata, QUOTA_SIZE_KEY, (void **)&size);
@@ -2687,7 +2698,7 @@ quota_rename_get_size_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     return 0;
 
 out:
-    quota_handle_validate_error(frame, -1, op_errno);
+    quota_handle_validate_error(frame, gf_error, op_errno);
     return 0;
 }
 
@@ -2704,7 +2715,7 @@ quota_rename_continue(call_frame_t *frame)
     local = frame->local;
     this = THIS;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         goto err;
     }
@@ -2769,8 +2780,8 @@ quota_rename_continue(call_frame_t *frame)
     return;
 
 err:
-    QUOTA_STACK_UNWIND(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                       NULL, NULL);
+    QUOTA_STACK_UNWIND(rename, frame, gf_error, op_errno, NULL, NULL, NULL,
+                       NULL, NULL, NULL);
     return;
 }
 
@@ -2840,8 +2851,8 @@ quota_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     return 0;
 
 err:
-    QUOTA_STACK_UNWIND(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                       NULL, NULL);
+    QUOTA_STACK_UNWIND(rename, frame, gf_error, op_errno, NULL, NULL, NULL,
+                       NULL, NULL, NULL);
     return 0;
 
 off:
@@ -2857,7 +2868,7 @@ wind:
 
 int32_t
 quota_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
@@ -2866,7 +2877,7 @@ quota_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_dentry_t *dentry = NULL;
     int32_t ret = -1;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -2894,7 +2905,7 @@ quota_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                    "cannot create "
                    "a new dentry (name:%s) for inode(gfid:%s)",
                    local->loc.name, uuid_utoa(local->loc.inode->gfid));
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
         }
     }
@@ -2918,7 +2929,7 @@ quota_symlink_helper(call_frame_t *frame, xlator_t *this, const char *linkpath,
 
     GF_VALIDATE_OR_GOTO("quota", local, unwind);
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         goto unwind;
     }
@@ -2928,8 +2939,8 @@ quota_symlink_helper(call_frame_t *frame, xlator_t *this, const char *linkpath,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(symlink, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                       NULL);
+    QUOTA_STACK_UNWIND(symlink, frame, gf_error, op_errno, NULL, NULL, NULL,
+                       NULL, NULL);
     return 0;
 }
 
@@ -2980,8 +2991,8 @@ quota_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
     return 0;
 
 err:
-    QUOTA_STACK_UNWIND(symlink, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                       NULL);
+    QUOTA_STACK_UNWIND(symlink, frame, gf_error, op_errno, NULL, NULL, NULL,
+                       NULL, NULL);
 
     return 0;
 
@@ -2993,13 +3004,13 @@ off:
 
 int32_t
 quota_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3061,7 +3072,7 @@ quota_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     return 0;
 
 err:
-    QUOTA_STACK_UNWIND(truncate, frame, -1, ENOMEM, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(truncate, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     return 0;
 off:
@@ -3072,13 +3083,13 @@ off:
 
 int32_t
 quota_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3132,7 +3143,7 @@ quota_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
     return 0;
 err:
-    QUOTA_STACK_UNWIND(ftruncate, frame, -1, ENOMEM, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(ftruncate, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     return 0;
 
@@ -3184,7 +3195,7 @@ dict_set:
 
     gf_msg_debug(this->name, 0, "str = %s", dir_limit);
 
-    QUOTA_STACK_UNWIND(getxattr, frame, 0, 0, dict, NULL);
+    QUOTA_STACK_UNWIND(getxattr, frame, gf_success, 0, dict, NULL);
 
     ret = 0;
 
@@ -3235,13 +3246,13 @@ quota_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 int32_t
 quota_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *buf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                dict_t *xdata)
 {
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3302,7 +3313,7 @@ quota_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(stat, frame, -1, ENOMEM, NULL, NULL);
+    QUOTA_STACK_UNWIND(stat, frame, gf_error, ENOMEM, NULL, NULL);
     return 0;
 
 off:
@@ -3313,13 +3324,13 @@ off:
 
 int32_t
 quota_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                 dict_t *xdata)
 {
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3375,7 +3386,7 @@ quota_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(fstat, frame, -1, ENOMEM, NULL, NULL);
+    QUOTA_STACK_UNWIND(fstat, frame, gf_error, ENOMEM, NULL, NULL);
     return 0;
 
 off:
@@ -3386,13 +3397,13 @@ off:
 
 int32_t
 quota_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, const char *path,
+                   gf_return_t op_ret, int32_t op_errno, const char *path,
                    struct iatt *buf, dict_t *xdata)
 {
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3452,7 +3463,7 @@ quota_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(readlink, frame, -1, ENOMEM, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(readlink, frame, gf_error, ENOMEM, NULL, NULL, NULL);
     return 0;
 
 off:
@@ -3463,14 +3474,14 @@ off:
 
 int32_t
 quota_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                 int32_t count, struct iatt *buf, struct iobref *iobref,
                 dict_t *xdata)
 {
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3525,7 +3536,8 @@ quota_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(readv, frame, -1, ENOMEM, NULL, -1, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(readv, frame, gf_error, ENOMEM, NULL, -1, NULL, NULL,
+                       NULL);
     return 0;
 
 off:
@@ -3536,13 +3548,13 @@ off:
 
 int32_t
 quota_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                 struct iatt *postbuf, dict_t *xdata)
 {
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3596,7 +3608,7 @@ quota_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(fsync, frame, -1, ENOMEM, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(fsync, frame, gf_error, ENOMEM, NULL, NULL, NULL);
     return 0;
 
 off:
@@ -3607,13 +3619,13 @@ off:
 
 int32_t
 quota_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                   struct iatt *statpost, dict_t *xdata)
 {
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3677,7 +3689,7 @@ quota_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(setattr, frame, -1, ENOMEM, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(setattr, frame, gf_error, ENOMEM, NULL, NULL, NULL);
     return 0;
 
 off:
@@ -3688,13 +3700,13 @@ off:
 
 int32_t
 quota_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                    struct iatt *statpost, dict_t *xdata)
 {
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3752,7 +3764,7 @@ quota_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(fsetattr, frame, -1, ENOMEM, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(fsetattr, frame, gf_error, ENOMEM, NULL, NULL, NULL);
     return 0;
 
 off:
@@ -3763,7 +3775,7 @@ off:
 
 int32_t
 quota_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -3773,7 +3785,7 @@ quota_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     quota_dentry_t *dentry = NULL;
 
     local = frame->local;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -3783,7 +3795,7 @@ quota_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                "cannot create quota context in "
                "inode(gfid:%s)",
                uuid_utoa(inode->gfid));
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -3799,7 +3811,7 @@ quota_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                    "cannot create a new dentry "
                    "(name:%s) for inode(gfid:%s)",
                    local->loc.name, uuid_utoa(local->loc.inode->gfid));
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unlock;
         }
@@ -3824,7 +3836,7 @@ quota_mknod_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     GF_VALIDATE_OR_GOTO("quota", local, unwind);
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         goto unwind;
     }
@@ -3835,7 +3847,7 @@ quota_mknod_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    QUOTA_STACK_UNWIND(mknod, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                        NULL);
     return 0;
 }
@@ -3887,7 +3899,8 @@ quota_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     return 0;
 
 err:
-    QUOTA_STACK_UNWIND(mknod, frame, -1, ENOMEM, NULL, NULL, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(mknod, frame, gf_error, ENOMEM, NULL, NULL, NULL, NULL,
+                       NULL);
     return 0;
 
 off:
@@ -3898,13 +3911,13 @@ off:
 
 int
 quota_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     quota_local_t *local = NULL;
     quota_inode_ctx_t *ctx = NULL;
     int ret = 0;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         goto out;
     }
 
@@ -3938,7 +3951,7 @@ quota_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
 {
     quota_priv_t *priv = NULL;
     int op_errno = EINVAL;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int64_t hard_lim = -1;
     int64_t soft_lim = -1;
     int64_t object_hard_limit = -1;
@@ -4001,20 +4014,22 @@ off:
 
 int
 quota_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     quota_inode_ctx_t *ctx = NULL;
     quota_local_t *local = NULL;
+    int ret;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     local = frame->local;
     if (!local)
         goto out;
 
-    op_ret = quota_inode_ctx_get(local->loc.inode, this, &ctx, 1);
-    if ((op_ret < 0) || (ctx == NULL)) {
+    ret = quota_inode_ctx_get(local->loc.inode, this, &ctx, 1);
+    if ((ret < 0) || (ctx == NULL)) {
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto out;
     }
@@ -4038,7 +4053,7 @@ quota_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
                 int flags, dict_t *xdata)
 {
     quota_priv_t *priv = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     quota_local_t *local = NULL;
     int64_t hard_lim = -1;
@@ -4098,7 +4113,7 @@ off:
 
 int
 quota_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     QUOTA_STACK_UNWIND(removexattr, frame, op_ret, op_errno, xdata);
     return 0;
@@ -4134,7 +4149,7 @@ quota_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     return 0;
 
 err:
-    QUOTA_STACK_UNWIND(removexattr, frame, -1, op_errno, NULL);
+    QUOTA_STACK_UNWIND(removexattr, frame, gf_error, op_errno, NULL);
     return 0;
 
 off:
@@ -4145,7 +4160,7 @@ off:
 
 int
 quota_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     QUOTA_STACK_UNWIND(fremovexattr, frame, op_ret, op_errno, xdata);
     return 0;
@@ -4156,7 +4171,7 @@ quota_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
                    const char *name, dict_t *xdata)
 {
     quota_priv_t *priv = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
 
     priv = this->private;
@@ -4187,7 +4202,7 @@ off:
 
 int32_t
 quota_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                  dict_t *xdata)
 {
     inode_t *inode = NULL;
@@ -4202,7 +4217,7 @@ quota_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     /* This fop will fail mostly in case of client disconnect,
      * which is already logged. Hence, not logging here */
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto unwind;
     /*
      * We should never get here unless quota_statfs (below) sent us a
@@ -4266,7 +4281,7 @@ quota_statfs_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     GF_VALIDATE_OR_GOTO("quota", local, err);
 
-    if (-1 == local->op_ret) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         goto err;
     }
@@ -4275,14 +4290,14 @@ quota_statfs_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
                       FIRST_CHILD(this)->fops->statfs, loc, xdata);
     return 0;
 err:
-    QUOTA_STACK_UNWIND(statfs, frame, -1, op_errno, NULL, NULL);
+    QUOTA_STACK_UNWIND(statfs, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 int32_t
 quota_statfs_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, inode_t *inode,
+                          gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                           struct iatt *buf, dict_t *xdata,
                           struct iatt *postparent)
 {
@@ -4296,7 +4311,7 @@ quota_statfs_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto resume;
 
     GF_ASSERT(local);
@@ -4341,7 +4356,8 @@ resume:
 
 void
 quota_get_limit_dir_continuation(struct list_head *parents, inode_t *inode,
-                                 int32_t op_ret, int32_t op_errno, void *data)
+                                 gf_return_t op_ret, int32_t op_errno,
+                                 void *data)
 {
     call_frame_t *frame = NULL;
     xlator_t *this = NULL;
@@ -4351,8 +4367,8 @@ quota_get_limit_dir_continuation(struct list_head *parents, inode_t *inode,
     frame = data;
     this = THIS;
 
-    if ((op_ret < 0) || list_empty(parents)) {
-        if (op_ret >= 0) {
+    if (IS_ERROR(op_ret) || list_empty(parents)) {
+        if (IS_SUCCESS(op_ret)) {
             gf_msg(this->name, GF_LOG_WARNING, EIO, Q_MSG_ANCESTRY_BUILD_FAILED,
                    "Couldn't build ancestry for inode (gfid:%s). "
                    "Without knowing ancestors till root, quota "
@@ -4362,7 +4378,7 @@ quota_get_limit_dir_continuation(struct list_head *parents, inode_t *inode,
             op_errno = EIO;
         }
 
-        quota_handle_validate_error(frame, -1, op_errno);
+        quota_handle_validate_error(frame, gf_error, op_errno);
         goto out;
     }
 
@@ -4390,7 +4406,7 @@ quota_statfs_continue(call_frame_t *frame, xlator_t *this, inode_t *inode)
 
     ret = quota_validate(frame, local->inode, this, quota_statfs_validate_cbk);
     if (0 > ret)
-        quota_handle_validate_error(frame, -1, -ret);
+        quota_handle_validate_error(frame, gf_error, -ret);
 }
 
 void
@@ -4524,14 +4540,14 @@ off:
     return 0;
 
 err:
-    QUOTA_STACK_UNWIND(statfs, frame, -1, op_errno, NULL, NULL);
+    QUOTA_STACK_UNWIND(statfs, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 int
 quota_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int op_ret, int op_errno, gf_dirent_t *entries,
+                   gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
                    dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
@@ -4540,7 +4556,7 @@ quota_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret <= 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     local = frame->local;
@@ -4625,7 +4641,7 @@ quota_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(readdirp, frame, -1, EINVAL, NULL, NULL);
+    STACK_UNWIND_STRICT(readdirp, frame, gf_error, EINVAL, NULL, NULL);
 
     if (new_dict) {
         dict_unref(dict);
@@ -4641,7 +4657,7 @@ off:
 
 int32_t
 quota_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     int32_t ret = 0;
@@ -4651,7 +4667,7 @@ quota_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if ((op_ret < 0) || (local == NULL)) {
+    if (IS_ERROR(op_ret) || (local == NULL)) {
         goto out;
     }
 
@@ -4695,7 +4711,7 @@ quota_fallocate_helper(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     GF_VALIDATE_OR_GOTO("quota", local, unwind);
 
-    if (local->op_ret == -1) {
+    if (IS_ERROR(local->op_ret)) {
         op_errno = local->op_errno;
         if (op_errno == ENOENT || op_errno == ESTALE) {
             /* We may get ENOENT/ESTALE in case of below scenario
@@ -4723,7 +4739,7 @@ quota_fallocate_helper(call_frame_t *frame, xlator_t *this, fd_t *fd,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(fallocate, frame, -1, op_errno, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(fallocate, frame, gf_error, op_errno, NULL, NULL, NULL);
     return 0;
 }
 
@@ -4836,7 +4852,7 @@ quota_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
     return 0;
 
 unwind:
-    QUOTA_STACK_UNWIND(fallocate, frame, -1, op_errno, NULL, NULL, NULL);
+    QUOTA_STACK_UNWIND(fallocate, frame, gf_error, op_errno, NULL, NULL, NULL);
     return 0;
 
 off:

--- a/xlators/features/quota/src/quota.h
+++ b/xlators/features/quota/src/quota.h
@@ -161,7 +161,7 @@ struct quota_inode_ctx {
 typedef struct quota_inode_ctx quota_inode_ctx_t;
 
 typedef void (*quota_ancestry_built_t)(struct list_head *parents,
-                                       inode_t *inode, int32_t op_ret,
+                                       inode_t *inode, gf_return_t op_ret,
                                        int32_t op_errno, void *data);
 
 typedef void (*quota_fop_continue_t)(call_frame_t *frame);
@@ -175,7 +175,7 @@ struct quota_local {
     loc_t validate_loc;
     int64_t delta;
     int8_t object_delta;
-    int32_t op_ret;
+    gf_return_t op_ret;
     int32_t op_errno;
     int64_t size;
     char just_validated;

--- a/xlators/features/quota/src/quotad-aggregator.c
+++ b/xlators/features/quota/src/quotad-aggregator.c
@@ -139,7 +139,7 @@ quotad_aggregator_getlimit_cbk(xlator_t *this, call_frame_t *frame,
     int ret = -1;
     int type = 0;
 
-    if (!rsp || (rsp->op_ret == -1))
+    if (!rsp || (rsp->op_ret < 0))
         goto reply;
 
     GF_PROTOCOL_DICT_UNSERIALIZE(frame->this, xdata, (rsp->xdata.xdata_val),

--- a/xlators/features/quota/src/quotad.c
+++ b/xlators/features/quota/src/quotad.c
@@ -43,9 +43,9 @@ mem_acct_init(xlator_t *this)
 }
 
 int32_t
-qd_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode, struct iatt *buf, dict_t *xdata,
-              struct iatt *postparent)
+qd_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+              struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     quotad_aggregator_lookup_cbk_t lookup_cbk = NULL;
     gfs3_lookup_rsp rsp = {
@@ -54,7 +54,7 @@ qd_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     lookup_cbk = cookie;
 
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = op_errno;
 
     gf_stat_from_iatt(&rsp.postparent, postparent);

--- a/xlators/features/read-only/src/read-only-common.c
+++ b/xlators/features/read-only/src/read-only-common.c
@@ -50,7 +50,7 @@ ro_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc,
         allzero = _gf_true;
 
     if (is_readonly_or_worm_enabled(frame, this) && !allzero)
-        STACK_UNWIND_STRICT(xattrop, frame, -1, EROFS, NULL, xdata);
+        STACK_UNWIND_STRICT(xattrop, frame, gf_error, EROFS, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->xattrop, loc, flags, dict,
@@ -70,7 +70,7 @@ ro_fxattrop(call_frame_t *frame, xlator_t *this, fd_t *fd,
         allzero = _gf_true;
 
     if (is_readonly_or_worm_enabled(frame, this) && !allzero)
-        STACK_UNWIND_STRICT(fxattrop, frame, -1, EROFS, NULL, xdata);
+        STACK_UNWIND_STRICT(fxattrop, frame, gf_error, EROFS, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->fxattrop, fd, flags, dict,
@@ -136,7 +136,7 @@ ro_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc, struct iatt *stbuf,
            int32_t valid, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(setattr, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(setattr, frame, gf_error, EROFS, NULL, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->setattr, loc, stbuf, valid,
@@ -150,7 +150,8 @@ ro_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iatt *stbuf,
             int32_t valid, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(fsetattr, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(fsetattr, frame, gf_error, EROFS, NULL, NULL,
+                            xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->fsetattr, fd, stbuf, valid,
@@ -164,7 +165,8 @@ ro_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
             dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(truncate, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(truncate, frame, gf_error, EROFS, NULL, NULL,
+                            xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->truncate, loc, offset, xdata);
@@ -177,7 +179,8 @@ ro_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
              dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(ftruncate, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(ftruncate, frame, gf_error, EROFS, NULL, NULL,
+                            xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->ftruncate, fd, offset, xdata);
@@ -190,7 +193,8 @@ ro_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
              off_t offset, size_t len, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(fallocate, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(fallocate, frame, gf_error, EROFS, NULL, NULL,
+                            xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->fallocate, fd, mode, offset,
@@ -203,8 +207,8 @@ ro_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
          dev_t rdev, mode_t umask, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(mknod, frame, -1, EROFS, NULL, NULL, NULL, NULL,
-                            xdata);
+        STACK_UNWIND_STRICT(mknod, frame, gf_error, EROFS, NULL, NULL, NULL,
+                            NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->mknod, loc, mode, rdev, umask,
@@ -218,8 +222,8 @@ ro_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
          mode_t umask, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(mkdir, frame, -1, EROFS, NULL, NULL, NULL, NULL,
-                            xdata);
+        STACK_UNWIND_STRICT(mkdir, frame, gf_error, EROFS, NULL, NULL, NULL,
+                            NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->mkdir, loc, mode, umask,
@@ -233,7 +237,7 @@ ro_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
           dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(unlink, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(unlink, frame, gf_error, EROFS, NULL, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->unlink, loc, xflag, xdata);
@@ -246,7 +250,7 @@ ro_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
          dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(rmdir, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(rmdir, frame, gf_error, EROFS, NULL, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->rmdir, loc, flags, xdata);
@@ -259,8 +263,8 @@ ro_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
            loc_t *loc, mode_t umask, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(symlink, frame, -1, EROFS, NULL, NULL, NULL, NULL,
-                            xdata);
+        STACK_UNWIND_STRICT(symlink, frame, gf_error, EROFS, NULL, NULL, NULL,
+                            NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->symlink, linkpath, loc, umask,
@@ -274,8 +278,8 @@ ro_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
           dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(rename, frame, -1, EROFS, NULL, NULL, NULL, NULL,
-                            NULL, xdata);
+        STACK_UNWIND_STRICT(rename, frame, gf_error, EROFS, NULL, NULL, NULL,
+                            NULL, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->rename, oldloc, newloc, xdata);
@@ -288,8 +292,8 @@ ro_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
         dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(link, frame, -1, EROFS, NULL, NULL, NULL, NULL,
-                            xdata);
+        STACK_UNWIND_STRICT(link, frame, gf_error, EROFS, NULL, NULL, NULL,
+                            NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this), FIRST_CHILD(this)->fops->link,
                         oldloc, newloc, xdata);
@@ -302,8 +306,8 @@ ro_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
           mode_t mode, mode_t umask, fd_t *fd, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(create, frame, -1, EROFS, NULL, NULL, NULL, NULL,
-                            NULL, xdata);
+        STACK_UNWIND_STRICT(create, frame, gf_error, EROFS, NULL, NULL, NULL,
+                            NULL, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->create, loc, flags, mode,
@@ -313,8 +317,8 @@ ro_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 }
 
 static int32_t
-ro_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, fd_t *fd, dict_t *xdata)
+ro_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(open, frame, op_ret, op_errno, fd, xdata);
     return 0;
@@ -327,7 +331,7 @@ ro_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     if (is_readonly_or_worm_enabled(frame, this) &&
         (((flags & O_ACCMODE) == O_WRONLY) ||
          ((flags & O_ACCMODE) == O_RDWR))) {
-        STACK_UNWIND_STRICT(open, frame, -1, EROFS, NULL, xdata);
+        STACK_UNWIND_STRICT(open, frame, gf_error, EROFS, NULL, xdata);
         return 0;
     }
 
@@ -341,7 +345,7 @@ ro_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
              int32_t flags, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(fsetxattr, frame, -1, EROFS, xdata);
+        STACK_UNWIND_STRICT(fsetxattr, frame, gf_error, EROFS, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->fsetxattr, fd, dict, flags,
@@ -355,7 +359,7 @@ ro_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
             dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(fsyncdir, frame, -1, EROFS, xdata);
+        STACK_UNWIND_STRICT(fsyncdir, frame, gf_error, EROFS, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->fsyncdir, fd, flags, xdata);
@@ -369,7 +373,7 @@ ro_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
           dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(writev, frame, -1, EROFS, NULL, NULL, xdata);
+        STACK_UNWIND_STRICT(writev, frame, gf_error, EROFS, NULL, NULL, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->writev, fd, vector, count, off,
@@ -383,7 +387,7 @@ ro_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
             int32_t flags, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(setxattr, frame, -1, EROFS, xdata);
+        STACK_UNWIND_STRICT(setxattr, frame, gf_error, EROFS, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->setxattr, loc, dict, flags,
@@ -397,7 +401,7 @@ ro_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                const char *name, dict_t *xdata)
 {
     if (is_readonly_or_worm_enabled(frame, this))
-        STACK_UNWIND_STRICT(removexattr, frame, -1, EROFS, xdata);
+        STACK_UNWIND_STRICT(removexattr, frame, gf_error, EROFS, xdata);
     else
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->removexattr, loc, name, xdata);

--- a/xlators/features/sdfs/src/sdfs.c
+++ b/xlators/features/sdfs/src/sdfs.c
@@ -209,7 +209,7 @@ err:
 
 int
 sdfs_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     sdfs_local_t *local = NULL;
     call_stub_t *stub = NULL;
@@ -224,7 +224,7 @@ sdfs_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->stub = NULL;
         call_resume(stub);
     } else {
-        if (op_ret < 0)
+        if (IS_ERROR(op_ret))
             gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                    "Unlocking entry lock failed for %s", local->loc.name);
 
@@ -236,7 +236,7 @@ sdfs_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int
 sdfs_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *stbuf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -266,7 +266,7 @@ sdfs_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -280,8 +280,8 @@ sdfs_mkdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(mkdir, local->main_frame, -1, op_errno, NULL, NULL,
-                        NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(mkdir, local->main_frame, gf_error, op_errno, NULL,
+                        NULL, NULL, NULL, NULL);
 
     local->main_frame = NULL;
     SDFS_STACK_DESTROY(frame);
@@ -318,8 +318,8 @@ sdfs_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -329,7 +329,7 @@ err:
 
 int
 sdfs_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
     sdfs_local_t *local = NULL;
@@ -357,7 +357,7 @@ sdfs_rmdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -370,8 +370,8 @@ sdfs_rmdir_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(rmdir, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL);
+    STACK_UNWIND_STRICT(rmdir, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL);
 
     local->main_frame = NULL;
     SDFS_STACK_DESTROY(frame);
@@ -407,7 +407,7 @@ sdfs_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(rmdir, frame, -1, op_errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(rmdir, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -417,7 +417,7 @@ err:
 
 int
 sdfs_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
                 struct iatt *stbuf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -447,7 +447,7 @@ sdfs_create_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -461,8 +461,8 @@ sdfs_create_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(create, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(create, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL, NULL, NULL, NULL);
 
     local->main_frame = NULL;
     SDFS_STACK_DESTROY(frame);
@@ -499,8 +499,8 @@ sdfs_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(create, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    STACK_UNWIND_STRICT(create, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -510,7 +510,7 @@ err:
 
 int
 sdfs_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
     sdfs_local_t *local = NULL;
@@ -538,7 +538,7 @@ sdfs_unlink_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -551,8 +551,8 @@ sdfs_unlink_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(unlink, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL);
+    STACK_UNWIND_STRICT(unlink, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL);
 
     local->main_frame = NULL;
     SDFS_STACK_DESTROY(frame);
@@ -588,7 +588,7 @@ sdfs_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(unlink, frame, -1, op_errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(unlink, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -598,7 +598,7 @@ err:
 
 int
 sdfs_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *stbuf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -627,7 +627,7 @@ sdfs_symlink_helper(call_frame_t *frame, xlator_t *this, const char *linkname,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -640,8 +640,8 @@ sdfs_symlink_helper(call_frame_t *frame, xlator_t *this, const char *linkname,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(link, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(link, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL, NULL, NULL);
 
     local->main_frame = NULL;
     SDFS_STACK_DESTROY(frame);
@@ -678,7 +678,7 @@ sdfs_symlink(call_frame_t *frame, xlator_t *this, const char *linkname,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    STACK_UNWIND_STRICT(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                         NULL);
 
     if (new_frame)
@@ -689,7 +689,7 @@ err:
 
 int
 sdfs_common_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     sdfs_local_t *local = NULL;
     int this_call_cnt = 0;
@@ -701,7 +701,7 @@ sdfs_common_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     locks = local->lock;
     lk_index = (long)cookie;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         local->op_ret = op_ret;
         local->op_errno = op_errno;
     } else {
@@ -721,7 +721,7 @@ sdfs_common_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         local->stub = NULL;
         call_resume(stub);
     } else {
-        if (local->op_ret < 0)
+        if (IS_ERROR(local->op_ret))
             gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                    "unlocking entry lock failed ");
         SDFS_STACK_DESTROY(frame);
@@ -731,9 +731,10 @@ sdfs_common_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 }
 
 int
-sdfs_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode, struct iatt *stbuf,
-              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+sdfs_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+              struct iatt *stbuf, struct iatt *preparent,
+              struct iatt *postparent, dict_t *xdata)
 {
     sdfs_local_t *local = NULL;
     sdfs_lock_t *lock = NULL;
@@ -772,7 +773,7 @@ sdfs_link_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
     local = frame->local;
     locks = local->lock;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed");
         goto err;
@@ -783,8 +784,8 @@ sdfs_link_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(link, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(link, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL, NULL, NULL);
 
     local->main_frame = NULL;
     for (i = 0; i < locks->lock_count && locks->entrylk->locked[i]; i++) {
@@ -921,7 +922,7 @@ sdfs_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     return 0;
 err:
 
-    STACK_UNWIND_STRICT(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    STACK_UNWIND_STRICT(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                         NULL);
 
     if (new_frame)
@@ -932,7 +933,7 @@ err:
 
 int
 sdfs_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *stbuf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -961,7 +962,7 @@ sdfs_mknod_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -974,8 +975,8 @@ sdfs_mknod_helper(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(mknod, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(mknod, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL, NULL, NULL);
 
     local->main_frame = NULL;
     SDFS_STACK_DESTROY(frame);
@@ -1012,8 +1013,8 @@ sdfs_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(mknod, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -1023,7 +1024,7 @@ err:
 
 int
 sdfs_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                 struct iatt *preoldparent, struct iatt *postoldparent,
                 struct iatt *prenewparent, struct iatt *postnewparent,
                 dict_t *xdata)
@@ -1068,7 +1069,7 @@ sdfs_rename_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
     local = frame->local;
     lock = local->lock;
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed ");
         goto err;
@@ -1080,8 +1081,8 @@ sdfs_rename_helper(call_frame_t *frame, xlator_t *this, loc_t *oldloc,
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(rename, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(rename, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL, NULL, NULL, NULL);
 
     local->main_frame = NULL;
     for (i = 0; i < lock->lock_count && lock->entrylk->locked[i]; i++) {
@@ -1185,8 +1186,8 @@ sdfs_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     return 0;
 err:
 
-    STACK_UNWIND_STRICT(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    STACK_UNWIND_STRICT(rename, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -1196,7 +1197,7 @@ err:
 
 int
 sdfs_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *stbuf, dict_t *xdata, struct iatt *postparent)
 {
     sdfs_local_t *local = NULL;
@@ -1232,7 +1233,7 @@ sdfs_lookup_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     gf_uuid_unparse(loc->pargfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -1245,8 +1246,8 @@ sdfs_lookup_helper(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(lookup, local->main_frame, -1, local->op_errno, NULL,
-                        NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(lookup, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL, NULL, NULL);
     local->main_frame = NULL;
 
     SDFS_STACK_DESTROY(frame);
@@ -1294,7 +1295,8 @@ sdfs_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(lookup, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);
@@ -1304,7 +1306,7 @@ err:
 
 int32_t
 sdfs_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                  gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                   dict_t *xdata)
 {
     sdfs_local_t *local = NULL;
@@ -1331,7 +1333,7 @@ sdfs_readdirp_helper(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     gf_uuid_unparse(fd->inode->gfid, gfid);
 
-    if (local->op_ret < 0) {
+    if (IS_ERROR(local->op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, SDFS_MSG_ENTRYLK_ERROR,
                "Acquiring entry lock failed for directory %s "
                "with parent gfid %s",
@@ -1344,8 +1346,8 @@ sdfs_readdirp_helper(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(readdirp, local->main_frame, -1, local->op_errno, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(readdirp, local->main_frame, gf_error, local->op_errno,
+                        NULL, NULL);
 
     local->main_frame = NULL;
 
@@ -1384,7 +1386,7 @@ sdfs_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(readdirp, frame, -1, op_errno, NULL, NULL);
+    STACK_UNWIND_STRICT(readdirp, frame, gf_error, op_errno, NULL, NULL);
 
     if (new_frame)
         SDFS_STACK_DESTROY(new_frame);

--- a/xlators/features/sdfs/src/sdfs.h
+++ b/xlators/features/sdfs/src/sdfs.h
@@ -32,7 +32,7 @@ struct sdfs_local {
     loc_t parent_loc;
     call_stub_t *stub;
     sdfs_lock_t *lock;
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
     gf_atomic_t call_cnt;
 };

--- a/xlators/features/selinux/src/selinux.c
+++ b/xlators/features/selinux/src/selinux.c
@@ -17,7 +17,8 @@
 
 static int
 selinux_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, dict_t *dict, dict_t *xdata)
+                      gf_return_t op_ret, int op_errno, dict_t *dict,
+                      dict_t *xdata)
 {
     int ret = 0;
     char *name = cookie;
@@ -40,7 +41,7 @@ selinux_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
                   const char *name, dict_t *xdata)
 {
     selinux_priv_t *priv = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     char *xattr_name = (char *)name;
 
@@ -68,7 +69,8 @@ err:
 
 static int
 selinux_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, dict_t *dict, dict_t *xdata)
+                     gf_return_t op_ret, int op_errno, dict_t *dict,
+                     dict_t *xdata)
 {
     int ret = 0;
     char *name = cookie;
@@ -92,7 +94,7 @@ selinux_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                  const char *name, dict_t *xdata)
 {
     selinux_priv_t *priv = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     char *xattr_name = (char *)name;
 
@@ -119,7 +121,7 @@ err:
 
 static int
 selinux_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, dict_t *xdata)
+                      gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(fsetxattr, frame, op_ret, op_errno, xdata);
     return 0;
@@ -130,7 +132,7 @@ selinux_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
                   int flags, dict_t *xdata)
 {
     selinux_priv_t *priv = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     int32_t ret = -1;
 
@@ -157,7 +159,7 @@ err:
 
 static int
 selinux_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(setxattr, frame, op_ret, op_errno, xdata);
     return 0;
@@ -168,7 +170,7 @@ selinux_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
                  int flags, dict_t *xdata)
 {
     selinux_priv_t *priv = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     int32_t ret = -1;
 

--- a/xlators/features/shard/src/shard.h
+++ b/xlators/features/shard/src/shard.h
@@ -156,7 +156,7 @@ shard_unlock_entrylk(call_frame_t *frame, xlator_t *this);
                                                                                \
         __ret = dict_set_uint64(dict, GF_XATTR_SHARD_FILE_SIZE, 8 * 4);        \
         if (__ret) {                                                           \
-            local->op_ret = -1;                                                \
+            local->op_ret = gf_error;                                          \
             local->op_errno = ENOMEM;                                          \
             gf_msg(this->name, GF_LOG_WARNING, 0, SHARD_MSG_DICT_OP_FAILED,    \
                    "Failed to set dict value:"                                 \
@@ -252,7 +252,7 @@ typedef int32_t (*shard_post_update_size_fop_handler_t)(call_frame_t *frame,
                                                         xlator_t *this);
 
 typedef struct shard_local {
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
     uint64_t first_block;
     uint64_t last_block;

--- a/xlators/features/snapview-client/src/snapview-client.c
+++ b/xlators/features/snapview-client/src/snapview-client.c
@@ -283,7 +283,7 @@ out:
 
 static int32_t
 gf_svc_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     svc_local_t *local = NULL;
@@ -316,7 +316,7 @@ gf_svc_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
        is lost. In this case if nameless lookup fails with ESTALE,
        then send the lookup to the 2nd child of svc.
     */
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         if (subvolume == FIRST_CHILD(this)) {
             gf_smsg(this->name,
                     (op_errno == ENOENT || op_errno == ESTALE) ? GF_LOG_DEBUG
@@ -377,7 +377,7 @@ gf_svc_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     int32_t ret = -1;
     svc_local_t *local = NULL;
     xlator_t *subvolume = NULL;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     inode_t *parent = NULL;
     dict_t *new_xdata = NULL;
@@ -407,7 +407,7 @@ gf_svc_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
     local = mem_get0(this->local_pool);
     if (!local) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, SVC_MSG_NO_MEMORY, NULL);
         goto out;
@@ -501,7 +501,7 @@ gf_svc_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     xlator_t *subvolume = NULL;
     int32_t ret = -1;
     int inode_type = -1;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     svc_private_t *priv = NULL;
@@ -564,7 +564,7 @@ out:
 
 static int32_t
 gf_svc_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                 dict_t *xdata)
 {
     /* TODO: FIX ME
@@ -600,7 +600,7 @@ gf_svc_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     int32_t ret = -1;
     int inode_type = -1;
     xlator_t *subvolume = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -629,7 +629,7 @@ gf_svc_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     int32_t ret = -1;
     int inode_type = -1;
     xlator_t *subvolume = NULL;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -654,7 +654,8 @@ out:
 
 static int32_t
 gf_svc_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   dict_t *xdata)
 {
     svc_fd_t *svc_fd = NULL;
     svc_local_t *local = NULL;
@@ -667,7 +668,7 @@ gf_svc_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_VALIDATE_OR_GOTO("snapview-client", this, out);
     GF_VALIDATE_OR_GOTO(this->name, this->private, out);
 
-    if (op_ret)
+    if (IS_ERROR(op_ret))
         goto out;
 
     priv = this->private;
@@ -725,7 +726,7 @@ gf_svc_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
     int32_t ret = -1;
     int inode_type = -1;
     xlator_t *subvolume = NULL;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     svc_local_t *local = NULL;
@@ -769,7 +770,7 @@ gf_svc_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 {
     int32_t ret = -1;
     int inode_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -780,7 +781,7 @@ gf_svc_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "path=%s", loc->path,
@@ -793,7 +794,7 @@ gf_svc_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                         FIRST_CHILD(this)->fops->setattr, loc, stbuf, valid,
                         xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -814,7 +815,7 @@ gf_svc_fsetattr (call_frame_t *frame, xlator_t *this, fd_t *fd,
 {
         int32_t      ret        = -1;
         int          inode_type = -1;
-        int          op_ret     = -1;
+        gf_return_t  op_ret     = gf_error;
         int          op_errno   = EINVAL;
         gf_boolean_t wind       = _gf_false;
 
@@ -825,7 +826,7 @@ gf_svc_fsetattr (call_frame_t *frame, xlator_t *this, fd_t *fd,
 
         ret = svc_inode_ctx_get (this, fd->inode, &inode_type);
         if (ret < 0) {
-                op_ret = -1;
+                op_ret = gf_error;
                 op_errno = EINVAL;
                 gf_msg (this->name, GF_LOG_ERROR, op_errno,
                         SVC_MSG_GET_INODE_CONTEXT_FAILED, "failed to "
@@ -839,7 +840,7 @@ gf_svc_fsetattr (call_frame_t *frame, xlator_t *this, fd_t *fd,
                                  FIRST_CHILD (this)->fops->fsetattr, fd, stbuf,
                                  valid, xdata);
         } else {
-                op_ret = -1;
+                op_ret = gf_error;
                 op_errno = EROFS;
                 goto out;
         }
@@ -861,7 +862,7 @@ gf_svc_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     int32_t ret = -1;
     int inode_type = -1;
     xlator_t *subvolume = NULL;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     svc_private_t *priv = NULL;
@@ -915,7 +916,7 @@ gf_svc_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
             }
 
             op_errno = 0;
-            op_ret = strlen(entry_point) + 1;
+            SET_RET(op_ret, (strlen(entry_point) + 1));
             /* We should return from here */
             goto out;
         }
@@ -949,7 +950,7 @@ gf_svc_fgetxattr (call_frame_t *frame, xlator_t *this, fd_t *fd,
         int           inode_type = -1;
         xlator_t     *subvolume  = NULL;
         gf_boolean_t  wind       = _gf_false;
-        int           op_ret     = -1;
+        gf_return_t   op_ret     = -1;
         int           op_errno   = EINVAL;
 
         GF_VALIDATE_OR_GOTO ("svc", this, out);
@@ -979,7 +980,7 @@ gf_svc_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
 {
     int32_t ret = -1;
     int inode_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -990,7 +991,7 @@ gf_svc_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "name=%s", loc->name,
@@ -1003,7 +1004,7 @@ gf_svc_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
                         FIRST_CHILD(this)->fops->setxattr, loc, dict, flags,
                         xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1023,7 +1024,7 @@ gf_svc_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
 {
     int32_t ret = -1;
     int inode_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -1034,7 +1035,7 @@ gf_svc_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
 
     ret = svc_inode_ctx_get(this, fd->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -1047,7 +1048,7 @@ gf_svc_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
                         FIRST_CHILD(this)->fops->fsetxattr, fd, dict, flags,
                         xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1067,7 +1068,7 @@ gf_svc_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 {
     int inode_type = -1;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -1078,7 +1079,7 @@ gf_svc_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "name=%s", loc->name,
@@ -1090,7 +1091,7 @@ gf_svc_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->rmdir, loc, flags, xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1105,14 +1106,14 @@ out:
 
 static int32_t
 gf_svc_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
     int inode_type = -1;
     int ret = -1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     inode_type = NORMAL_INODE;
@@ -1133,7 +1134,7 @@ gf_svc_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 {
     int parent_type = -1;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     char entry_point[NAME_MAX + 1] = {
@@ -1147,7 +1148,7 @@ gf_svc_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     ret = svc_inode_ctx_get(this, loc->parent, &parent_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -1165,7 +1166,7 @@ gf_svc_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
         STACK_WIND(frame, gf_svc_mkdir_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->mkdir, loc, mode, umask, xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1181,14 +1182,14 @@ out:
 
 static int32_t
 gf_svc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
     int inode_type = -1;
     int ret = -1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     inode_type = NORMAL_INODE;
@@ -1209,7 +1210,7 @@ gf_svc_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 {
     int parent_type = -1;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     char entry_point[NAME_MAX + 1] = {
@@ -1223,7 +1224,7 @@ gf_svc_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
     ret = svc_inode_ctx_get(this, loc->parent, &parent_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -1242,7 +1243,7 @@ gf_svc_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
                    FIRST_CHILD(this)->fops->mknod, loc, mode, rdev, umask,
                    xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1266,7 +1267,7 @@ gf_svc_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 {
     xlator_t *subvolume = NULL;
     int inode_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     int ret = -1;
     gf_boolean_t wind = _gf_false;
@@ -1286,7 +1287,7 @@ gf_svc_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
     if (((flags & O_ACCMODE) == O_WRONLY) || ((flags & O_ACCMODE) == O_RDWR)) {
         if (subvolume != FIRST_CHILD(this)) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = EINVAL;
             goto out;
         }
@@ -1305,14 +1306,14 @@ out:
 
 static int32_t
 gf_svc_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                  struct iatt *stbuf, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                  inode_t *inode, struct iatt *stbuf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     int inode_type = -1;
     int ret = -1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     inode_type = NORMAL_INODE;
@@ -1334,7 +1335,7 @@ gf_svc_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 {
     int parent_type = -1;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     char entry_point[NAME_MAX + 1] = {
@@ -1349,7 +1350,7 @@ gf_svc_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
 
     ret = svc_inode_ctx_get(this, loc->parent, &parent_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -1368,7 +1369,7 @@ gf_svc_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
                    FIRST_CHILD(this)->fops->create, loc, flags, mode, umask, fd,
                    xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1384,14 +1385,14 @@ out:
 
 static int32_t
 gf_svc_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     int inode_type = -1;
     int ret = -1;
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     inode_type = NORMAL_INODE;
@@ -1412,7 +1413,7 @@ gf_svc_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
                loc_t *loc, mode_t umask, dict_t *xdata)
 {
     int parent_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     int ret = -1;
     gf_boolean_t wind = _gf_false;
@@ -1427,7 +1428,7 @@ gf_svc_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
 
     ret = svc_inode_ctx_get(this, loc->parent, &parent_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -1446,7 +1447,7 @@ gf_svc_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
                    FIRST_CHILD(this)->fops->symlink, linkpath, loc, umask,
                    xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1465,7 +1466,7 @@ gf_svc_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
               dict_t *xdata)
 {
     int inode_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     int ret = -1;
     gf_boolean_t wind = _gf_false;
@@ -1477,7 +1478,7 @@ gf_svc_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -1489,7 +1490,7 @@ gf_svc_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->unlink, loc, flags, xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -1509,7 +1510,7 @@ gf_svc_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     int inode_type = -1;
     xlator_t *subvolume = NULL;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -1540,7 +1541,7 @@ gf_svc_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
     int inode_type = -1;
     xlator_t *subvolume = NULL;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -1571,7 +1572,7 @@ gf_svc_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t mask,
     int ret = -1;
     int inode_type = -1;
     xlator_t *subvolume = NULL;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -1597,7 +1598,7 @@ out:
 
 int32_t
 gf_svc_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                   gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                    dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
@@ -1607,7 +1608,7 @@ gf_svc_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     local = frame->local;
@@ -1653,7 +1654,7 @@ gf_svc_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     xlator_t *subvolume = NULL;
     svc_local_t *local = NULL;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     svc_fd_t *svc_fd = NULL;
@@ -1672,7 +1673,7 @@ gf_svc_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
                 "gfid=%s", uuid_utoa(fd->inode->gfid), NULL);
     else {
         if (svc_fd->entry_point_handled && off == svc_fd->last_offset) {
-            op_ret = 0;
+            op_ret = gf_success;
             op_errno = ENOENT;
             goto out;
         }
@@ -1730,7 +1731,7 @@ out:
 
 static int32_t
 gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                           int32_t op_ret, int32_t op_errno, inode_t *inode,
+                           gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                            struct iatt *buf, dict_t *xdata,
                            struct iatt *postparent)
 {
@@ -1750,7 +1751,7 @@ gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ESTALE && !local->revalidate) {
             local->revalidate = 1;
             ret = gf_svc_special_dir_revalidate_lookup(frame, this, xdata);
@@ -1758,7 +1759,7 @@ gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             if (!ret)
                 return 0;
         }
-        op_ret = 0;
+        op_ret = gf_success;
         op_errno = ENOENT;
         goto out;
     }
@@ -1767,7 +1768,7 @@ gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!svc_fd) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, SVC_MSG_GET_FD_CONTEXT_FAILED,
                 "gfid=%s", uuid_utoa(local->fd->inode->gfid), NULL);
-        op_ret = 0;
+        op_ret = gf_success;
         op_errno = ENOENT;
         goto out;
     }
@@ -1775,7 +1776,7 @@ gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (gf_svc_get_entry_point(this, entry_point, sizeof(entry_point))) {
         gf_smsg(this->name, GF_LOG_WARNING, 0, SVC_MSG_COPY_ENTRY_POINT_FAILED,
                 NULL);
-        op_ret = 0;
+        op_ret = gf_success;
         op_errno = ENOENT;
         goto out;
     }
@@ -1784,7 +1785,7 @@ gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!entry) {
         gf_smsg(this->name, GF_LOG_ERROR, 0, SVC_MSG_NO_MEMORY,
                 "entry-point=%s", entry_point, NULL);
-        op_ret = 0;
+        op_ret = gf_success;
         op_errno = ENOMEM;
         goto out;
     }
@@ -1801,7 +1802,7 @@ gf_svc_readdirp_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 "entry-name=%s", entry->d_name, NULL);
 
     list_add_tail(&entry->list, &entries.list);
-    op_ret = 1;
+    SET_RET(op_ret, 1);
     svc_fd->last_offset = entry->d_off;
     svc_fd->entry_point_handled = _gf_true;
 
@@ -1896,7 +1897,7 @@ out:
 
 static gf_boolean_t
 gf_svc_readdir_on_special_dir(call_frame_t *frame, void *cookie, xlator_t *this,
-                              int32_t op_ret, int32_t op_errno,
+                              gf_return_t op_ret, int32_t op_errno,
                               gf_dirent_t *entries, dict_t *xdata)
 {
     svc_local_t *local = NULL;
@@ -1938,7 +1939,7 @@ gf_svc_readdir_on_special_dir(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!private->show_entry_point)
         goto out;
 
-    if (op_ret == 0 && op_errno == ENOENT && private->special_dir &&
+    if (IS_SUCCESS(op_ret) && op_errno == ENOENT && private->special_dir &&
         strcmp(private->special_dir, "") && svc_fd->special_dir &&
         local->subvolume == FIRST_CHILD(this)) {
         if (gf_svc_get_entry_point(this, entry_point, sizeof(entry_point))) {
@@ -2009,7 +2010,7 @@ out:
 
 static int32_t
 gf_svc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                     dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
@@ -2023,7 +2024,7 @@ gf_svc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         0,
     };
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     GF_VALIDATE_OR_GOTO("snapview-client", this, out);
@@ -2095,7 +2096,7 @@ gf_svc_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     xlator_t *subvolume = NULL;
     svc_local_t *local = NULL;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
     svc_fd_t *svc_fd = NULL;
@@ -2130,7 +2131,7 @@ gf_svc_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
                 "gfid=%s", uuid_utoa(fd->inode->gfid), NULL);
     else {
         if (svc_fd->entry_point_handled && off == svc_fd->last_offset) {
-            op_ret = 0;
+            op_ret = gf_success;
             op_errno = ENOENT;
             goto out;
         }
@@ -2167,7 +2168,7 @@ gf_svc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     int src_inode_type = -1;
     int dst_inode_type = -1;
     int dst_parent_type = -1;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = 0;
     int32_t ret = -1;
     gf_boolean_t wind = _gf_false;
@@ -2180,7 +2181,7 @@ gf_svc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     ret = svc_inode_ctx_get(this, oldloc->inode, &src_inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -2189,7 +2190,7 @@ gf_svc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 
     if (src_inode_type == VIRTUAL_INODE) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_RENAME_SNAPSHOT_ENTRY, "name=%s", oldloc->name, NULL);
@@ -2199,7 +2200,7 @@ gf_svc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     if (newloc->inode) {
         ret = svc_inode_ctx_get(this, newloc->inode, &dst_inode_type);
         if (!ret && dst_inode_type == VIRTUAL_INODE) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = EROFS;
             gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                     SVC_MSG_RENAME_SNAPSHOT_ENTRY, "oldloc-name=%s",
@@ -2211,7 +2212,7 @@ gf_svc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     if (dst_inode_type < 0) {
         ret = svc_inode_ctx_get(this, newloc->parent, &dst_parent_type);
         if (!ret && dst_parent_type == VIRTUAL_INODE) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = EROFS;
             gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                     SVC_MSG_RENAME_SNAPSHOT_ENTRY, "oldloc-name=%s",
@@ -2242,7 +2243,7 @@ gf_svc_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 {
     int src_inode_type = -1;
     int dst_parent_type = -1;
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = 0;
     int32_t ret = -1;
     gf_boolean_t wind = _gf_false;
@@ -2255,7 +2256,7 @@ gf_svc_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     ret = svc_inode_ctx_get(this, oldloc->inode, &src_inode_type);
     if (!ret && src_inode_type == VIRTUAL_INODE) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, SVC_MSG_LINK_SNAPSHOT_ENTRY,
                 "oldloc-name=%s", oldloc->name, NULL);
@@ -2264,7 +2265,7 @@ gf_svc_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
     ret = svc_inode_ctx_get(this, newloc->parent, &dst_parent_type);
     if (!ret && dst_parent_type == VIRTUAL_INODE) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno, SVC_MSG_LINK_SNAPSHOT_ENTRY,
                 "oldloc-name=%s", oldloc->name, "newloc-name=%s", newloc->name,
@@ -2290,7 +2291,7 @@ gf_svc_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 {
     int ret = -1;
     int inode_type = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -2301,7 +2302,7 @@ gf_svc_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     ret = svc_inode_ctx_get(this, loc->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "path=%s", loc->path,
@@ -2313,7 +2314,7 @@ gf_svc_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->removexattr, loc, name, xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -2333,7 +2334,7 @@ gf_svc_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
 {
     int inode_type = -1;
     int ret = -1;
-    int op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int op_errno = EINVAL;
     gf_boolean_t wind = _gf_false;
 
@@ -2344,7 +2345,7 @@ gf_svc_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
 
     ret = svc_inode_ctx_get(this, fd->inode, &inode_type);
     if (ret < 0) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         gf_smsg(this->name, GF_LOG_ERROR, op_errno,
                 SVC_MSG_GET_INODE_CONTEXT_FAILED, "gfid=%s",
@@ -2356,7 +2357,7 @@ gf_svc_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
         STACK_WIND_TAIL(frame, FIRST_CHILD(this),
                         FIRST_CHILD(this)->fops->fsync, fd, datasync, xdata);
     } else {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EROFS;
         goto out;
     }
@@ -2373,7 +2374,7 @@ out:
 static int32_t
 gf_svc_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t op_ret = gf_error;
     int32_t op_errno = 0;
     int ret = -1;
     int inode_type = -1;

--- a/xlators/features/snapview-client/src/snapview-client.h
+++ b/xlators/features/snapview-client/src/snapview-client.h
@@ -47,7 +47,7 @@ typedef struct __svc_local svc_local_t;
             if (!new_xdata) {                                                  \
                 gf_log(this->name, GF_LOG_ERROR,                               \
                        "failed to allocate new dict");                         \
-                op_ret = -1;                                                   \
+                op_ret = gf_error;                                             \
                 op_errno = ENOMEM;                                             \
                 goto label;                                                    \
             }                                                                  \
@@ -55,7 +55,7 @@ typedef struct __svc_local svc_local_t;
         ret = dict_set_str(xdata, "entry-point", "true");                      \
         if (ret) {                                                             \
             gf_log(this->name, GF_LOG_ERROR, "failed to set dict");            \
-            op_ret = -1;                                                       \
+            op_ret = gf_error;                                                 \
             op_errno = ENOMEM;                                                 \
             goto label;                                                        \
         }                                                                      \
@@ -69,7 +69,7 @@ typedef struct __svc_local svc_local_t;
             gf_log(this->name, GF_LOG_ERROR,                                   \
                    "inode context not found for gfid %s",                      \
                    uuid_utoa(inode->gfid));                                    \
-            op_ret = -1;                                                       \
+            op_ret = gf_error;                                                 \
             op_errno = EINVAL;                                                 \
             goto label;                                                        \
         }                                                                      \

--- a/xlators/features/snapview-server/src/snapview-server-mgmt.c
+++ b/xlators/features/snapview-server/src/snapview-server-mgmt.c
@@ -279,7 +279,7 @@ mgmt_get_snapinfo_cbk(struct rpc_req *req, struct iovec *iov, int count,
         goto out;
     }
 
-    if (rsp.op_ret == -1) {
+    if (rsp.op_ret < 0) {
         errno = rsp.op_errno;
         ret = -1;
         goto out;

--- a/xlators/features/snapview-server/src/snapview-server.h
+++ b/xlators/features/snapview-server/src/snapview-server.h
@@ -100,7 +100,7 @@
                        "failed to get the handle for %s "                      \
                        "(gfid: %s)",                                           \
                        loc->path, uuid_utoa_r(loc->inode->gfid, tmp_uuid));    \
-                ret = -1;                                                      \
+                ret = gf_error;                                                \
                 goto label;                                                    \
             }                                                                  \
                                                                                \

--- a/xlators/features/thin-arbiter/src/thin-arbiter.c
+++ b/xlators/features/thin-arbiter/src/thin-arbiter.c
@@ -92,7 +92,7 @@ ta_release_fop(ta_fop_t *fop)
 
 int32_t
 ta_set_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *dict,
+                   gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                    dict_t *xdata)
 {
     TA_STACK_UNWIND(xattrop, frame, op_ret, op_errno, dict, xdata);
@@ -130,14 +130,14 @@ ta_verify_on_disk_source(ta_fop_t *fop, dict_t *dict)
 
 int32_t
 ta_get_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *dict,
+                   gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                    dict_t *xdata)
 {
     ta_fop_t *fop = NULL;
     int ret = 0;
 
     fop = frame->local;
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         goto unwind;
     }
 
@@ -160,7 +160,7 @@ ta_get_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 unwind:
 
-    TA_STACK_UNWIND(xattrop, frame, -1, op_errno, NULL, NULL);
+    TA_STACK_UNWIND(xattrop, frame, gf_error, op_errno, NULL, NULL);
     return -1;
 }
 
@@ -226,7 +226,7 @@ ta_fxattrop(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
 unwind:
 
-    TA_STACK_UNWIND(xattrop, frame, -1, -ret, NULL, NULL);
+    TA_STACK_UNWIND(xattrop, frame, gf_error, -ret, NULL, NULL);
     return 0;
 }
 
@@ -250,7 +250,7 @@ ta_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
 unwind:
 
-    TA_STACK_UNWIND(xattrop, frame, -1, -ret, NULL, NULL);
+    TA_STACK_UNWIND(xattrop, frame, gf_error, -ret, NULL, NULL);
     return 0;
 }
 

--- a/xlators/features/thin-arbiter/src/thin-arbiter.h
+++ b/xlators/features/thin-arbiter/src/thin-arbiter.h
@@ -29,7 +29,7 @@
 #define TA_STACK_UNWIND(fop, frame, op_ret, op_errno, params...)               \
     do {                                                                       \
         ta_fop_t *__local = NULL;                                              \
-        int32_t __op_ret = 0;                                                  \
+        gf_return_t __op_ret = gf_success;                                     \
         int32_t __op_errno = 0;                                                \
                                                                                \
         __local = frame->local;                                                \

--- a/xlators/features/trash/src/trash.c
+++ b/xlators/features/trash/src/trash.c
@@ -20,18 +20,19 @@
 
 int32_t
 trash_truncate_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                          struct iatt *postbuf, dict_t *xdata);
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *prebuf, struct iatt *postbuf,
+                          dict_t *xdata);
 
 int32_t
 trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, inode_t *inode,
+                         gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                          struct iatt *stbuf, struct iatt *preparent,
                          struct iatt *postparent, dict_t *xdata);
 
 int32_t
 trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                        gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                         struct iatt *preoldparent, struct iatt *postoldparent,
                         struct iatt *prenewparent, struct iatt *postnewparent,
                         dict_t *xdata);
@@ -296,7 +297,7 @@ wipe_eliminate_path(trash_elim_path **trav)
  */
 int32_t
 trash_dir_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                      struct iatt *preoldparent, struct iatt *postoldparent,
                      struct iatt *prenewparent, struct iatt *postnewparent,
                      dict_t *xdata)
@@ -308,7 +309,7 @@ trash_dir_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_ERROR,
                "rename trash directory "
                "failed: %s",
@@ -320,7 +321,7 @@ trash_dir_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     priv->oldtrash_dir = gf_strdup(priv->newtrash_dir);
     if (!priv->oldtrash_dir) {
-        op_ret = ENOMEM;
+        SET_RET(op_ret, ENOMEM);
         gf_log(this->name, GF_LOG_DEBUG, "out of memory");
     }
 
@@ -328,7 +329,7 @@ out:
     frame->local = NULL;
     STACK_DESTROY(frame->root);
     trash_local_wipe(local);
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 int
@@ -415,14 +416,15 @@ out:
 
 int32_t
 trash_internal_op_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, inode_t *inode,
-                            struct iatt *buf, struct iatt *preparent,
-                            struct iatt *postparent, dict_t *xdata)
+                            gf_return_t op_ret, int32_t op_errno,
+                            inode_t *inode, struct iatt *buf,
+                            struct iatt *preparent, struct iatt *postparent,
+                            dict_t *xdata)
 {
     trash_local_t *local = NULL;
     local = frame->local;
 
-    if (op_ret != 0 && !(op_errno == EEXIST))
+    if (IS_ERROR(op_ret) && !(op_errno == EEXIST))
         gf_log(this->name, GF_LOG_ERROR,
                "mkdir failed for "
                "internal op directory : %s",
@@ -431,7 +433,7 @@ trash_internal_op_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     STACK_DESTROY(frame->root);
     trash_local_wipe(local);
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 /**
@@ -443,7 +445,7 @@ trash_internal_op_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 trash_dir_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -454,13 +456,13 @@ trash_dir_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         priv->oldtrash_dir = gf_strdup(priv->newtrash_dir);
         if (!priv->oldtrash_dir) {
             gf_log(this->name, GF_LOG_ERROR, "out of memory");
-            op_ret = ENOMEM;
+            SET_RET(op_ret, ENOMEM);
         }
-    } else if (op_ret != 0 && errno != EEXIST)
+    } else if (IS_ERROR(op_ret) && errno != EEXIST)
         gf_log(this->name, GF_LOG_ERROR,
                "mkdir failed for trash"
                " directory : %s",
@@ -469,7 +471,7 @@ trash_dir_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     STACK_DESTROY(frame->root);
     trash_local_wipe(local);
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 /**
@@ -478,7 +480,7 @@ trash_dir_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
  */
 int32_t
 trash_dir_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *dict,
+                       gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                        dict_t *xdata)
 {
     data_t *data = NULL;
@@ -531,7 +533,7 @@ out:
  */
 int32_t
 trash_internalop_dir_lookup_cbk(call_frame_t *frame, void *cookie,
-                                xlator_t *this, int32_t op_ret,
+                                xlator_t *this, gf_return_t op_ret,
                                 int32_t op_errno, inode_t *inode,
                                 struct iatt *buf, dict_t *xdata,
                                 struct iatt *postparent)
@@ -552,7 +554,7 @@ trash_internalop_dir_lookup_cbk(call_frame_t *frame, void *cookie,
     GF_VALIDATE_OR_GOTO("trash", priv, out);
 
     local = frame->local;
-    if (op_ret != 0 && op_errno == ENOENT) {
+    if (IS_ERROR(op_ret) && op_errno == ENOENT) {
         loc_wipe(&local->loc);
         gfid_ptr = GF_MALLOC(sizeof(uuid_t), gf_common_mt_uuid_t);
         if (!gfid_ptr) {
@@ -607,7 +609,7 @@ out:
     frame->local = NULL;
     STACK_DESTROY(frame->root);
     trash_local_wipe(local);
-    return op_ret;
+    return GET_RET(op_ret);
 }
 
 /**
@@ -617,7 +619,7 @@ out:
  */
 int32_t
 trash_dir_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, inode_t *inode,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                      struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     trash_private_t *priv = NULL;
@@ -635,7 +637,7 @@ trash_dir_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
 
     loc_wipe(&local->loc);
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG, "inode found with gfid %s",
                uuid_utoa(buf->ia_gfid));
 
@@ -801,7 +803,7 @@ out:
 
 int32_t
 trash_common_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, inode_t *inode,
+                       gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                        struct iatt *buf, struct iatt *preparent,
                        struct iatt *postparent, dict_t *xdata)
 {
@@ -812,7 +814,7 @@ trash_common_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 trash_common_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                        gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                         struct iatt *preoldparent, struct iatt *postoldparent,
                         struct iatt *prenewparent, struct iatt *postnewparent,
                         dict_t *xdata)
@@ -824,8 +826,9 @@ trash_common_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 trash_common_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, struct iatt *preparent,
-                       struct iatt *postparent, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iatt *preparent, struct iatt *postparent,
+                       dict_t *xdata)
 {
     STACK_UNWIND_STRICT(rmdir, frame, op_ret, op_errno, preparent, postparent,
                         xdata);
@@ -837,7 +840,7 @@ trash_common_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
  */
 int32_t
 trash_common_unwind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno,
+                        gf_return_t op_ret, int32_t op_errno,
                         struct iatt *preparent, struct iatt *postparent,
                         dict_t *xdata)
 {
@@ -853,7 +856,7 @@ trash_common_unwind_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
  */
 int32_t
 trash_unlink_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, inode_t *inode,
+                       gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                        struct iatt *stbuf, struct iatt *preparent,
                        struct iatt *postparent, dict_t *xdata)
 {
@@ -892,7 +895,7 @@ trash_unlink_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     loop_count = local->loop_count;
 
     /* The directory is not present , need to create it */
-    if ((op_ret == -1) && (op_errno == ENOENT)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOENT)) {
         tmp_dirname = strchr(tmp_str, '/');
         while (tmp_dirname) {
             count = tmp_dirname - tmp_str;
@@ -944,7 +947,7 @@ trash_unlink_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* Given path is created , comparing to the required path */
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         dir_name = dirname(tmp_str);
         if (strcmp((char *)cookie, dir_name) == 0) {
             /* File path exists we can rename it*/
@@ -957,7 +960,7 @@ trash_unlink_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    if ((op_ret == -1) && (op_errno != EEXIST)) {
+    if (IS_ERROR((op_ret)) && (op_errno != EEXIST)) {
         gf_log(this->name, GF_LOG_ERROR,
                "Directory creation failed [%s]. "
                "Therefore unlinking %s without moving to trash "
@@ -1037,7 +1040,7 @@ out:
  */
 int32_t
 trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                        gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                         struct iatt *preoldparent, struct iatt *postoldparent,
                         struct iatt *prenewparent, struct iatt *postnewparent,
                         dict_t *xdata)
@@ -1063,7 +1066,7 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if ((op_ret == -1) && (op_errno == ENOENT)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOENT)) {
         /* the file path does not exist we want to create path
          * for the file
          */
@@ -1106,7 +1109,7 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if ((op_ret == -1) && (op_errno == ENOTDIR)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOTDIR)) {
         /* if entry is already present in trash directory,
          * new one is not copied*/
         gf_log(this->name, GF_LOG_DEBUG,
@@ -1119,7 +1122,7 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if ((op_ret == -1) && (op_errno == EISDIR)) {
+    if (IS_ERROR((op_ret)) && (op_errno == EISDIR)) {
         /* if entry is directory,we remove directly */
         gf_log(this->name, GF_LOG_DEBUG,
                "target(%s) exists as directory, cannot keep copy, "
@@ -1172,14 +1175,14 @@ trash_unlink_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                        " GF_RESPONSE_LINK_COUNT_XDATA");
             }
         ctr_out:
-            TRASH_STACK_UNWIND(unlink, frame, 0, op_errno, preoldparent,
-                               postoldparent, new_xdata);
+            TRASH_STACK_UNWIND(unlink, frame, gf_success, op_errno,
+                               preoldparent, postoldparent, new_xdata);
             goto out;
         }
     }
     /* All other cases, unlink should return success */
-    TRASH_STACK_UNWIND(unlink, frame, 0, op_errno, preoldparent, postoldparent,
-                       xdata);
+    TRASH_STACK_UNWIND(unlink, frame, gf_success, op_errno, preoldparent,
+                       postoldparent, xdata);
 out:
 
     if (tmp_str)
@@ -1197,7 +1200,7 @@ out:
  */
 int32_t
 trash_common_unwind_buf_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno,
+                            gf_return_t op_ret, int32_t op_errno,
                             struct iatt *prebuf, struct iatt *postbuf,
                             dict_t *xdata)
 {
@@ -1208,7 +1211,7 @@ trash_common_unwind_buf_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 int32_t
 trash_unlink_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                      gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                       dict_t *xdata)
 {
     trash_private_t *priv = NULL;
@@ -1224,7 +1227,7 @@ trash_unlink_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG, "%s: %s", local->loc.path,
                strerror(op_errno));
         TRASH_STACK_UNWIND(unlink, frame, op_ret, op_errno, buf, NULL, xdata);
@@ -1346,7 +1349,7 @@ trash_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflags,
     local = mem_get0(this->local_pool);
     if (!local) {
         gf_log(this->name, GF_LOG_DEBUG, "out of memory");
-        TRASH_STACK_UNWIND(unlink, frame, -1, ENOMEM, NULL, NULL, xdata);
+        TRASH_STACK_UNWIND(unlink, frame, gf_error, ENOMEM, NULL, NULL, xdata);
         ret = ENOMEM;
         goto out;
     }
@@ -1390,7 +1393,7 @@ out:
  */
 int32_t
 trash_truncate_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno,
+                          gf_return_t op_ret, int32_t op_errno,
                           struct iatt *preparent, struct iatt *postparent,
                           dict_t *xdata)
 {
@@ -1399,7 +1402,7 @@ trash_truncate_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG, "deleting the newly created file: %s",
                strerror(op_errno));
     }
@@ -1416,16 +1419,17 @@ out:
  */
 int32_t
 trash_truncate_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, struct iovec *vector,
-                         int32_t count, struct iatt *stbuf,
-                         struct iobref *iobuf, dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno,
+                         struct iovec *vector, int32_t count,
+                         struct iatt *stbuf, struct iobref *iobuf,
+                         dict_t *xdata)
 {
     trash_local_t *local = NULL;
 
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG,
                "readv on the existing file failed: %s", strerror(op_errno));
 
@@ -1448,15 +1452,16 @@ out:
  */
 int32_t
 trash_truncate_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
-                          struct iatt *postbuf, dict_t *xdata)
+                          gf_return_t op_ret, int32_t op_errno,
+                          struct iatt *prebuf, struct iatt *postbuf,
+                          dict_t *xdata)
 {
     trash_local_t *local = NULL;
 
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Let truncate work, but previous copy is not preserved. */
         gf_log(this->name, GF_LOG_DEBUG,
                "writev on the existing file failed: %s", strerror(op_errno));
@@ -1489,7 +1494,7 @@ out:
  */
 int32_t
 trash_truncate_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, fd_t *fd,
+                        gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                         dict_t *xdata)
 {
     trash_local_t *local = NULL;
@@ -1497,7 +1502,7 @@ trash_truncate_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     local = frame->local;
     GF_VALIDATE_OR_GOTO("trash", local, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Let truncate work, but previous copy is not preserved. */
         gf_log(this->name, GF_LOG_DEBUG, "open on the existing file failed: %s",
                strerror(op_errno));
@@ -1525,7 +1530,7 @@ out:
  */
 int32_t
 trash_truncate_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                          int32_t op_ret, int32_t op_errno, fd_t *fd,
+                          gf_return_t op_ret, int32_t op_errno, fd_t *fd,
                           inode_t *inode, struct iatt *buf,
                           struct iatt *preparent, struct iatt *postparent,
                           dict_t *xdata)
@@ -1554,7 +1559,7 @@ trash_truncate_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     /* Checks whether path is present in trash directory or not */
 
-    if ((op_ret == -1) && (op_errno == ENOENT)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOENT)) {
         /* Creating the directory structure here. */
         tmp_str = gf_strdup(local->newpath);
         if (!tmp_str) {
@@ -1591,7 +1596,7 @@ trash_truncate_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         /* Let truncate work, but previous copy is not preserved.
          * Deleting the newly created copy.
          */
@@ -1631,7 +1636,7 @@ out:
  */
 int32_t
 trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, inode_t *inode,
+                         gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                          struct iatt *stbuf, struct iatt *preparent,
                          struct iatt *postparent, dict_t *xdata)
 {
@@ -1671,7 +1676,7 @@ trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if ((op_ret == -1) && (op_errno == ENOENT)) {
+    if (IS_ERROR((op_ret)) && (op_errno == ENOENT)) {
         tmp_dirname = strchr(tmp_str, '/');
         while (tmp_dirname) {
             count = tmp_dirname - tmp_str;
@@ -1721,7 +1726,7 @@ trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         dir_name = dirname(tmp_str);
         if (strcmp((char *)cookie, dir_name) == 0) {
             flags = O_CREAT | O_EXCL | O_WRONLY;
@@ -1741,7 +1746,7 @@ trash_truncate_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         }
     }
 
-    if ((op_ret == -1) && (op_errno != EEXIST)) {
+    if (IS_ERROR((op_ret)) && (op_errno != EEXIST)) {
         gf_log(this->name, GF_LOG_ERROR,
                "Directory creation failed [%s]. "
                "Therefore truncating %s without moving the "
@@ -1815,7 +1820,7 @@ out:
 
 int32_t
 trash_truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                        gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                         dict_t *xdata)
 {
     trash_private_t *priv = NULL;
@@ -1842,7 +1847,7 @@ trash_truncate_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
     pthread_mutex_unlock(&table->lock);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_log(this->name, GF_LOG_DEBUG, "fstat on the file failed: %s",
                strerror(op_errno));
 
@@ -2007,7 +2012,8 @@ trash_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     local = mem_get0(this->local_pool);
     if (!local) {
         gf_log(this->name, GF_LOG_DEBUG, "out of memory");
-        TRASH_STACK_UNWIND(truncate, frame, -1, ENOMEM, NULL, NULL, xdata);
+        TRASH_STACK_UNWIND(truncate, frame, gf_error, ENOMEM, NULL, NULL,
+                           xdata);
         ret = ENOMEM;
         goto out;
     }
@@ -2095,7 +2101,8 @@ trash_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     local = mem_get0(this->local_pool);
     if (!local) {
         gf_log(this->name, GF_LOG_DEBUG, "out of memory");
-        TRASH_STACK_UNWIND(ftruncate, frame, -1, ENOMEM, NULL, NULL, xdata);
+        TRASH_STACK_UNWIND(ftruncate, frame, gf_error, ENOMEM, NULL, NULL,
+                           xdata);
         ret = -1;
         goto out;
     }
@@ -2129,7 +2136,7 @@ int32_t
 trash_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
             mode_t umask, dict_t *xdata)
 {
-    int32_t op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int32_t op_errno = 0;
     trash_private_t *priv = NULL;
 
@@ -2141,7 +2148,7 @@ trash_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
                "mkdir issued on %s, which is not permitted",
                priv->newtrash_dir);
         op_errno = EPERM;
-        op_ret = -1;
+        op_ret = gf_error;
 
         STACK_UNWIND_STRICT(mkdir, frame, op_ret, op_errno, NULL, NULL, NULL,
                             NULL, xdata);
@@ -2162,7 +2169,7 @@ int
 trash_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
              dict_t *xdata)
 {
-    int32_t op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int32_t op_errno = 0;
     trash_private_t *priv = NULL;
 
@@ -2174,7 +2181,7 @@ trash_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
                "rename issued on %s, which is not permitted",
                priv->newtrash_dir);
         op_errno = EPERM;
-        op_ret = -1;
+        op_ret = gf_error;
 
         STACK_UNWIND_STRICT(rename, frame, op_ret, op_errno, NULL, NULL, NULL,
                             NULL, NULL, xdata);
@@ -2195,7 +2202,7 @@ int32_t
 trash_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
             dict_t *xdata)
 {
-    int32_t op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int32_t op_errno = 0;
     trash_private_t *priv = NULL;
 
@@ -2207,7 +2214,7 @@ trash_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
                "rmdir issued on %s, which is not permitted",
                priv->newtrash_dir);
         op_errno = EPERM;
-        op_ret = -1;
+        op_ret = gf_error;
 
         STACK_UNWIND_STRICT(rmdir, frame, op_ret, op_errno, NULL, NULL, xdata);
     } else {

--- a/xlators/features/upcall/src/upcall.c
+++ b/xlators/features/upcall/src/upcall.c
@@ -28,8 +28,8 @@
 #include <glusterfs/defaults.h>
 
 static int32_t
-up_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, fd_t *fd, dict_t *xdata)
+up_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -40,7 +40,7 @@ up_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR(op_ret) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -74,15 +74,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(open, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(open, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-              dict_t *xdata)
+up_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+              struct iatt *postbuf, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -91,7 +91,7 @@ up_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR(op_ret) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -128,15 +128,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(writev, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(writev, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-             int op_errno, struct iovec *vector, int count, struct iatt *stbuf,
-             struct iobref *iobref, dict_t *xdata)
+up_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int op_errno, struct iovec *vector, int count,
+             struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -147,7 +147,7 @@ up_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR(op_ret) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -182,13 +182,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(readv, frame, -1, op_errno, NULL, 0, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(readv, frame, gf_error, op_errno, NULL, 0, NULL, NULL,
+                        NULL);
 
     return 0;
 }
 
 static int32_t
-up_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
+up_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, gf_return_t op_ret,
           int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
 {
     client_t *client = NULL;
@@ -200,7 +201,7 @@ up_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -233,15 +234,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(lk, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(lk, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, struct iatt *prebuf, struct iatt *postbuf,
-                dict_t *xdata)
+up_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, struct iatt *prebuf,
+                struct iatt *postbuf, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -252,7 +253,7 @@ up_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -287,15 +288,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(truncate, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(truncate, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-               int op_errno, struct iatt *statpre, struct iatt *statpost,
-               dict_t *xdata)
+up_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+               gf_return_t op_ret, int op_errno, struct iatt *statpre,
+               struct iatt *statpost, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -306,7 +307,7 @@ up_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     /* XXX: setattr -> UP_SIZE or UP_OWN or UP_MODE or UP_TIMES
@@ -355,16 +356,17 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(setattr, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(setattr, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *stbuf, struct iatt *preoldparent,
-              struct iatt *postoldparent, struct iatt *prenewparent,
-              struct iatt *postnewparent, dict_t *xdata)
+up_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
+              struct iatt *preoldparent, struct iatt *postoldparent,
+              struct iatt *prenewparent, struct iatt *postnewparent,
+              dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -375,7 +377,7 @@ up_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = (UP_RENAME_FLAGS | UP_PARENT_DENTRY_FLAGS);
@@ -423,16 +425,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    UPCALL_STACK_UNWIND(rename, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, struct iatt *preparent, struct iatt *postparent,
-              dict_t *xdata)
+up_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, struct iatt *preparent,
+              struct iatt *postparent, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -443,7 +445,7 @@ up_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = (UP_NLINK_FLAGS | UP_PARENT_DENTRY_FLAGS);
@@ -482,15 +484,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(unlink, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(unlink, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-            int op_errno, inode_t *inode, struct iatt *stbuf,
-            struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+up_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int op_errno, inode_t *inode,
+            struct iatt *stbuf, struct iatt *preparent, struct iatt *postparent,
+            dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -501,7 +504,7 @@ up_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = (UP_NLINK_FLAGS | UP_PARENT_DENTRY_FLAGS);
@@ -540,16 +543,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    UPCALL_STACK_UNWIND(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                         NULL);
 
     return 0;
 }
 
 static int32_t
-up_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-             int op_errno, struct iatt *preparent, struct iatt *postparent,
-             dict_t *xdata)
+up_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int op_errno, struct iatt *preparent,
+             struct iatt *postparent, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -560,7 +563,7 @@ up_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -600,15 +603,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(rmdir, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(rmdir, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-             int op_errno, inode_t *inode, struct iatt *stbuf,
-             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+up_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int op_errno, inode_t *inode,
+             struct iatt *stbuf, struct iatt *preparent,
+             struct iatt *postparent, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -619,7 +623,7 @@ up_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -660,16 +664,17 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    UPCALL_STACK_UNWIND(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, fd_t *fd, inode_t *inode, struct iatt *stbuf,
-              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+up_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, fd_t *fd, inode_t *inode,
+              struct iatt *stbuf, struct iatt *preparent,
+              struct iatt *postparent, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -680,7 +685,7 @@ up_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -724,16 +729,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(create, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    UPCALL_STACK_UNWIND(create, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, inode_t *inode, struct iatt *stbuf, dict_t *xattr,
-              struct iatt *postparent)
+up_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, inode_t *inode,
+              struct iatt *stbuf, dict_t *xattr, struct iatt *postparent)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -744,7 +749,7 @@ up_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -778,14 +783,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL);
 
     return 0;
 }
 
 static int32_t
-up_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, struct iatt *buf, dict_t *xdata)
+up_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+            dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -796,7 +803,7 @@ up_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -829,7 +836,7 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(stat, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(stat, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -854,7 +861,7 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(fstat, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(fstat, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -880,14 +887,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(ftruncate, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(ftruncate, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-              int op_errno, dict_t *xdata)
+up_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -898,7 +905,7 @@ up_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -932,15 +939,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(access, frame, -1, op_errno, NULL);
+    UPCALL_STACK_UNWIND(access, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 static int32_t
-up_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, const char *path, struct iatt *stbuf,
-                dict_t *xdata)
+up_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, const char *path,
+                struct iatt *stbuf, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -951,7 +958,7 @@ up_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -985,15 +992,16 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(readlink, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(readlink, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, inode_t *inode, struct iatt *buf,
-             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+up_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+             struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+             dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1004,7 +1012,7 @@ up_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1045,15 +1053,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    UPCALL_STACK_UNWIND(mknod, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *buf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -1066,7 +1074,7 @@ up_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1107,15 +1115,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(symlink, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    UPCALL_STACK_UNWIND(symlink, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1126,7 +1134,7 @@ up_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1160,14 +1168,15 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(opendir, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(opendir, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct statvfs *buf, dict_t *xdata)
+up_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
+              dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1178,7 +1187,7 @@ up_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1211,14 +1220,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(statfs, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(statfs, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+               gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                dict_t *xdata)
 {
     client_t *client = NULL;
@@ -1230,7 +1239,7 @@ up_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1264,14 +1273,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(readdir, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(readdir, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                 dict_t *xdata)
 {
     client_t *client = NULL;
@@ -1284,7 +1293,7 @@ up_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1327,7 +1336,7 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(readdirp, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(readdirp, frame, gf_error, op_errno, NULL, NULL);
 
     return 0;
 }
@@ -1353,14 +1362,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(fsetattr, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(fsetattr, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                  struct iatt *post, dict_t *xdata)
 {
     client_t *client = NULL;
@@ -1372,7 +1381,7 @@ up_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -1407,14 +1416,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(fallocate, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(fallocate, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *pre,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                struct iatt *post, dict_t *xdata)
 {
     client_t *client = NULL;
@@ -1426,7 +1435,7 @@ up_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -1460,14 +1469,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(discard, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(discard, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
 up_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                 struct iatt *post, dict_t *xdata)
 {
     client_t *client = NULL;
@@ -1479,7 +1488,7 @@ up_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_WRITE_FLAGS;
@@ -1513,14 +1522,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(zerofill, frame, -1, op_errno, NULL, NULL, NULL);
+    UPCALL_STACK_UNWIND(zerofill, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 static int32_t
-up_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-            int op_errno, off_t offset, dict_t *xdata)
+up_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int op_errno, off_t offset, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1531,7 +1540,7 @@ up_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_UPDATE_CLIENT;
@@ -1565,14 +1574,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(seek, frame, -1, op_errno, 0, NULL);
+    UPCALL_STACK_UNWIND(seek, frame, gf_error, op_errno, 0, NULL);
 
     return 0;
 }
 
 static int32_t
 up_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1591,7 +1600,7 @@ up_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1599,7 +1608,7 @@ up_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
     if (ret < 0) {
-        op_ret = ret;
+        SET_RET(op_ret, ret);
         goto out;
     }
     if (!up_invalidate_needed(local->xattr))
@@ -1639,14 +1648,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(setxattr, frame, -1, op_errno, NULL);
+    UPCALL_STACK_UNWIND(setxattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 static int32_t
 up_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1665,7 +1674,7 @@ up_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1673,7 +1682,7 @@ up_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
     if (ret < 0) {
-        op_ret = ret;
+        SET_RET(op_ret, ret);
         goto out;
     }
     if (!up_invalidate_needed(local->xattr))
@@ -1713,14 +1722,14 @@ out:
     return 0;
 
 err:
-    UPCALL_STACK_UNWIND(fsetxattr, frame, -1, op_errno, NULL);
+    UPCALL_STACK_UNWIND(fsetxattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 static int32_t
 up_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1739,14 +1748,14 @@ up_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_XATTR_RM;
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
     if (ret < 0) {
-        op_ret = ret;
+        SET_RET(op_ret, ret);
         goto out;
     }
     if (!up_invalidate_needed(local->xattr))
@@ -1796,14 +1805,14 @@ err:
     if (xattr)
         dict_unref(xattr);
 
-    UPCALL_STACK_UNWIND(fremovexattr, frame, -1, op_errno, NULL);
+    UPCALL_STACK_UNWIND(fremovexattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 static int32_t
 up_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1822,14 +1831,14 @@ up_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
     flags = UP_XATTR_RM;
 
     ret = up_filter_xattr(local->xattr, priv->xattrs);
     if (ret < 0) {
-        op_ret = ret;
+        SET_RET(op_ret, ret);
         goto out;
     }
     if (!up_invalidate_needed(local->xattr))
@@ -1879,14 +1888,15 @@ err:
     if (xattr)
         dict_unref(xattr);
 
-    UPCALL_STACK_UNWIND(removexattr, frame, -1, op_errno, NULL);
+    UPCALL_STACK_UNWIND(removexattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
 
 static int32_t
 up_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                 dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1897,7 +1907,7 @@ up_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1929,13 +1939,14 @@ out:
                FIRST_CHILD(this)->fops->fgetxattr, fd, name, xdata);
     return 0;
 err:
-    UPCALL_STACK_UNWIND(fgetxattr, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(fgetxattr, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
 static int32_t
 up_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                dict_t *xdata)
 {
     client_t *client = NULL;
     uint32_t flags = 0;
@@ -1946,7 +1957,7 @@ up_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -1978,7 +1989,7 @@ out:
                FIRST_CHILD(this)->fops->getxattr, loc, name, xdata);
     return 0;
 err:
-    UPCALL_STACK_UNWIND(getxattr, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(getxattr, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
@@ -2011,7 +2022,8 @@ err:
  */
 static int32_t
 up_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+               dict_t *xdata)
 {
     client_t *client = NULL;
     upcall_local_t *local = NULL;
@@ -2021,7 +2033,7 @@ up_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     client = frame->root->client;
     local = frame->local;
 
-    if ((op_ret < 0) || !local) {
+    if (IS_ERROR((op_ret)) || !local) {
         goto out;
     }
 
@@ -2071,7 +2083,7 @@ out:
                FIRST_CHILD(this)->fops->xattrop, loc, optype, xattr, xdata);
     return 0;
 err:
-    UPCALL_STACK_UNWIND(xattrop, frame, -1, op_errno, NULL, NULL);
+    UPCALL_STACK_UNWIND(xattrop, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
@@ -2105,7 +2117,7 @@ out:
                FIRST_CHILD(this)->fops->fxattrop, fd, optype, xattr, xdata);
     return 0;
 err:
-    STACK_UNWIND_STRICT(fxattrop, frame, -1, op_errno, NULL, NULL);
+    STACK_UNWIND_STRICT(fxattrop, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
@@ -2188,6 +2200,7 @@ up_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
 {
     upcall_private_t *priv = NULL;
     int ret = 0;
+    gf_return_t op_ret;
 
     priv = this->private;
     GF_VALIDATE_OR_GOTO(this->name, priv, out);
@@ -2205,7 +2218,8 @@ up_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
     }
 
 out:
-    STACK_UNWIND_STRICT(ipc, frame, ret, 0, NULL);
+    SET_RET(op_ret, ret);
+    STACK_UNWIND_STRICT(ipc, frame, op_ret, 0, NULL);
     return 0;
 
 wind:

--- a/xlators/features/utime/src/utime-gen-fops-c.py
+++ b/xlators/features/utime/src/utime-gen-fops-c.py
@@ -26,7 +26,7 @@ gf_utime_@NAME@ (call_frame_t *frame, xlator_t *this,
 FOPS_CBK_COMMON_TEMPLATE = """
 int32_t
 gf_utime_@NAME@_cbk (call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno,
+                     gf_return_t op_ret, int32_t op_errno,
                     @LONG_ARGS@)
 {
         STACK_UNWIND_STRICT (@NAME@, frame, op_ret, op_errno, @SHORT_ARGS@);

--- a/xlators/lib/src/libxlator.h
+++ b/xlators/lib/src/libxlator.h
@@ -27,9 +27,9 @@
 #define MARKER_UUID_TYPE 1
 #define MARKER_XTIME_TYPE 2
 
-typedef int32_t (*xlator_specf_unwind_t)(call_frame_t *frame, int op_ret,
-                                         int op_errno, dict_t *dict,
-                                         dict_t *xdata);
+typedef int32_t (*xlator_specf_unwind_t)(call_frame_t *frame,
+                                         gf_return_t op_ret, int op_errno,
+                                         dict_t *dict, dict_t *xdata);
 
 struct volume_mark {
     uint8_t major;
@@ -122,11 +122,13 @@ typedef struct marker_str xl_marker_local_t;
 
 int32_t
 cluster_markerxtime_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int op_ret, int op_errno, dict_t *dict, dict_t *xdata);
+                        gf_return_t op_ret, int op_errno, dict_t *dict,
+                        dict_t *xdata);
 
 int32_t
 cluster_markeruuid_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, dict_t *dict, dict_t *xdata);
+                       gf_return_t op_ret, int op_errno, dict_t *dict,
+                       dict_t *xdata);
 
 int
 cluster_handle_marker_getxattr(call_frame_t *frame, loc_t *loc,

--- a/xlators/meta/src/meta-helpers.c
+++ b/xlators/meta/src/meta-helpers.c
@@ -241,7 +241,7 @@ meta_inode_discover(call_frame_t *frame, xlator_t *this, loc_t *loc,
 
     meta_iatt_fill(&iatt, loc->inode, loc->inode->ia_type);
 
-    META_STACK_UNWIND(lookup, frame, 0, 0, loc->inode, &iatt, xdata,
+    META_STACK_UNWIND(lookup, frame, gf_success, 0, loc->inode, &iatt, xdata,
                       &postparent);
     return 0;
 }

--- a/xlators/meta/src/meta.c
+++ b/xlators/meta/src/meta.c
@@ -30,8 +30,8 @@ meta_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         meta_iatt_fill(&iatt, loc->inode, IA_IFDIR);
         gf_uuid_parse(META_ROOT_GFID, iatt.ia_gfid);
 
-        META_STACK_UNWIND(lookup, frame, 0, 0, loc->inode, &iatt, xdata,
-                          &parent);
+        META_STACK_UNWIND(lookup, frame, gf_success, 0, loc->inode, &iatt,
+                          xdata, &parent);
         return 0;
     }
 

--- a/xlators/mgmt/glusterd/src/glusterd-handler.c
+++ b/xlators/mgmt/glusterd/src/glusterd-handler.c
@@ -5409,7 +5409,7 @@ glusterd_print_client_details(FILE *fp, dict_t *dict,
     GD_SYNCOP(rpc, (&args), NULL, gd_syncop_brick_op_cbk, brick_req,
               &gd_brick_prog, brick_req->op, xdr_gd1_mgmt_brick_op_req);
 
-    if (args.op_ret)
+    if (IS_ERROR(args.op_ret))
         goto out;
 
     ret = dict_get_int32n(args.dict, "clientcount", SLEN("clientcount"),

--- a/xlators/mgmt/glusterd/src/glusterd-mgmt.c
+++ b/xlators/mgmt/glusterd/src/glusterd-mgmt.c
@@ -49,7 +49,7 @@ gd_mgmt_v3_collate_errors(struct syncargs *args, int op_ret, int op_errno,
     GF_ASSERT(uuid);
 
     if (op_ret) {
-        args->op_ret = op_ret;
+        SET_RET(args->op_ret, op_ret);
         args->op_errno = op_errno;
 
         RCU_READ_LOCK;
@@ -754,7 +754,7 @@ glusterd_mgmt_v3_initiate_lockdown(glusterd_op_t op, dict_t *dict,
     if (args.errstr)
         *op_errstr = gf_strdup(args.errstr);
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
     *op_errno = args.op_errno;
 
     gf_msg_debug(this->name, 0,
@@ -1108,7 +1108,7 @@ glusterd_mgmt_v3_pre_validate(glusterd_op_t op, dict_t *req_dict,
 
     gd_synctask_barrier_wait((&args), peer_cnt);
 
-    if (args.op_ret) {
+    if (IS_ERROR(args.op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_PRE_VALIDATION_FAIL,
                "Pre Validation failed on peers");
 
@@ -1116,7 +1116,7 @@ glusterd_mgmt_v3_pre_validate(glusterd_op_t op, dict_t *req_dict,
             *op_errstr = gf_strdup(args.errstr);
     }
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
     *op_errno = args.op_errno;
 
     gf_msg_debug(this->name, 0,
@@ -1461,7 +1461,7 @@ glusterd_mgmt_v3_brick_op(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
 
     gd_synctask_barrier_wait((&args), peer_cnt);
 
-    if (args.op_ret) {
+    if (IS_ERROR(args.op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_BRICK_OP_FAIL,
                "Brick ops failed on peers");
 
@@ -1469,7 +1469,7 @@ glusterd_mgmt_v3_brick_op(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
             *op_errstr = gf_strdup(args.errstr);
     }
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
 
     gf_msg_debug(this->name, 0,
                  "Sent brick op req for %s "
@@ -1745,7 +1745,7 @@ glusterd_mgmt_v3_commit(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
 
     gd_synctask_barrier_wait((&args), peer_cnt);
 
-    if (args.op_ret) {
+    if (IS_ERROR(args.op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_COMMIT_OP_FAIL,
                "Commit failed on peers");
 
@@ -1753,7 +1753,7 @@ glusterd_mgmt_v3_commit(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
             *op_errstr = gf_strdup(args.errstr);
     }
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
     *op_errno = args.op_errno;
 
     gf_msg_debug(this->name, 0,
@@ -2013,7 +2013,7 @@ glusterd_mgmt_v3_post_commit(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
 
     gd_synctask_barrier_wait((&args), peer_cnt);
 
-    if (args.op_ret) {
+    if (IS_ERROR(args.op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_POST_COMMIT_OP_FAIL,
                "Post commit failed on peers");
 
@@ -2021,7 +2021,7 @@ glusterd_mgmt_v3_post_commit(glusterd_op_t op, dict_t *op_ctx, dict_t *req_dict,
             *op_errstr = gf_strdup(args.errstr);
     }
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
     *op_errno = args.op_errno;
 
     gf_msg_debug(this->name, 0,
@@ -2242,7 +2242,7 @@ glusterd_mgmt_v3_post_validate(glusterd_op_t op, int32_t op_ret, dict_t *dict,
 
     gd_synctask_barrier_wait((&args), peer_cnt);
 
-    if (args.op_ret) {
+    if (IS_ERROR(args.op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_POST_VALIDATION_FAIL,
                "Post Validation failed on peers");
 
@@ -2250,7 +2250,7 @@ glusterd_mgmt_v3_post_validate(glusterd_op_t op, int32_t op_ret, dict_t *dict,
             *op_errstr = gf_strdup(args.errstr);
     }
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
 
     gf_msg_debug(this->name, 0,
                  "Sent post valaidation req for %s "
@@ -2431,7 +2431,7 @@ glusterd_mgmt_v3_release_peer_locks(glusterd_op_t op, dict_t *dict,
 
     gd_synctask_barrier_wait((&args), peer_cnt);
 
-    if (args.op_ret) {
+    if (IS_ERROR(args.op_ret)) {
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_MGMTV3_UNLOCK_FAIL,
                "Unlock failed on peers");
 
@@ -2439,7 +2439,7 @@ glusterd_mgmt_v3_release_peer_locks(glusterd_op_t op, dict_t *dict,
             *op_errstr = gf_strdup(args.errstr);
     }
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
 
     gf_msg_debug(this->name, 0,
                  "Sent unlock op req for %s "

--- a/xlators/mgmt/glusterd/src/glusterd-snapshot.c
+++ b/xlators/mgmt/glusterd/src/glusterd-snapshot.c
@@ -6502,7 +6502,7 @@ glusterd_take_brick_snapshot_cbk(int ret, call_frame_t *frame, void *opaque)
     args = snap_args->args;
 
     if (ret)
-        args->op_ret = ret;
+        SET_RET(args->op_ret, ret);
 
     GF_FREE(opaque);
     synctask_barrier_wake(args);
@@ -6616,11 +6616,11 @@ glusterd_schedule_brick_snapshot(dict_t *dict, dict_t *rsp_dict,
     synctask_barrier_wait((&args), taskcount);
     taskcount = 0;
 
-    if (args.op_ret)
+    if (IS_ERROR(args.op_ret))
         gf_msg(this->name, GF_LOG_ERROR, 0, GD_MSG_SNAP_CREATION_FAIL,
                "Failed to create snapshot");
 
-    ret = args.op_ret;
+    ret = GET_RET(args.op_ret);
 out:
     if (ret && taskcount)
         synctask_barrier_wait((&args), taskcount);

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.c
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.c
@@ -2663,7 +2663,7 @@ static volgen_brick_xlator_t server_graph_table[] = {
     {brick_graph_add_posix, "posix"},
 };
 
-static glusterd_server_xlator_t
+static gf_xlator_list_t
 get_server_xlator(char *xlator)
 {
     int i = 0;

--- a/xlators/mgmt/glusterd/src/glusterd-volgen.h
+++ b/xlators/mgmt/glusterd/src/glusterd-volgen.h
@@ -115,21 +115,6 @@ typedef enum gd_volopt_flags_ {
     VOLOPT_FLAG_NEVER_RESET = 0x08, /* option which should not be reset */
 } gd_volopt_flags_t;
 
-typedef enum {
-    GF_XLATOR_POSIX = 0,
-    GF_XLATOR_ACL,
-    GF_XLATOR_LOCKS,
-    GF_XLATOR_LEASES,
-    GF_XLATOR_UPCALL,
-    GF_XLATOR_IOT,
-    GF_XLATOR_INDEX,
-    GF_XLATOR_MARKER,
-    GF_XLATOR_IO_STATS,
-    GF_XLATOR_BD,
-    GF_XLATOR_SERVER,
-    GF_XLATOR_NONE,
-} glusterd_server_xlator_t;
-
 /* As of now debug xlators can be loaded only below fuse in the client
  * graph via cli. More xlators can be added below when the cli option
  * for adding debug xlators anywhere in the client graph has to be made

--- a/xlators/mount/fuse/src/fuse-bridge.c
+++ b/xlators/mount/fuse/src/fuse-bridge.c
@@ -986,7 +986,7 @@ send_fuse_err(xlator_t *this, fuse_in_header_t *finh, int error)
 
 static int
 fuse_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *buf, dict_t *xdata)
 {
     fuse_state_t *state = NULL;
@@ -1002,7 +1002,7 @@ fuse_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     state = frame->root->state;
     finh = state->finh;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         if (__is_root_gfid(state->loc.inode->gfid))
             buf->ia_ino = 1;
         if (gf_uuid_is_null(buf->ia_gfid)) {
@@ -1012,7 +1012,7 @@ fuse_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
             */
             gf_log("glusterfs-fuse", GF_LOG_WARNING,
                    "Received NULL gfid for %s. Forcing EIO", state->loc.path);
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = EIO;
         }
     }
@@ -1020,15 +1020,15 @@ fuse_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     /* log into the event-history after the null uuid check is done, since
      * the op_ret and op_errno are being changed if the gfid is NULL.
      */
-    fuse_log_eh(
-        this,
-        "op_ret: %d op_errno: %d "
-        "%" PRIu64 ": %s() %s => %s",
-        op_ret, op_errno, frame->root->unique, gf_fop_list[frame->root->op],
-        state->loc.path,
-        (op_ret == 0) ? uuid_utoa(buf->ia_gfid) : uuid_utoa(state->loc.gfid));
+    fuse_log_eh(this,
+                "op_ret: %d op_errno: %d "
+                "%" PRIu64 ": %s() %s => %s",
+                GET_RET(op_ret), op_errno, frame->root->unique,
+                gf_fop_list[frame->root->op], state->loc.path,
+                (IS_SUCCESS(op_ret)) ? uuid_utoa(buf->ia_gfid)
+                                     : uuid_utoa(state->loc.gfid));
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE,
                "%" PRIu64 ": %s() %s => %" PRIu64, frame->root->unique,
                gf_fop_list[frame->root->op], state->loc.path, buf->ia_ino);
@@ -1091,7 +1091,7 @@ fuse_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int
 fuse_newentry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
@@ -1105,7 +1105,7 @@ fuse_newentry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int
 fuse_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *stat, dict_t *dict, struct iatt *postparent)
 {
     fuse_state_t *state = NULL;
@@ -1115,7 +1115,7 @@ fuse_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     state = frame->root->state;
     prev = cookie;
 
-    if (op_ret == -1 && state->is_revalidate == 1) {
+    if (IS_ERROR(op_ret) && state->is_revalidate == 1) {
         itable = state->itable;
         /*
          * A stale mapping might exist for a dentry/inode that has been
@@ -1147,7 +1147,7 @@ fuse_fop_resume(fuse_state_t *state)
     /*
      * Fail fd resolution failures right away.
      */
-    if (state->resolve.fd && state->resolve.op_ret < 0) {
+    if (state->resolve.fd && IS_ERROR(state->resolve.op_ret)) {
         send_fuse_err(state->this, state->finh, state->resolve.op_errno);
         free_fuse_state(state);
         return;
@@ -1171,8 +1171,9 @@ fuse_lookup_resume(fuse_state_t *state)
     /* parent was resolved, entry could not, may be a missing gfid?
      * Hence try to do a regular lookup
      */
-    if ((state->resolve.op_ret == -1) && (state->resolve.op_errno == ENODATA)) {
-        state->resolve.op_ret = 0;
+    if (IS_ERROR(state->resolve.op_ret) &&
+        (state->resolve.op_errno == ENODATA)) {
+        state->resolve.op_ret = gf_success;
     }
 
     if (state->loc.inode) {
@@ -1265,7 +1266,7 @@ fuse_batch_forget(xlator_t *this, fuse_in_header_t *finh, void *msg,
 
 static int
 fuse_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     fuse_state_t *state;
@@ -1279,7 +1280,7 @@ fuse_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE,
                "%" PRIu64 ": %s() %s => %" PRIu64, frame->root->unique,
                gf_fop_list[frame->root->op],
@@ -1319,12 +1320,13 @@ fuse_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int
 fuse_root_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, inode_t *inode,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                      struct iatt *stat, dict_t *dict, struct iatt *postparent);
 
 static int
-fuse_attr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *buf, dict_t *xdata)
+fuse_attr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+              dict_t *xdata)
 {
     int32_t ret = 0;
     fuse_state_t *state;
@@ -1340,10 +1342,10 @@ fuse_attr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
                 "op_ret: %d, op_errno: %d, %" PRIu64
                 ": %s() %s => "
                 "gfid: %s",
-                op_ret, op_errno, frame->root->unique,
+                GET_RET(op_ret), op_errno, frame->root->unique,
                 gf_fop_list[frame->root->op], state->loc.path,
                 state->loc.inode ? uuid_utoa(state->loc.inode->gfid) : "");
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE,
                "%" PRIu64 ": %s() %s => %" PRIu64, frame->root->unique,
                gf_fop_list[frame->root->op],
@@ -1413,7 +1415,7 @@ fuse_attr_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
 static int
 fuse_root_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, inode_t *inode,
+                     gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                      struct iatt *stat, dict_t *dict, struct iatt *postparent)
 {
     fuse_attr_cbk(frame, cookie, this, op_ret, op_errno, stat, dict);
@@ -1554,8 +1556,8 @@ direct_io_mode(dict_t *xdata)
 }
 
 static int
-fuse_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-            int32_t op_errno, fd_t *fd, dict_t *xdata)
+fuse_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+            gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     fuse_state_t *state = NULL;
     fuse_in_header_t *finh = NULL;
@@ -1571,7 +1573,7 @@ fuse_fd_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         foo.fh = (uintptr_t)fd;
         foo.open_flags = 0;
 
@@ -1667,7 +1669,7 @@ fuse_do_truncate(fuse_state_t *state)
 
 static int
 fuse_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                  struct iatt *statpost, dict_t *xdata)
 {
     fuse_state_t *state;
@@ -1685,11 +1687,11 @@ fuse_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 "op_ret: %d, op_errno: %d, %" PRIu64
                 ", %s() %s => "
                 "gfid: %s",
-                op_ret, op_errno, frame->root->unique,
+                GET_RET(op_ret), op_errno, frame->root->unique,
                 gf_fop_list[frame->root->op], state->loc.path,
                 state->loc.inode ? uuid_utoa(state->loc.inode->gfid) : "");
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE,
                "%" PRIu64 ": %s() %s => %" PRIu64, frame->root->unique,
                gf_fop_list[frame->root->op],
@@ -1905,7 +1907,7 @@ fuse_setattr(xlator_t *this, fuse_in_header_t *finh, void *msg,
 
 static int
 fuse_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     fuse_state_t *state = NULL;
     fuse_in_header_t *finh = NULL;
@@ -1918,7 +1920,7 @@ fuse_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE, "%" PRIu64 ": %s() %s => 0",
                frame->root->unique, gf_fop_list[frame->root->op],
                state->loc.path ? state->loc.path : "ERR");
@@ -1945,15 +1947,15 @@ fuse_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 }
 
 static int
-fuse_err_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, dict_t *xdata)
+fuse_err_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     fuse_state_t *state = frame->root->state;
     fuse_in_header_t *finh = state->finh;
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE, "%" PRIu64 ": %s() %s => 0",
                frame->root->unique, gf_fop_list[frame->root->op],
                state->loc.path ? state->loc.path : "ERR");
@@ -1983,7 +1985,7 @@ fuse_err_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
 static int
 fuse_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     fuse_private_t *priv = this->private;
 
@@ -1998,7 +2000,7 @@ fuse_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int
 fuse_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                struct iatt *postbuf, dict_t *xdata)
 {
     return fuse_err_cbk(frame, cookie, this, op_ret, op_errno, xdata);
@@ -2006,9 +2008,9 @@ fuse_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int
 fuse_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
-    if (op_ret == -1 && op_errno == ENOTSUP)
+    if (IS_ERROR(op_ret) && op_errno == ENOTSUP)
         GF_LOG_OCCASIONALLY(gf_fuse_xattr_enotsup_log, "glusterfs-fuse",
                             GF_LOG_CRITICAL,
                             "extended attribute not supported "
@@ -2019,7 +2021,7 @@ fuse_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int
 fuse_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
     fuse_state_t *state = NULL;
@@ -2032,11 +2034,11 @@ fuse_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 "op_ret: %d, op_errno: %d, %" PRIu64
                 ": %s() %s => "
                 "gfid: %s",
-                op_ret, op_errno, frame->root->unique,
+                GET_RET(op_ret), op_errno, frame->root->unique,
                 gf_fop_list[frame->root->op], state->loc.path,
                 state->loc.inode ? uuid_utoa(state->loc.inode->gfid) : "");
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         inode_unlink(state->loc.inode, state->loc.parent, state->loc.name);
         gf_log("glusterfs-fuse", GF_LOG_TRACE, "%" PRIu64 ": %s() %s => 0",
                frame->root->unique, gf_fop_list[frame->root->op],
@@ -2106,7 +2108,7 @@ fuse_access(xlator_t *this, fuse_in_header_t *finh, void *msg,
 
 static int
 fuse_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, const char *linkname,
+                  gf_return_t op_ret, int32_t op_errno, const char *linkname,
                   struct iatt *buf, dict_t *xdata)
 {
     fuse_state_t *state = NULL;
@@ -2119,15 +2121,15 @@ fuse_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                 "op_ret: %d, op_errno: %d %" PRIu64
                 ": %s() => %s"
                 " linkname: %s, gfid: %s",
-                op_ret, op_errno, frame->root->unique,
+                GET_RET(op_ret), op_errno, frame->root->unique,
                 gf_fop_list[frame->root->op], state->loc.gfid, linkname,
                 uuid_utoa(state->loc.gfid));
 
-    if (op_ret > 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE,
                "%" PRIu64 ": %s => %s (size:%d)", frame->root->unique,
-               state->loc.path, linkname, op_ret);
-        send_fuse_data(this, finh, (void *)linkname, op_ret);
+               state->loc.path, linkname, GET_RET(op_ret));
+        send_fuse_data(this, finh, (void *)linkname, GET_RET(op_ret));
     } else {
         /* facilitate retry from VFS */
         if (op_errno == ENOENT)
@@ -2204,7 +2206,7 @@ fuse_mknod_resume(fuse_state_t *state)
     }
 
     if (state->resolve.op_errno == ENOENT) {
-        state->resolve.op_ret = 0;
+        state->resolve.op_ret = gf_success;
         state->resolve.op_errno = 0;
     }
 
@@ -2277,7 +2279,7 @@ fuse_mkdir_resume(fuse_state_t *state)
     }
 
     if (state->resolve.op_errno == ENOENT) {
-        state->resolve.op_ret = 0;
+        state->resolve.op_ret = gf_success;
         state->resolve.op_errno = 0;
     }
 
@@ -2417,7 +2419,7 @@ fuse_symlink_resume(fuse_state_t *state)
     }
 
     if (state->resolve.op_errno == ENOENT) {
-        state->resolve.op_ret = 0;
+        state->resolve.op_ret = gf_success;
         state->resolve.op_errno = 0;
     }
 
@@ -2459,7 +2461,7 @@ fuse_symlink(xlator_t *this, fuse_in_header_t *finh, void *msg,
 
 int
 fuse_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                 struct iatt *preoldparent, struct iatt *postoldparent,
                 struct iatt *prenewparent, struct iatt *postnewparent,
                 dict_t *xdata)
@@ -2477,8 +2479,8 @@ fuse_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         ": %s() "
         "path: %s parent: %s ==> path: %s parent: %s"
         "gfid: %s",
-        op_ret, op_errno, frame->root->unique, gf_fop_list[frame->root->op],
-        state->loc.path,
+        GET_RET(op_ret), op_errno, frame->root->unique,
+        gf_fop_list[frame->root->op], state->loc.path,
         (state->loc.parent ? uuid_utoa_r(state->loc.parent->gfid, loc_uuid_str)
                            : ""),
         state->loc2.path,
@@ -2489,7 +2491,7 @@ fuse_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     /* need to check for loc->parent to keep clang-scan happy.
        It gets dereferenced below, and is checked for NULL above. */
-    if ((op_ret == 0) && (state->loc.parent) && (state->loc.inode)) {
+    if ((IS_SUCCESS(op_ret)) && (state->loc.parent) && (state->loc.inode)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE,
                "%" PRIu64 ": %s -> %s => 0 (buf->ia_ino=%" PRIu64 ")",
                frame->root->unique, state->loc.path, state->loc2.path,
@@ -2560,8 +2562,8 @@ fuse_rename_resume(fuse_state_t *state)
         return;
     }
 
-    state->resolve.op_ret = 0;
-    state->resolve2.op_ret = 0;
+    state->resolve.op_ret = gf_success;
+    state->resolve2.op_ret = gf_success;
 
     gf_log("glusterfs-fuse", GF_LOG_TRACE,
            "%" PRIu64 ": RENAME `%s (%s)' -> `%s (%s)'", state->finh->unique,
@@ -2608,8 +2610,8 @@ fuse_link_resume(fuse_state_t *state)
         return;
     }
 
-    state->resolve.op_ret = 0;
-    state->resolve2.op_ret = 0;
+    state->resolve.op_ret = gf_success;
+    state->resolve2.op_ret = gf_success;
 
     if (state->loc.inode) {
         inode_unref(state->loc.inode);
@@ -2645,7 +2647,7 @@ fuse_link(xlator_t *this, fuse_in_header_t *finh, void *msg,
 
 static int
 fuse_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -2672,7 +2674,7 @@ fuse_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         foo.fh = (uintptr_t)fd;
 
         if (((priv->direct_io_mode == 2) &&
@@ -2776,7 +2778,7 @@ fuse_create_resume(fuse_state_t *state)
     }
 
     if (state->resolve.op_errno == ENOENT) {
-        state->resolve.op_ret = 0;
+        state->resolve.op_ret = gf_success;
         state->resolve.op_errno = 0;
     }
 
@@ -2933,7 +2935,7 @@ fuse_open(xlator_t *this, fuse_in_header_t *finh, void *msg,
 
 static int
 fuse_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iovec *vector,
+               gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                int32_t count, struct iatt *stbuf, struct iobref *iobref,
                dict_t *xdata)
 {
@@ -2949,10 +2951,10 @@ fuse_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE,
                "%" PRIu64 ": READ => %d/%" GF_PRI_SIZET ",%" PRId64 "/%" PRIu64,
-               frame->root->unique, op_ret, state->size, state->off,
+               frame->root->unique, GET_RET(op_ret), state->size, state->off,
                stbuf->ia_size);
 
         iov_out = GF_CALLOC(count + 1, sizeof(*iov_out), gf_fuse_mt_iovec);
@@ -2967,7 +2969,7 @@ fuse_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     } else {
         gf_log("glusterfs-fuse", GF_LOG_WARNING,
                "%" PRIu64 ": READ => %d gfid=%s fd=%p (%s)",
-               frame->root->unique, op_ret,
+               frame->root->unique, GET_RET(op_ret),
                (state->fd && state->fd->inode)
                    ? uuid_utoa(state->fd->inode->gfid)
                    : "nil",
@@ -3030,7 +3032,7 @@ fuse_readv(xlator_t *this, fuse_in_header_t *finh, void *msg,
 
 static int
 fuse_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                 struct iatt *postbuf, dict_t *xdata)
 {
     fuse_state_t *state = NULL;
@@ -3044,14 +3046,14 @@ fuse_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE,
                "%" PRIu64 ": WRITE => %d/%" GF_PRI_SIZET ",%" PRId64
                "/%" PRIu64,
-               frame->root->unique, op_ret, state->size, state->off,
+               frame->root->unique, GET_RET(op_ret), state->size, state->off,
                stbuf->ia_size);
 
-        fwo.size = op_ret;
+        fwo.size = GET_RET(op_ret);
         send_fuse_obj(this, finh, &fwo);
     } else {
         gf_log(
@@ -3153,9 +3155,9 @@ fuse_write(xlator_t *this, fuse_in_header_t *finh, void *msg,
 #if FUSE_KERNEL_MINOR_VERSION >= 28
 static int
 fuse_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                         int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
-                         struct iatt *prebuf_dst, struct iatt *postbuf_dst,
-                         dict_t *xdata)
+                         gf_return_t op_ret, int32_t op_errno,
+                         struct iatt *stbuf, struct iatt *prebuf_dst,
+                         struct iatt *postbuf_dst, dict_t *xdata)
 {
     fuse_state_t *state = NULL;
     fuse_in_header_t *finh = NULL;
@@ -3178,14 +3180,14 @@ fuse_copy_file_range_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE,
                "%" PRIu64 ": WRITE => %d/%" GF_PRI_SIZET ",%" PRIu64
                " , %" PRIu64 " ,%" PRIu64 ",%" PRIu64,
-               frame->root->unique, op_ret, state->size, state->off_in,
+               frame->root->unique, GET_RET(op_ret), state->size, state->off_in,
                state->off_out, stbuf->ia_size, postbuf_dst->ia_size);
 
-        fcfro.size = op_ret;
+        fcfro.size = GET_RET(op_ret);
         send_fuse_obj(this, finh, &fcfro);
     } else {
         if (state->fd && state->fd->inode)
@@ -3266,7 +3268,8 @@ fuse_copy_file_range(xlator_t *this, fuse_in_header_t *finh, void *msg,
 #if FUSE_KERNEL_MINOR_VERSION >= 24 && HAVE_SEEK_HOLE
 static int
 fuse_lseek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, off_t offset,
+               dict_t *xdata)
 {
     fuse_state_t *state = frame->root->state;
     fuse_in_header_t *finh = state->finh;
@@ -3276,7 +3279,7 @@ fuse_lseek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         flo.offset = offset;
         send_fuse_obj(this, finh, &flo);
     } else {
@@ -3578,7 +3581,7 @@ d_type_from_stat(struct iatt *buf)
 
 static int
 fuse_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                 gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                  dict_t *xdata)
 {
     fuse_state_t *state = NULL;
@@ -3596,7 +3599,7 @@ fuse_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_WARNING,
                "%" PRIu64 ": READDIR => -1 (%s)", frame->root->unique,
                strerror(op_errno));
@@ -3607,7 +3610,7 @@ fuse_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     gf_log("glusterfs-fuse", GF_LOG_TRACE,
            "%" PRIu64 ": READDIR => %d/%" GF_PRI_SIZET ",%" PRId64,
-           frame->root->unique, op_ret, state->size, state->off);
+           frame->root->unique, GET_RET(op_ret), state->size, state->off);
 
     list_for_each_entry(entry, &entries->list, list)
     {
@@ -3694,7 +3697,7 @@ fuse_readdir(xlator_t *this, fuse_in_header_t *finh, void *msg,
 #if FUSE_KERNEL_MINOR_VERSION >= 20
 static int
 fuse_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                  gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                   dict_t *xdata)
 {
     fuse_state_t *state = NULL;
@@ -3711,7 +3714,7 @@ fuse_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     finh = state->finh;
     priv = this->private;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_WARNING,
                "%" PRIu64 ": READDIRP => -1 (%s)", frame->root->unique,
                strerror(op_errno));
@@ -3722,7 +3725,7 @@ fuse_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     gf_log("glusterfs-fuse", GF_LOG_TRACE,
            "%" PRIu64 ": READDIRP => %d/%" GF_PRI_SIZET ",%" PRId64,
-           frame->root->unique, op_ret, state->size, state->off);
+           frame->root->unique, GET_RET(op_ret), state->size, state->off);
 
     list_for_each_entry(entry, &entries->list, list)
     {
@@ -3854,7 +3857,7 @@ fuse_readdirp(xlator_t *this, fuse_in_header_t *finh, void *msg,
 #ifdef FALLOC_FL_KEEP_SIZE
 static int
 fuse_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     return fuse_err_cbk(frame, cookie, this, op_ret, op_errno, xdata);
@@ -3964,7 +3967,7 @@ fuse_fsyncdir(xlator_t *this, fuse_in_header_t *finh, void *msg,
 
 static int
 fuse_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                 dict_t *xdata)
 {
     fuse_state_t *state = NULL;
@@ -3980,10 +3983,11 @@ fuse_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     priv = this->private;
     finh = state->finh;
 
-    fuse_log_eh(this, "op_ret: %d, op_errno: %d, %" PRIu64 ": %s()", op_ret,
-                op_errno, frame->root->unique, gf_fop_list[frame->root->op]);
+    fuse_log_eh(this, "op_ret: %d, op_errno: %d, %" PRIu64 ": %s()",
+                GET_RET(op_ret), op_errno, frame->root->unique,
+                gf_fop_list[frame->root->op]);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         fso.st.bsize = buf->f_bsize;
         fso.st.frsize = buf->f_frsize;
         fso.st.blocks = buf->f_blocks;
@@ -4264,7 +4268,8 @@ fuse_filter_xattr(char *key)
 
 static int
 fuse_xattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+               dict_t *xdata)
 {
     char *value = "";
     fuse_state_t *state = NULL;
@@ -4279,10 +4284,10 @@ fuse_xattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE, "%" PRIu64 ": %s() %s => %d",
                frame->root->unique, gf_fop_list[frame->root->op],
-               state->loc.path, op_ret);
+               state->loc.path, GET_RET(op_ret));
 
         /* if successful */
         if (state->name) {
@@ -4644,7 +4649,7 @@ static int gf_fuse_lk_enosys_log;
 
 static int
 fuse_getlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+               gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                dict_t *xdata)
 {
     fuse_state_t *state = NULL;
@@ -4658,7 +4663,7 @@ fuse_getlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE, "%" PRIu64 ": ERR => 0",
                frame->root->unique);
         flo.lk.type = lock->l_type;
@@ -4730,7 +4735,7 @@ fuse_getlk(xlator_t *this, fuse_in_header_t *finh, void *msg,
 
 static int
 fuse_setlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct gf_flock *lock,
+               gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
                dict_t *xdata)
 {
     uint32_t op = 0;
@@ -4750,7 +4755,7 @@ fuse_setlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     fuse_log_eh_fop(this, state, frame, op_ret, op_errno);
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         gf_log("glusterfs-fuse", GF_LOG_TRACE, "%" PRIu64 ": ERR => 0",
                frame->root->unique);
         fd_lk_insert_and_merge(state->fd,
@@ -4792,13 +4797,13 @@ fuse_setlk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 static int
 fuse_setlk_interrupt_handler_cbk(call_frame_t *frame, void *cookie,
-                                 xlator_t *this, int32_t op_ret,
+                                 xlator_t *this, gf_return_t op_ret,
                                  int32_t op_errno, dict_t *dict, dict_t *xdata)
 {
     fuse_interrupt_state_t intstat = INTERRUPT_NONE;
     fuse_interrupt_record_t *fir = cookie;
 
-    intstat = op_ret >= 0 ? INTERRUPT_HANDLED : INTERRUPT_SQUELCHED;
+    intstat = IS_SUCCESS(op_ret) ? INTERRUPT_HANDLED : INTERRUPT_SQUELCHED;
 
     fuse_interrupt_finish_interrupt(this, fir, intstat, _gf_true, NULL);
 

--- a/xlators/mount/fuse/src/fuse-bridge.h
+++ b/xlators/mount/fuse/src/fuse-bridge.h
@@ -371,14 +371,14 @@ typedef struct fuse_graph_switch_args fuse_graph_switch_args_t;
                 gf_log_eh(                                                     \
                     "op_ret: %d, op_errno: %d, "                               \
                     "%" PRIu64 ", %s () => %p, gfid: %s",                      \
-                    op_ret, op_errno, frame->root->unique,                     \
+                    GET_RET(op_ret), op_errno, frame->root->unique,            \
                     gf_fop_list[frame->root->op], state->fd,                   \
                     uuid_utoa(state->fd->inode->gfid));                        \
             else                                                               \
                 gf_log_eh(                                                     \
                     "op_ret: %d, op_errno: %d, "                               \
                     "%" PRIu64 ", %s () => %s, gfid: %s",                      \
-                    op_ret, op_errno, frame->root->unique,                     \
+                    GET_RET(op_ret), op_errno, frame->root->unique,            \
                     gf_fop_list[frame->root->op], state->loc.path,             \
                     uuid_utoa(state->loc.gfid));                               \
         }                                                                      \
@@ -418,7 +418,7 @@ typedef struct {
     inode_t *hint;
     u_char pargfid[16];
     inode_t *parhint;
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
     loc_t resolve_loc;
 } fuse_resolve_t;

--- a/xlators/nfs/server/src/acl3.c
+++ b/xlators/nfs/server/src/acl3.c
@@ -257,7 +257,8 @@ acl3_setacl_reply(rpcsvc_request_t *req, setaclreply *reply)
  */
 int
 acl3_getacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *dict, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *dict,
+                dict_t *xdata)
 {
     nfsstat3 stat = NFS3ERR_SERVERFAULT;
     nfs3_call_state_t *cs = NULL;
@@ -273,7 +274,7 @@ acl3_getacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
     cs = frame->local;
     getaclreply = &cs->args.getaclreply;
-    if ((op_ret < 0) && (op_errno != ENODATA && op_errno != ENOATTR)) {
+    if (IS_ERROR(op_ret) && (op_errno != ENODATA && op_errno != ENOATTR)) {
         stat = nfs3_cbk_errno_status(op_ret, op_errno);
         goto err;
     } else if (!dict) {
@@ -321,7 +322,7 @@ err:
  */
 int
 acl3_default_getacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *dict,
+                        gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                         dict_t *xdata)
 {
     nfsstat3 stat = NFS3ERR_SERVERFAULT;
@@ -342,7 +343,7 @@ acl3_default_getacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
     cs = frame->local;
     getaclreply = &cs->args.getaclreply;
-    if ((op_ret < 0) && (op_errno != ENODATA && op_errno != ENOATTR)) {
+    if (IS_ERROR(op_ret) && (op_errno != ENODATA && op_errno != ENOATTR)) {
         stat = nfs3_cbk_errno_status(op_ret, op_errno);
         goto err;
     } else if (!dict) {
@@ -389,8 +390,9 @@ err:
 }
 
 int
-acl3_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *buf, dict_t *xdata)
+acl3_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+              dict_t *xdata)
 {
     nfsstat3 stat = NFS3ERR_SERVERFAULT;
     nfs3_call_state_t *cs = NULL;
@@ -410,7 +412,7 @@ acl3_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     cs = frame->local;
     getaclreply = &cs->args.getaclreply;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         stat = nfs3_cbk_errno_status(op_ret, op_errno);
         goto err;
     }
@@ -538,11 +540,11 @@ rpcerr:
 
 int
 acl3_setacl_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     nfs3_call_state_t *cs = NULL;
     cs = frame->local;
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         nfsstat3 status = nfs3_cbk_errno_status(op_ret, op_errno);
         cs->args.setaclreply.status = status;
     }

--- a/xlators/nfs/server/src/nfs-fops.c
+++ b/xlators/nfs/server/src/nfs-fops.c
@@ -265,7 +265,7 @@ err:
 #define nfs_fop_restore_root_ino(locl, fopret, preattr, postattr, prepar,      \
                                  postpar)                                      \
     do {                                                                       \
-        if (fopret == -1)                                                      \
+        if (IS_ERROR(fopret))                                                  \
             break;                                                             \
         if ((locl)->rootinode) {                                               \
             if ((preattr)) {                                                   \
@@ -302,7 +302,7 @@ err:
 #define nfs_fop_newloc_restore_root_ino(locl, fopret, preattr, postattr,       \
                                         prepar, postpar)                       \
     do {                                                                       \
-        if (fopret == -1)                                                      \
+        if (IS_ERROR(fopret))                                                  \
             break;                                                             \
                                                                                \
         if ((locl)->newrootinode) {                                            \
@@ -397,13 +397,13 @@ nfs_gfid_dict(inode_t *inode)
 
 int32_t
 nfs_fop_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, dict_t *xattr, struct iatt *postparent)
 {
     struct nfs_fop_local *local = NULL;
     fop_lookup_cbk_t progcbk;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         nfs_fix_generation(this, inode);
     }
 
@@ -449,7 +449,7 @@ err:
 
 int32_t
 nfs_fop_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_access_cbk_t progcbk = NULL;
@@ -494,7 +494,7 @@ err:
 
 int32_t
 nfs_fop_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                  dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -539,7 +539,7 @@ err:
 
 int32_t
 nfs_fop_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                   dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -585,7 +585,8 @@ err:
 
 int32_t
 nfs_fop_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                    dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_opendir_cbk_t progcbk = NULL;
@@ -627,7 +628,7 @@ err:
 
 int
 nfs_fop_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_flush_cbk_t progcbk = NULL;
@@ -668,7 +669,7 @@ err:
 
 int32_t
 nfs_fop_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                     gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                      dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -714,7 +715,7 @@ err:
 
 int32_t
 nfs_fop_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                    dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -757,14 +758,14 @@ err:
 
 int32_t
 nfs_fop_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                   struct iatt *buf, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   inode_t *inode, struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_create_cbk_t progcbk = NULL;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         nfs_fix_generation(this, inode);
     }
 
@@ -811,7 +812,7 @@ err:
 
 int32_t
 nfs_fop_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                     struct iatt *post, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -856,14 +857,14 @@ err:
 
 int32_t
 nfs_fop_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_mkdir_cbk_t progcbk = NULL;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         nfs_fix_generation(this, inode);
     }
 
@@ -907,14 +908,14 @@ err:
 
 int32_t
 nfs_fop_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_symlink_cbk_t progcbk = NULL;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         nfs_fix_generation(this, inode);
     }
 
@@ -958,7 +959,7 @@ err:
 
 int32_t
 nfs_fop_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, const char *path,
+                     gf_return_t op_ret, int32_t op_errno, const char *path,
                      struct iatt *buf, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -1002,14 +1003,14 @@ err:
 
 int32_t
 nfs_fop_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *buf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_mknod_cbk_t progcbk = NULL;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         nfs_fix_generation(this, inode);
     }
 
@@ -1053,7 +1054,7 @@ err:
 
 int32_t
 nfs_fop_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = frame->local;
@@ -1098,7 +1099,7 @@ err:
 
 int32_t
 nfs_fop_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = frame->local;
@@ -1143,14 +1144,14 @@ err:
 
 int32_t
 nfs_fop_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *buf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_link_cbk_t progcbk = NULL;
 
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         nfs_fix_generation(this, inode);
     }
 
@@ -1194,7 +1195,7 @@ err:
 
 int32_t
 nfs_fop_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                    struct iatt *preoldparent, struct iatt *postoldparent,
                    struct iatt *prenewparent, struct iatt *postnewparent,
                    dict_t *xdata)
@@ -1249,7 +1250,7 @@ err:
 
 int32_t
 nfs_fop_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_open_cbk_t progcbk = NULL;
@@ -1291,7 +1292,7 @@ err:
 
 int32_t
 nfs_fop_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                    struct iatt *postbuf, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -1360,7 +1361,7 @@ err:
 
 int32_t
 nfs_fop_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -1404,7 +1405,7 @@ err:
 
 int32_t
 nfs_fop_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                  gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                   int32_t count, struct iatt *stbuf, struct iobref *iobref,
                   dict_t *xdata)
 {
@@ -1450,7 +1451,7 @@ err:
 
 int32_t
 nfs_fop_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct gf_flock *flock,
+               gf_return_t op_ret, int32_t op_errno, struct gf_flock *flock,
                dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -1458,7 +1459,7 @@ nfs_fop_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     nfl_to_prog_data(nfl, progcbk, frame);
 
-    if (!op_ret)
+    if (IS_SUCCESS(op_ret))
         fd_lk_insert_and_merge(nfl->fd, nfl->cmd, &nfl->flock);
 
     fd_unref(nfl->fd);
@@ -1502,7 +1503,7 @@ err:
 
 int32_t
 nfs_fop_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
@@ -1545,7 +1546,7 @@ err:
 
 int32_t
 nfs_fop_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_setxattr_cbk_t progcbk = NULL;
@@ -1588,7 +1589,7 @@ err:
 
 int32_t
 nfs_fop_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;

--- a/xlators/nfs/server/src/nfs-inodes.c
+++ b/xlators/nfs/server/src/nfs-inodes.c
@@ -52,15 +52,15 @@ nfl_inodes_init(struct nfs_fop_local *nfl, inode_t *inode, inode_t *parent,
 
 int32_t
 nfs_inode_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                     struct iatt *buf, struct iatt *preparent,
+                     gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                     inode_t *inode, struct iatt *buf, struct iatt *preparent,
                      struct iatt *postparent, dict_t *xdata)
 {
     struct nfs_fop_local *nfl = frame->local;
     fop_create_cbk_t progcbk = NULL;
     inode_t *linked_inode = NULL;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     linked_inode = inode_link(inode, nfl->parent, nfl->path, buf);
@@ -122,7 +122,7 @@ err:
 
 int32_t
 nfs_inode_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -130,7 +130,7 @@ nfs_inode_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop_mkdir_cbk_t progcbk = NULL;
     inode_t *linked_inode = NULL;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     linked_inode = inode_link(inode, nfl->parent, nfl->path, buf);
@@ -172,12 +172,13 @@ err:
 
 int32_t
 nfs_inode_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_open_cbk_t progcbk = NULL;
 
-    if ((op_ret == -1) && (fd))
+    if ((IS_ERROR(op_ret)) && (fd))
         fd_unref(fd);
     /* Not needed here since the fd is cached in higher layers and the bind
      * must happen atomically when the fd gets added to the fd LRU.
@@ -229,7 +230,7 @@ err:
 
 int32_t
 nfs_inode_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *buf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                      struct iatt *preoldparent, struct iatt *postoldparent,
                      struct iatt *prenewparent, struct iatt *postnewparent,
                      dict_t *xdata)
@@ -238,7 +239,7 @@ nfs_inode_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop_rename_cbk_t progcbk = NULL;
 
     nfl = frame->local;
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     inode_rename(this->itable, nfl->parent, nfl->path, nfl->newparent,
@@ -277,7 +278,7 @@ err:
 
 int32_t
 nfs_inode_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *buf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -285,7 +286,7 @@ nfs_inode_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fop_link_cbk_t progcbk = NULL;
     inode_t *linked_inode = NULL;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     nfl = frame->local;
@@ -328,15 +329,16 @@ err:
 
 int32_t
 nfs_inode_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *preparent,
-                     struct iatt *postparent, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno,
+                     struct iatt *preparent, struct iatt *postparent,
+                     dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_unlink_cbk_t progcbk = NULL;
 
     nfl = frame->local;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_unlink;
 
     inode_unlink(nfl->inode, nfl->parent, nfl->path);
@@ -374,15 +376,16 @@ err:
 
 int32_t
 nfs_inode_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *preparent,
-                    struct iatt *postparent, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno,
+                    struct iatt *preparent, struct iatt *postparent,
+                    dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_rmdir_cbk_t progcbk = NULL;
 
     nfl = frame->local;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_unlink;
 
     inode_unlink(nfl->inode, nfl->parent, nfl->path);
@@ -421,7 +424,7 @@ err:
 
 int32_t
 nfs_inode_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, inode_t *inode,
+                    gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                     struct iatt *buf, struct iatt *preparent,
                     struct iatt *postparent, dict_t *xdata)
 {
@@ -431,7 +434,7 @@ nfs_inode_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     nfl = frame->local;
 
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     linked_inode = inode_link(inode, nfl->parent, nfl->path, buf);
@@ -476,7 +479,7 @@ err:
 
 int32_t
 nfs_inode_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, inode_t *inode,
+                      gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                       struct iatt *buf, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata)
 {
@@ -485,7 +488,7 @@ nfs_inode_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     inode_t *linked_inode = NULL;
 
     nfl = frame->local;
-    if (op_ret == -1)
+    if (IS_ERROR(op_ret))
         goto do_not_link;
 
     linked_inode = inode_link(inode, nfl->parent, nfl->path, buf);
@@ -529,12 +532,13 @@ err:
 
 int32_t
 nfs_inode_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                      gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                      dict_t *xdata)
 {
     struct nfs_fop_local *nfl = NULL;
     fop_open_cbk_t progcbk = NULL;
 
-    if (op_ret != -1)
+    if (IS_SUCCESS(op_ret))
         fd_bind(fd);
 
     inodes_nfl_to_prog_data(nfl, progcbk, frame);

--- a/xlators/nfs/server/src/nfs.c
+++ b/xlators/nfs/server/src/nfs.c
@@ -469,11 +469,11 @@ unlock:
 
 int32_t
 nfs_start_subvol_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                            int32_t op_ret, int32_t op_errno, inode_t *inode,
-                            struct iatt *buf, dict_t *xattr,
+                            gf_return_t op_ret, int32_t op_errno,
+                            inode_t *inode, struct iatt *buf, dict_t *xattr,
                             struct iatt *postparent)
 {
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(GF_NFS, GF_LOG_CRITICAL, op_errno, NFS_MSG_LOOKUP_ROOT_FAIL,
                "Failed to lookup root: %s", strerror(op_errno));
         goto err;

--- a/xlators/nfs/server/src/nfs3-helpers.c
+++ b/xlators/nfs/server/src/nfs3-helpers.c
@@ -251,9 +251,9 @@ nfs3_errno_to_nfsstat3(int errnum)
  * happens by any means, then set NFS3 status to NFS3ERR_SERVERFAULT.
  */
 nfsstat3
-nfs3_cbk_errno_status(int32_t op_ret, int32_t op_errno)
+nfs3_cbk_errno_status(gf_return_t op_ret, int32_t op_errno)
 {
-    if ((op_ret == -1) && (op_errno == 0)) {
+    if (IS_ERROR(op_ret) && (op_errno == 0)) {
         return NFS3ERR_SERVERFAULT;
     }
 
@@ -3522,7 +3522,7 @@ err:
 
 int32_t
 nfs3_fh_resolve_entry_lookup_cbk(call_frame_t *frame, void *cookie,
-                                 xlator_t *this, int32_t op_ret,
+                                 xlator_t *this, gf_return_t op_ret,
                                  int32_t op_errno, inode_t *inode,
                                  struct iatt *buf, dict_t *xattr,
                                  struct iatt *postparent)
@@ -3531,10 +3531,10 @@ nfs3_fh_resolve_entry_lookup_cbk(call_frame_t *frame, void *cookie,
     inode_t *linked_inode = NULL;
 
     cs = frame->local;
-    cs->resolve_ret = op_ret;
+    cs->resolve_ret = GET_RET(op_ret);
     cs->resolve_errno = op_errno;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ENOENT) {
             gf_msg_trace(GF_NFS3, 0, "Lookup failed: %s: %s",
                          cs->resolvedloc.path, strerror(op_errno));
@@ -3570,7 +3570,7 @@ err:
 
 int32_t
 nfs3_fh_resolve_inode_lookup_cbk(call_frame_t *frame, void *cookie,
-                                 xlator_t *this, int32_t op_ret,
+                                 xlator_t *this, gf_return_t op_ret,
                                  int32_t op_errno, inode_t *inode,
                                  struct iatt *buf, dict_t *xattr,
                                  struct iatt *postparent)
@@ -3579,10 +3579,10 @@ nfs3_fh_resolve_inode_lookup_cbk(call_frame_t *frame, void *cookie,
     inode_t *linked_inode = NULL;
 
     cs = frame->local;
-    cs->resolve_ret = op_ret;
+    cs->resolve_ret = GET_RET(op_ret);
     cs->resolve_errno = op_errno;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ENOENT) {
             gf_msg_trace(GF_NFS3, 0, "Lookup failed: %s: %s",
                          cs->resolvedloc.path, strerror(op_errno));
@@ -3778,7 +3778,7 @@ err_resume_call:
 
 int32_t
 nfs3_fh_resolve_root_lookup_cbk(call_frame_t *frame, void *cookie,
-                                xlator_t *this, int32_t op_ret,
+                                xlator_t *this, gf_return_t op_ret,
                                 int32_t op_errno, inode_t *inode,
                                 struct iatt *buf, dict_t *xattr,
                                 struct iatt *postparent)
@@ -3786,10 +3786,10 @@ nfs3_fh_resolve_root_lookup_cbk(call_frame_t *frame, void *cookie,
     nfs3_call_state_t *cs = NULL;
 
     cs = frame->local;
-    cs->resolve_ret = op_ret;
+    cs->resolve_ret = GET_RET(op_ret);
     cs->resolve_errno = op_errno;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(GF_NFS3, GF_LOG_ERROR, op_errno, NFS_MSG_LOOKUP_ROOT_FAIL,
                "Root lookup failed: %s", strerror(op_errno));
         goto err;

--- a/xlators/nfs/server/src/nfs3-helpers.h
+++ b/xlators/nfs/server/src/nfs3-helpers.h
@@ -30,7 +30,7 @@ nfs3_extract_lookup_name(lookup3args *args);
 extern nfsstat3
 nfs3_errno_to_nfsstat3(int errnum);
 
-extern nfsstat3 nfs3_cbk_errno_status(int32_t, int32_t);
+extern nfsstat3 nfs3_cbk_errno_status(gf_return_t, int32_t);
 
 extern void
 nfs3_fill_lookup3res(lookup3res *res, nfsstat3 stat, struct nfs3_fh *newfh,

--- a/xlators/nfs/server/src/nlm4.c
+++ b/xlators/nfs/server/src/nlm4.c
@@ -523,13 +523,14 @@ typedef int (*nlm4_resume_fn_t)(void *cs);
 
 int32_t
 nlm4_file_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   dict_t *xdata)
 {
     nfs3_call_state_t *cs = frame->local;
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         fd_bind(cs->fd);
-    cs->resolve_ret = op_ret;
+    cs->resolve_ret = GET_RET(op_ret);
     cs->resume_fn(cs);
 
     frame->local = NULL;
@@ -779,14 +780,14 @@ nlm4_test_reply(nfs3_call_state_t *cs, nlm4_stats stat, struct gf_flock *flock)
 
 int
 nlm4svc_test_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct gf_flock *flock,
+                 gf_return_t op_ret, int32_t op_errno, struct gf_flock *flock,
                  dict_t *xdata)
 {
     nlm4_stats stat = nlm4_denied;
     nfs3_call_state_t *cs = NULL;
 
     cs = frame->local;
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         stat = nlm4_errno_to_nlm4stat(op_errno);
         goto err;
     } else if (flock->l_type == F_UNLCK)
@@ -1390,7 +1391,7 @@ ret:
 
 int
 nlm4svc_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct gf_flock *flock,
+                 gf_return_t op_ret, int32_t op_errno, struct gf_flock *flock,
                  dict_t *xdata)
 {
     nlm4_stats stat = nlm4_denied;
@@ -1404,7 +1405,7 @@ nlm4svc_lock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     caller_name = cs->args.nlm4_lockargs.alock.caller_name;
     transit_cnt = nlm_dec_transit_count(cs->fd, caller_name);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (transit_cnt == 0)
             nlm_search_and_delete(cs->fd, &cs->args.nlm4_lockargs.alock);
         stat = nlm4_errno_to_nlm4stat(op_errno);
@@ -1594,14 +1595,14 @@ nlm4svc_nm_lock(rpcsvc_request_t *req)
 
 int
 nlm4svc_cancel_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct gf_flock *flock,
+                   gf_return_t op_ret, int32_t op_errno, struct gf_flock *flock,
                    dict_t *xdata)
 {
     nlm4_stats stat = nlm4_denied;
     nfs3_call_state_t *cs = NULL;
 
     cs = frame->local;
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         stat = nlm4_errno_to_nlm4stat(op_errno);
         goto err;
     } else {
@@ -1753,14 +1754,14 @@ rpcerr:
 
 int
 nlm4svc_unlock_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct gf_flock *flock,
+                   gf_return_t op_ret, int32_t op_errno, struct gf_flock *flock,
                    dict_t *xdata)
 {
     nlm4_stats stat = nlm4_denied;
     nfs3_call_state_t *cs = NULL;
 
     cs = GF_REF_GET((nfs3_call_state_t *)frame->local);
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         stat = nlm4_errno_to_nlm4stat(op_errno);
         goto err;
     } else {

--- a/xlators/performance/io-cache/src/io-cache.c
+++ b/xlators/performance/io-cache/src/io-cache.c
@@ -80,7 +80,8 @@ ioc_get_inode (dict_t *dict, char *name)
 
 int
 ioc_update_pages(call_frame_t *frame, ioc_inode_t *ioc_inode,
-                 struct iovec *vector, int32_t count, int op_ret, off_t offset)
+                 struct iovec *vector, int32_t count, gf_return_t op_ret,
+                 off_t offset)
 {
     size_t size = 0;
     off_t rounded_offset = 0, rounded_end = 0, trav_offset = 0,
@@ -89,7 +90,7 @@ ioc_update_pages(call_frame_t *frame, ioc_inode_t *ioc_inode,
     ioc_page_t *trav = NULL;
 
     size = iov_length(vector, count);
-    size = min(size, op_ret);
+    size = min(size, GET_RET(op_ret));
 
     rounded_offset = gf_floor(offset, ioc_inode->table->page_size);
     rounded_end = gf_roof(offset + size, ioc_inode->table->page_size);
@@ -195,7 +196,7 @@ ioc_inode_flush(ioc_inode_t *ioc_inode)
 
 int32_t
 ioc_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *preop,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *preop,
                 struct iatt *postop, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(setattr, frame, op_ret, op_errno, preop, postop, xdata);
@@ -279,23 +280,23 @@ out:
 
 int32_t
 ioc_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *stbuf, dict_t *xdata, struct iatt *postparent)
 {
     ioc_local_t *local = NULL;
 
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto out;
 
     local = frame->local;
     if (local == NULL) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto out;
     }
 
     if (!this || !this->private) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto out;
     }
@@ -346,7 +347,8 @@ unwind:
         mem_put(local);
     }
 
-    STACK_UNWIND_STRICT(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(lookup, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL);
 
     return 0;
 }
@@ -398,7 +400,7 @@ ioc_invalidate(xlator_t *this, inode_t *inode)
  */
 int32_t
 ioc_cache_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                       gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                        dict_t *xdata)
 {
     ioc_local_t *local = NULL;
@@ -410,8 +412,8 @@ ioc_cache_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     ioc_inode = local->inode;
     local_stbuf = stbuf;
 
-    if ((op_ret == -1) ||
-        ((op_ret >= 0) && !ioc_cache_still_valid(ioc_inode, stbuf))) {
+    if ((IS_ERROR(op_ret)) ||
+        ((IS_SUCCESS(op_ret)) && !ioc_cache_still_valid(ioc_inode, stbuf))) {
         gf_msg_debug(ioc_inode->table->xl->name, 0,
                      "cache for inode(%p) is invalid. flushing all pages",
                      ioc_inode);
@@ -422,7 +424,7 @@ ioc_cache_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         ioc_inode_lock(ioc_inode);
         {
             destroy_size = __ioc_inode_flush(ioc_inode);
-            if (op_ret >= 0) {
+            if (IS_SUCCESS(op_ret)) {
                 ioc_inode->cache.mtime = stbuf->ia_mtime;
                 ioc_inode->cache.mtime_nsec = stbuf->ia_mtime_nsec;
             }
@@ -439,7 +441,7 @@ ioc_cache_validate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         ioc_table_unlock(ioc_inode->table);
     }
 
-    if (op_ret < 0)
+    if (IS_ERROR(op_ret))
         local_stbuf = NULL;
 
     ioc_inode_lock(ioc_inode);
@@ -517,7 +519,7 @@ ioc_cache_validate(call_frame_t *frame, ioc_inode_t *ioc_inode, fd_t *fd,
     validate_local = mem_get0(THIS->local_pool);
     if (validate_local == NULL) {
         ret = -1;
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOMEM;
         gf_smsg(ioc_inode->table->xl->name, GF_LOG_ERROR, 0,
                 IO_CACHE_MSG_NO_MEMORY, NULL);
@@ -527,7 +529,7 @@ ioc_cache_validate(call_frame_t *frame, ioc_inode_t *ioc_inode, fd_t *fd,
     validate_frame = copy_frame(frame);
     if (validate_frame == NULL) {
         ret = -1;
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = ENOMEM;
         mem_put(validate_local);
         gf_smsg(ioc_inode->table->xl->name, GF_LOG_ERROR, 0,
@@ -590,8 +592,8 @@ ioc_get_priority(ioc_table_t *table, const char *path)
  *
  */
 int32_t
-ioc_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, fd_t *fd, dict_t *xdata)
+ioc_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     uint64_t tmp_ioc_inode = 0;
     ioc_local_t *local = NULL;
@@ -600,14 +602,14 @@ ioc_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     local = frame->local;
     if (!this || !this->private) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto out;
     }
 
     table = this->private;
 
-    if (op_ret != -1) {
+    if (IS_SUCCESS(op_ret)) {
         inode_ctx_get(fd->inode, this, &tmp_ioc_inode);
         ioc_inode = (ioc_inode_t *)(long)tmp_ioc_inode;
 
@@ -669,7 +671,7 @@ out:
  */
 int32_t
 ioc_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
                struct iatt *buf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -682,7 +684,7 @@ ioc_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     local = frame->local;
     if (!this || !this->private) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto out;
     }
@@ -690,7 +692,7 @@ ioc_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     table = this->private;
     path = local->file_loc.path;
 
-    if (op_ret != -1) {
+    if (IS_SUCCESS(op_ret)) {
         /* assign weight */
         weight = ioc_get_priority(table, path);
 
@@ -750,9 +752,10 @@ out:
 }
 
 int32_t
-ioc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode, struct iatt *buf,
-              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+ioc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+              struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+              dict_t *xdata)
 {
     ioc_local_t *local = NULL;
     ioc_table_t *table = NULL;
@@ -762,7 +765,7 @@ ioc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     local = frame->local;
     if (!this || !this->private) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto out;
     }
@@ -770,7 +773,7 @@ ioc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     table = this->private;
     path = local->file_loc.path;
 
-    if (op_ret != -1) {
+    if (IS_SUCCESS(op_ret)) {
         /* assign weight */
         weight = ioc_get_priority(table, path);
 
@@ -831,8 +834,8 @@ unwind:
         mem_put(local);
     }
 
-    STACK_UNWIND_STRICT(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(mknod, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     return 0;
 }
@@ -854,7 +857,7 @@ ioc_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     local = mem_get0(this->local_pool);
     if (local == NULL) {
         gf_smsg(this->name, GF_LOG_ERROR, ENOMEM, IO_CACHE_MSG_NO_MEMORY, NULL);
-        STACK_UNWIND_STRICT(open, frame, -1, ENOMEM, NULL, NULL);
+        STACK_UNWIND_STRICT(open, frame, gf_error, ENOMEM, NULL, NULL);
         return 0;
     }
 
@@ -889,8 +892,8 @@ ioc_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     local = mem_get0(this->local_pool);
     if (local == NULL) {
         gf_smsg(this->name, GF_LOG_ERROR, ENOMEM, IO_CACHE_MSG_NO_MEMORY, NULL);
-        STACK_UNWIND_STRICT(create, frame, -1, ENOMEM, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(create, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
         return 0;
     }
 
@@ -1001,7 +1004,7 @@ ioc_dispatch_requests(call_frame_t *frame, ioc_inode_t *ioc_inode, fd_t *fd,
                 if (!trav) {
                     gf_smsg(frame->this->name, GF_LOG_CRITICAL, ENOMEM,
                             IO_CACHE_MSG_NO_MEMORY, NULL);
-                    local->op_ret = -1;
+                    local->op_ret = gf_error;
                     local->op_errno = ENOMEM;
                     ioc_inode_unlock(ioc_inode);
                     goto out;
@@ -1032,7 +1035,7 @@ ioc_dispatch_requests(call_frame_t *frame, ioc_inode_t *ioc_inode, fd_t *fd,
 
                     ret = ioc_wait_on_inode(ioc_inode, trav);
                     if (ret < 0) {
-                        local->op_ret = -1;
+                        local->op_ret = gf_error;
                         local->op_errno = -ret;
                         need_validate = 0;
 
@@ -1201,7 +1204,8 @@ ioc_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     return 0;
 
 out:
-    STACK_UNWIND_STRICT(readv, frame, -1, op_errno, NULL, 0, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(readv, frame, gf_error, op_errno, NULL, 0, NULL, NULL,
+                        NULL);
     return 0;
 }
 
@@ -1217,7 +1221,7 @@ out:
  */
 int32_t
 ioc_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                struct iatt *postbuf, dict_t *xdata)
 {
     ioc_local_t *local = NULL;
@@ -1227,9 +1231,9 @@ ioc_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     frame->local = NULL;
     inode_ctx_get(local->fd->inode, this, &ioc_inode);
 
-    if (op_ret >= 0) {
+    if (IS_SUCCESS(op_ret)) {
         ioc_update_pages(frame, (ioc_inode_t *)(long)ioc_inode, local->vector,
-                         local->op_ret, op_ret, local->offset);
+                         GET_RET(local->op_ret), op_ret, local->offset);
     }
 
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, prebuf, postbuf,
@@ -1266,7 +1270,7 @@ ioc_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
     if (local == NULL) {
         gf_smsg(this->name, GF_LOG_ERROR, ENOMEM, IO_CACHE_MSG_NO_MEMORY, NULL);
 
-        STACK_UNWIND_STRICT(writev, frame, -1, ENOMEM, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(writev, frame, gf_error, ENOMEM, NULL, NULL, NULL);
         return 0;
     }
 
@@ -1278,8 +1282,8 @@ ioc_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
     if (ioc_inode) {
         local->iobref = iobref_ref(iobref);
         local->vector = iov_dup(vector, count);
-        local->op_ret = count;
         local->offset = offset;
+        SET_RET(local->op_ret, count);
     }
 
     STACK_WIND(frame, ioc_writev_cbk, FIRST_CHILD(this),
@@ -1302,7 +1306,7 @@ ioc_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
  */
 int32_t
 ioc_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(truncate, frame, op_ret, op_errno, prebuf, postbuf,
@@ -1323,7 +1327,7 @@ ioc_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
  */
 int32_t
 ioc_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(ftruncate, frame, op_ret, op_errno, prebuf, postbuf,
@@ -1382,8 +1386,9 @@ ioc_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 }
 
 int32_t
-ioc_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-           int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
+ioc_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+           gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
+           dict_t *xdata)
 {
     STACK_UNWIND_STRICT(lk, frame, op_ret, op_errno, lock, xdata);
     return 0;
@@ -1401,7 +1406,7 @@ ioc_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
     if (!ioc_inode) {
         gf_msg_debug(this->name, EBADFD,
                      "inode context is NULL: returning EBADFD");
-        STACK_UNWIND_STRICT(lk, frame, -1, EBADFD, NULL, NULL);
+        STACK_UNWIND_STRICT(lk, frame, gf_error, EBADFD, NULL, NULL);
         return 0;
     }
 
@@ -1418,8 +1423,9 @@ ioc_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
 }
 
 int
-ioc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, gf_dirent_t *entries, dict_t *xdata)
+ioc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
+                 dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
     char *path = NULL;
@@ -1428,7 +1434,7 @@ ioc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     fd = frame->local;
     frame->local = NULL;
 
-    if (op_ret <= 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     list_for_each_entry(entry, &entries->list, list)
@@ -1459,7 +1465,7 @@ ioc_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
 static int32_t
 ioc_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                 struct iatt *post, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(discard, frame, op_ret, op_errno, pre, post, xdata);
@@ -1484,7 +1490,7 @@ ioc_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
 static int32_t
 ioc_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                  struct iatt *post, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(zerofill, frame, op_ret, op_errno, pre, post, xdata);

--- a/xlators/performance/io-cache/src/io-cache.h
+++ b/xlators/performance/io-cache/src/io-cache.h
@@ -70,7 +70,7 @@ struct ioc_local {
     loc_t file_loc;
     off_t offset;
     size_t size;
-    int32_t op_ret;
+    gf_return_t op_ret;
     int32_t op_errno;
     struct list_head fill_list; /* list of ioc_fill structures */
     off_t pending_offset;       /*
@@ -178,9 +178,9 @@ ptr_to_str(void *ptr);
 
 int32_t
 ioc_readv_disabled_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, struct iovec *vector,
-                       int32_t count, struct iatt *stbuf, struct iobref *iobref,
-                       dict_t *xdata);
+                       gf_return_t op_ret, int32_t op_errno,
+                       struct iovec *vector, int32_t count, struct iatt *stbuf,
+                       struct iobref *iobref, dict_t *xdata);
 
 ioc_page_t *
 __ioc_page_get(ioc_inode_t *ioc_inode, off_t offset);
@@ -202,7 +202,7 @@ void
 ioc_page_flush(ioc_page_t *page);
 
 ioc_waitq_t *
-__ioc_page_error(ioc_page_t *page, int32_t op_ret, int32_t op_errno);
+__ioc_page_error(ioc_page_t *page, gf_return_t op_ret, int32_t op_errno);
 
 void
 ioc_frame_return(call_frame_t *frame);

--- a/xlators/performance/io-cache/src/ioc-inode.c
+++ b/xlators/performance/io-cache/src/ioc-inode.c
@@ -73,7 +73,7 @@ ioc_inode_wakeup(call_frame_t *frame, ioc_inode_t *ioc_inode,
     GF_VALIDATE_OR_GOTO(frame->this->name, local, out);
 
     if (ioc_inode == NULL) {
-        local->op_ret = -1;
+        local->op_ret = gf_error;
         local->op_errno = EINVAL;
         gf_smsg(frame->this->name, GF_LOG_WARNING, 0, IO_CACHE_MSG_INODE_NULL,
                 NULL);

--- a/xlators/performance/io-threads/src/io-threads.c
+++ b/xlators/performance/io-threads/src/io-threads.c
@@ -609,7 +609,7 @@ iot_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
     iot_conf_t *conf = NULL;
     dict_t *depths = NULL;
     int i = 0;
-    int32_t op_ret = 0;
+    gf_return_t op_ret = {0};
     int32_t op_errno = 0;
 
     conf = this->private;
@@ -621,7 +621,7 @@ iot_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *name,
          */
         depths = dict_new();
         if (!depths) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unwind_special_getxattr;
         }

--- a/xlators/performance/md-cache/src/md-cache.c
+++ b/xlators/performance/md-cache/src/md-cache.c
@@ -1132,7 +1132,7 @@ mdc_prepare_request(xlator_t *this, mdc_local_t *local, dict_t *xdata)
 
 int
 mdc_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+               gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                dict_t *xdata)
 {
     struct mdc_conf *conf = this->private;
@@ -1142,7 +1142,7 @@ mdc_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE)) {
             mdc_inode_iatt_invalidate(this, local->loc.inode);
         }
@@ -1163,14 +1163,15 @@ out:
 int
 mdc_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 {
-    int ret = 0, op_ret = 0, op_errno = 0;
+    int ret = 0, op_errno = 0;
+    gf_return_t op_ret = {0};
     struct statvfs *buf = NULL;
     mdc_local_t *local = NULL;
     struct mdc_conf *conf = this->private;
 
     local = mdc_local_get(frame, loc->inode);
     if (!local) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto out;
     }
@@ -1187,7 +1188,6 @@ mdc_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
     ret = mdc_load_statfs_info_from_cache(this, &buf);
     if (ret == 0 && buf) {
-        op_ret = 0;
         op_errno = 0;
         goto out;
     }
@@ -1204,7 +1204,7 @@ out:
 
 int
 mdc_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                struct iatt *stbuf, dict_t *dict, struct iatt *postparent)
 {
     mdc_local_t *local = NULL;
@@ -1215,7 +1215,7 @@ mdc_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ENOENT)
             GF_ATOMIC_INC(conf->mdc_counter.negative_lookup);
 
@@ -1301,8 +1301,8 @@ mdc_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     }
 
     GF_ATOMIC_INC(conf->mdc_counter.stat_hit);
-    MDC_STACK_UNWIND(lookup, frame, 0, 0, loc->inode, &stbuf, xattr_rsp,
-                     &postparent);
+    MDC_STACK_UNWIND(lookup, frame, gf_success, 0, loc->inode, &stbuf,
+                     xattr_rsp, &postparent);
 
     if (xattr_rsp)
         dict_unref(xattr_rsp);
@@ -1326,8 +1326,9 @@ uncached:
 }
 
 int
-mdc_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, struct iatt *buf, dict_t *xdata)
+mdc_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+             dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -1335,7 +1336,7 @@ mdc_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT)) {
             mdc_inode_iatt_invalidate(this, local->loc.inode);
         }
@@ -1378,7 +1379,7 @@ mdc_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
         goto uncached;
 
     GF_ATOMIC_INC(conf->mdc_counter.stat_hit);
-    MDC_STACK_UNWIND(stat, frame, 0, 0, &stbuf, xdata);
+    MDC_STACK_UNWIND(stat, frame, gf_success, 0, &stbuf, xdata);
 
     return 0;
 
@@ -1397,8 +1398,9 @@ uncached:
 }
 
 int
-mdc_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *buf, dict_t *xdata)
+mdc_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
+              dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -1406,7 +1408,7 @@ mdc_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE)) {
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         }
@@ -1444,7 +1446,7 @@ mdc_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
         goto uncached;
 
     GF_ATOMIC_INC(conf->mdc_counter.stat_hit);
-    MDC_STACK_UNWIND(fstat, frame, 0, 0, &stbuf, xdata);
+    MDC_STACK_UNWIND(fstat, frame, gf_success, 0, &stbuf, xdata);
 
     return 0;
 
@@ -1464,7 +1466,7 @@ uncached:
 
 int
 mdc_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -1474,7 +1476,7 @@ mdc_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT))
             mdc_inode_iatt_invalidate(this, local->loc.inode);
 
@@ -1508,7 +1510,7 @@ mdc_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
 
 int
 mdc_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -1518,7 +1520,7 @@ mdc_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
 
@@ -1552,9 +1554,10 @@ mdc_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 }
 
 int
-mdc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode, struct iatt *buf,
-              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+mdc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+              struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+              dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -1563,7 +1566,7 @@ mdc_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT)) {
             mdc_inode_iatt_invalidate(this, local->loc.parent);
         }
@@ -1603,9 +1606,10 @@ mdc_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 }
 
 int
-mdc_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode, struct iatt *buf,
-              struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+mdc_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+              struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+              dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -1614,7 +1618,7 @@ mdc_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT)) {
             mdc_inode_iatt_invalidate(this, local->loc.parent);
         }
@@ -1655,7 +1659,7 @@ mdc_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
 
 int
 mdc_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -1665,7 +1669,7 @@ mdc_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         /* if errno is ESTALE, parent is not present, which implies even
          * child is not present. Also, man 2 unlink states unlink can
          * return ENOENT if a component in pathname does not
@@ -1713,9 +1717,9 @@ mdc_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t xflag,
 }
 
 int
-mdc_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *preparent, struct iatt *postparent,
-              dict_t *xdata)
+mdc_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
+              struct iatt *postparent, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -1724,7 +1728,7 @@ mdc_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         /* if errno is ESTALE, parent is not present, which implies even
          * child is not present. Also, man 2 rmdir states rmdir can
          * return ENOENT if a directory component in pathname does not
@@ -1769,7 +1773,7 @@ mdc_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flag,
 
 int
 mdc_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *buf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -1780,7 +1784,7 @@ mdc_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT)) {
             mdc_inode_iatt_invalidate(this, local->loc.parent);
         }
@@ -1830,7 +1834,7 @@ wind:
 
 int
 mdc_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *buf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *buf,
                struct iatt *preoldparent, struct iatt *postoldparent,
                struct iatt *prenewparent, struct iatt *postnewparent,
                dict_t *xdata)
@@ -1841,7 +1845,7 @@ mdc_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT)) {
             mdc_inode_iatt_invalidate(this, local->loc.inode);
             mdc_inode_iatt_invalidate(this, local->loc2.parent);
@@ -1891,9 +1895,10 @@ mdc_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 }
 
 int
-mdc_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, inode_t *inode, struct iatt *buf,
-             struct iatt *preparent, struct iatt *postparent, dict_t *xdata)
+mdc_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+             struct iatt *buf, struct iatt *preparent, struct iatt *postparent,
+             dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -1902,7 +1907,7 @@ mdc_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE)) {
             mdc_inode_iatt_invalidate(this, local->loc.inode);
             mdc_inode_iatt_invalidate(this, local->loc2.parent);
@@ -1944,7 +1949,7 @@ mdc_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
 
 int
 mdc_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
+               gf_return_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
                struct iatt *buf, struct iatt *preparent,
                struct iatt *postparent, dict_t *xdata)
 {
@@ -1955,7 +1960,7 @@ mdc_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT)) {
             mdc_inode_iatt_invalidate(this, local->loc.parent);
         }
@@ -1996,8 +2001,8 @@ mdc_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 }
 
 static int
-mdc_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-             int32_t op_errno, fd_t *fd, dict_t *xdata)
+mdc_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+             gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -2006,7 +2011,7 @@ mdc_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT))
             mdc_inode_iatt_invalidate(this, local->loc.inode);
         goto out;
@@ -2045,9 +2050,10 @@ out:
 }
 
 int
-mdc_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iovec *vector, int32_t count,
-              struct iatt *stbuf, struct iobref *iobref, dict_t *xdata)
+mdc_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
+              int32_t count, struct iatt *stbuf, struct iobref *iobref,
+              dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -2055,7 +2061,7 @@ mdc_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2088,7 +2094,7 @@ mdc_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
 int
 mdc_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -2097,7 +2103,7 @@ mdc_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2132,7 +2138,7 @@ mdc_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
 
 int
 mdc_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                 struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -2141,7 +2147,7 @@ mdc_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         mdc_inode_iatt_set(this, local->loc.inode, NULL, local->incident_time);
         goto out;
     }
@@ -2207,7 +2213,7 @@ wind:
 
 int
 mdc_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -2216,7 +2222,7 @@ mdc_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2282,9 +2288,9 @@ wind:
 }
 
 int
-mdc_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
-              dict_t *xdata)
+mdc_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
+              struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -2292,7 +2298,7 @@ mdc_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2325,7 +2331,7 @@ mdc_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
 
 int
 mdc_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
     struct iatt prestat = {
@@ -2340,7 +2346,7 @@ mdc_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->loc.inode);
         goto out;
@@ -2384,7 +2390,7 @@ mdc_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xattr,
 
 int
 mdc_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
     struct iatt prestat = {
@@ -2399,7 +2405,7 @@ mdc_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ESTALE) || (op_errno == ENOENT))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2443,7 +2449,8 @@ mdc_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xattr,
 
 int
 mdc_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xattr, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
+                 dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -2451,7 +2458,7 @@ mdc_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->loc.inode);
         goto out;
@@ -2478,6 +2485,7 @@ mdc_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *key,
              dict_t *xdata)
 {
     int ret;
+    gf_return_t op_ret;
     int op_errno = ENODATA;
     mdc_local_t *local = NULL;
     dict_t *xattr = NULL;
@@ -2506,7 +2514,8 @@ mdc_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, const char *key,
     }
 
     GF_ATOMIC_INC(conf->mdc_counter.xattr_hit);
-    MDC_STACK_UNWIND(getxattr, frame, ret, op_errno, xattr, xdata);
+    SET_RET(op_ret, ret);
+    MDC_STACK_UNWIND(getxattr, frame, op_ret, op_errno, xattr, xdata);
 
     if (xattr)
         dict_unref(xattr);
@@ -2531,7 +2540,7 @@ uncached:
 
 int
 mdc_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xattr,
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xattr,
                   dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -2540,7 +2549,7 @@ mdc_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2567,6 +2576,7 @@ mdc_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *key,
               dict_t *xdata)
 {
     int ret;
+    gf_return_t op_ret;
     mdc_local_t *local = NULL;
     dict_t *xattr = NULL;
     int op_errno = ENODATA;
@@ -2594,7 +2604,8 @@ mdc_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *key,
     }
 
     GF_ATOMIC_INC(conf->mdc_counter.xattr_hit);
-    MDC_STACK_UNWIND(fgetxattr, frame, ret, op_errno, xattr, xdata);
+    SET_RET(op_ret, ret);
+    MDC_STACK_UNWIND(fgetxattr, frame, op_ret, op_errno, xattr, xdata);
 
     if (xattr)
         dict_unref(xattr);
@@ -2619,7 +2630,7 @@ uncached:
 
 int
 mdc_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
     struct iatt prestat = {
@@ -2634,7 +2645,7 @@ mdc_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->loc.inode);
         goto out;
@@ -2698,7 +2709,7 @@ mdc_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
         ret = -1;
         op_errno = ENODATA;
 
-        MDC_STACK_UNWIND(removexattr, frame, ret, op_errno, xdata);
+        MDC_STACK_UNWIND(removexattr, frame, gf_error, op_errno, xdata);
     } else {
         STACK_WIND(frame, mdc_removexattr_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->removexattr, loc, name, xdata);
@@ -2718,7 +2729,7 @@ uncached:
 
 int
 mdc_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
     struct iatt prestat = {
@@ -2733,7 +2744,7 @@ mdc_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -2798,7 +2809,7 @@ mdc_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
         ret = -1;
         op_errno = ENODATA;
 
-        MDC_STACK_UNWIND(fremovexattr, frame, ret, op_errno, xdata);
+        MDC_STACK_UNWIND(fremovexattr, frame, gf_error, op_errno, xdata);
     } else {
         STACK_WIND(frame, mdc_fremovexattr_cbk, FIRST_CHILD(this),
                    FIRST_CHILD(this)->fops->fremovexattr, fd, name, xdata);
@@ -2818,7 +2829,7 @@ uncached:
 
 int32_t
 mdc_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -2826,7 +2837,7 @@ mdc_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         goto out;
 
     if ((op_errno == ESTALE) || (op_errno == ENOENT))
@@ -2863,8 +2874,9 @@ mdc_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
 }
 
 int
-mdc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, gf_dirent_t *entries, dict_t *xdata)
+mdc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
+                 dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
     mdc_local_t *local = NULL;
@@ -2873,8 +2885,8 @@ mdc_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (!local)
         goto unwind;
 
-    if (op_ret <= 0) {
-        if ((op_ret == -1) && ((op_errno == ENOENT) || (op_errno == ESTALE)))
+    if (GET_RET(op_ret) <= 0) {
+        if (IS_ERROR(op_ret) && ((op_errno == ENOENT) || (op_errno == ESTALE)))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto unwind;
     }
@@ -2918,13 +2930,14 @@ mdc_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     return 0;
 out:
-    MDC_STACK_UNWIND(readdirp, frame, -1, ENOMEM, NULL, NULL);
+    MDC_STACK_UNWIND(readdirp, frame, gf_error, ENOMEM, NULL, NULL);
     return 0;
 }
 
 int
-mdc_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, gf_dirent_t *entries, dict_t *xdata)
+mdc_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
+                dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -2932,7 +2945,7 @@ mdc_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     if (!local)
         goto out;
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         goto out;
 
     if ((op_errno == ESTALE) || (op_errno == ENOENT))
@@ -2972,13 +2985,13 @@ mdc_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     return 0;
 unwind:
-    MDC_STACK_UNWIND(readdir, frame, -1, ENOMEM, NULL, NULL);
+    MDC_STACK_UNWIND(readdir, frame, gf_error, ENOMEM, NULL, NULL);
     return 0;
 }
 
 int
 mdc_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -2987,7 +3000,7 @@ mdc_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -3023,7 +3036,7 @@ mdc_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
 
 int
 mdc_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                 struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -3032,7 +3045,7 @@ mdc_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -3066,7 +3079,7 @@ mdc_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
 int
 mdc_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -3075,7 +3088,7 @@ mdc_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret != 0) {
+    if (IS_ERROR(op_ret)) {
         if ((op_errno == ENOENT) || (op_errno == ESTALE))
             mdc_inode_iatt_invalidate(this, local->fd->inode);
         goto out;
@@ -3109,7 +3122,7 @@ mdc_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
 int32_t
 mdc_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, const char *path,
+                 gf_return_t op_ret, int32_t op_errno, const char *path,
                  struct iatt *buf, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
@@ -3118,7 +3131,7 @@ mdc_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         goto out;
 
     if ((op_errno == ENOENT) || (op_errno == ESTALE))
@@ -3146,13 +3159,13 @@ mdc_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
     return 0;
 
 unwind:
-    MDC_STACK_UNWIND(readlink, frame, -1, ENOMEM, NULL, NULL, NULL);
+    MDC_STACK_UNWIND(readlink, frame, gf_error, ENOMEM, NULL, NULL, NULL);
     return 0;
 }
 
 int32_t
 mdc_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -3160,7 +3173,7 @@ mdc_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         goto out;
 
     if ((op_errno == ESTALE) || (op_errno == ENOENT))
@@ -3188,13 +3201,13 @@ mdc_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
     return 0;
 
 unwind:
-    MDC_STACK_UNWIND(fsyncdir, frame, -1, ENOMEM, NULL);
+    MDC_STACK_UNWIND(fsyncdir, frame, gf_error, ENOMEM, NULL);
     return 0;
 }
 
 int32_t
 mdc_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     mdc_local_t *local = NULL;
 
@@ -3202,7 +3215,7 @@ mdc_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     if (!local)
         goto out;
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         goto out;
 
     if ((op_errno == ESTALE) || (op_errno == ENOENT))
@@ -3230,7 +3243,7 @@ mdc_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t mask,
     return 0;
 
 unwind:
-    MDC_STACK_UNWIND(access, frame, -1, ENOMEM, NULL);
+    MDC_STACK_UNWIND(access, frame, gf_error, ENOMEM, NULL);
     return 0;
 }
 

--- a/xlators/performance/open-behind/src/open-behind.c
+++ b/xlators/performance/open-behind/src/open-behind.c
@@ -151,7 +151,7 @@ typedef struct ob_inode {
             _xl, _fd, 0, true, false, &__ob_inode, &__first_fd);               \
         switch (__ob_state) {                                                  \
             case OB_STATE_OPEN_PENDING:                                        \
-                default_flush_cbk(_frame, NULL, _xl, 0, 0, NULL);              \
+                default_flush_cbk(_frame, NULL, _xl, gf_success, 0, NULL);     \
                 break;                                                         \
                 OB_POST_COMMON(flush, _xl, _frame, __first_fd, ##_args);       \
         }                                                                      \
@@ -387,14 +387,14 @@ ob_resume_pending(struct list_head *list)
 }
 
 static void
-ob_open_completed(xlator_t *xl, ob_inode_t *ob_inode, fd_t *fd, int32_t op_ret,
-                  int32_t op_errno)
+ob_open_completed(xlator_t *xl, ob_inode_t *ob_inode, fd_t *fd,
+                  gf_return_t op_ret, int32_t op_errno)
 {
     struct list_head list;
 
     INIT_LIST_HEAD(&list);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         fd_ctx_set(fd, xl, op_errno <= 0 ? EIO : op_errno);
     }
 
@@ -417,7 +417,7 @@ ob_open_completed(xlator_t *xl, ob_inode_t *ob_inode, fd_t *fd, int32_t op_ret,
 }
 
 static int32_t
-ob_open_cbk(call_frame_t *frame, void *cookie, xlator_t *xl, int32_t op_ret,
+ob_open_cbk(call_frame_t *frame, void *cookie, xlator_t *xl, gf_return_t op_ret,
             int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
     ob_inode_t *ob_inode;
@@ -486,7 +486,7 @@ ob_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags, fd_t *fd,
                  *       probably this doesn't make sense since it won't contain
                  *       any requested data. I think it would be better to pass
                  *       NULL for xdata. */
-                default_open_cbk(frame, NULL, this, 0, 0, fd, xdata);
+                default_open_cbk(frame, NULL, this, gf_success, 0, fd, xdata);
 
                 return ob_open_dispatch(this, ob_inode, first_fd, stub);
             }
@@ -496,7 +496,7 @@ ob_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags, fd_t *fd,
 
         /* In case of error, simulate a regular completion but with an error
          * code. */
-        ob_open_completed(this, ob_inode, first_fd, -1, ENOMEM);
+        ob_open_completed(this, ob_inode, first_fd, gf_error, ENOMEM);
 
         state = -ENOMEM;
     }

--- a/xlators/performance/quick-read/src/quick-read.c
+++ b/xlators/performance/quick-read/src/quick-read.c
@@ -565,9 +565,9 @@ __qr_cache_is_fresh(xlator_t *this, qr_inode_t *qr_inode)
 }
 
 int
-qr_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode_ret, struct iatt *buf,
-              dict_t *xdata, struct iatt *postparent)
+qr_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode_ret,
+              struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     void *content = NULL;
     qr_inode_t *qr_inode = NULL;
@@ -577,7 +577,7 @@ qr_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     local = frame->local;
     inode = local->inode;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         qr_inode_prune(this, inode, local->incident_gen);
         goto out;
     }
@@ -664,8 +664,9 @@ wind:
 }
 
 int
-qr_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                int op_errno, gf_dirent_t *entries, dict_t *xdata)
+qr_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
+                dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
     qr_inode_t *qr_inode = NULL;
@@ -673,7 +674,7 @@ qr_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
 
     local = frame->local;
 
-    if (op_ret <= 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     list_for_each_entry(entry, &entries->list, list)
@@ -715,7 +716,8 @@ qr_readv_cached(call_frame_t *frame, qr_inode_t *qr_inode, size_t size,
     xlator_t *this = NULL;
     qr_private_t *priv = NULL;
     qr_inode_table_t *table = NULL;
-    int op_ret = -1;
+    gf_return_t op_ret = {-1};
+    int ret = -1;
     struct iobuf *iobuf = NULL;
     struct iobref *iobref = NULL;
     struct iovec iov = {
@@ -740,23 +742,23 @@ qr_readv_cached(call_frame_t *frame, qr_inode_t *qr_inode, size_t size,
         if (!__qr_cache_is_fresh(this, qr_inode))
             goto unlock;
 
-        op_ret = min(size, (qr_inode->size - offset));
+        ret = min(size, (qr_inode->size - offset));
 
-        iobuf = iobuf_get2(this->ctx->iobuf_pool, op_ret);
+        iobuf = iobuf_get2(this->ctx->iobuf_pool, ret);
         if (!iobuf) {
-            op_ret = -1;
+            op_ret = gf_error;
             goto unlock;
         }
 
         iobref = iobref_new();
         if (!iobref) {
-            op_ret = -1;
+            op_ret = gf_error;
             goto unlock;
         }
 
         iobref_add(iobref, iobuf);
 
-        memcpy(iobuf->ptr, qr_inode->data + offset, op_ret);
+        memcpy(iobuf->ptr, qr_inode->data + offset, ret);
 
         buf = qr_inode->buf;
 
@@ -766,9 +768,10 @@ qr_readv_cached(call_frame_t *frame, qr_inode_t *qr_inode, size_t size,
 unlock:
     UNLOCK(&table->lock);
 
-    if (op_ret >= 0) {
+    SET_RET(op_ret, ret);
+    if (IS_SUCCESS(op_ret)) {
         iov.iov_base = iobuf->ptr;
-        iov.iov_len = op_ret;
+        iov.iov_len = ret;
 
         GF_ATOMIC_INC(priv->qr_counter.cache_hit);
         STACK_UNWIND_STRICT(readv, frame, op_ret, 0, &iov, 1, &buf, iobref,
@@ -783,7 +786,7 @@ unlock:
     if (iobref)
         iobref_unref(iobref);
 
-    return op_ret;
+    return ret;
 }
 
 int
@@ -807,9 +810,9 @@ wind:
 }
 
 int32_t
-qr_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
-              dict_t *xdata)
+qr_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
+              struct iatt *postbuf, dict_t *xdata)
 {
     qr_local_t *local = NULL;
 
@@ -841,7 +844,7 @@ qr_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *iov,
 
 int32_t
 qr_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                 struct iatt *postbuf, dict_t *xdata)
 {
     qr_local_t *local = NULL;
@@ -870,7 +873,7 @@ qr_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
 
 int32_t
 qr_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     qr_local_t *local = NULL;
@@ -899,7 +902,7 @@ qr_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
 int32_t
 qr_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                  struct iatt *post, dict_t *xdata)
 {
     qr_local_t *local = NULL;
@@ -929,7 +932,7 @@ qr_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int keep_size,
 
 int32_t
 qr_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *pre,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                struct iatt *post, dict_t *xdata)
 {
     qr_local_t *local = NULL;
@@ -958,7 +961,7 @@ qr_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 
 int32_t
 qr_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *pre,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *pre,
                 struct iatt *post, dict_t *xdata)
 {
     qr_local_t *local = NULL;

--- a/xlators/performance/read-ahead/src/read-ahead.h
+++ b/xlators/performance/read-ahead/src/read-ahead.h
@@ -44,7 +44,7 @@ struct ra_local {
     struct ra_fill fill;
     off_t offset;
     size_t size;
-    int32_t op_ret;
+    gf_return_t op_ret;
     int32_t op_errno;
     off_t pending_offset;
     size_t pending_size;
@@ -120,7 +120,7 @@ void
 ra_page_flush(ra_page_t *page);
 
 ra_waitq_t *
-ra_page_error(ra_page_t *page, int32_t op_ret, int32_t op_errno);
+ra_page_error(ra_page_t *page, gf_return_t op_ret, int32_t op_errno);
 void
 ra_page_purge(ra_page_t *page);
 

--- a/xlators/performance/write-behind/src/write-behind.c
+++ b/xlators/performance/write-behind/src/write-behind.c
@@ -148,7 +148,7 @@ typedef struct wb_request {
                            amount by which we shrink the window.
                         */
 
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
 
     int32_t refcount;
@@ -552,7 +552,7 @@ wb_enqueue_common(wb_inode_t *wb_inode, call_stub_t *stub, int tempted)
         /* Let's be optimistic that we can
            lie about it
         */
-        req->op_ret = req->write_size;
+        SET_RET(req->op_ret, req->write_size);
         req->op_errno = 0;
 
         if (stub->args.fd && (stub->args.fd->flags & O_APPEND))
@@ -867,7 +867,7 @@ __wb_fulfill_request_err(wb_request_t *req, int32_t op_errno)
 
     conf = wb_inode->this->private;
 
-    req->op_ret = -1;
+    req->op_ret = gf_error;
     req->op_errno = op_errno;
 
     if (req->ordering.lied)
@@ -882,7 +882,7 @@ __wb_fulfill_request_err(wb_request_t *req, int32_t op_errno)
             /* response was sent, store the error in a
              * waiter (either an fsync or flush).
              */
-            waiter->op_ret = -1;
+            waiter->op_ret = gf_error;
             waiter->op_errno = op_errno;
         }
 
@@ -1062,7 +1062,7 @@ out:
 
 int
 wb_fulfill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+               gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                struct iatt *postbuf, dict_t *xdata)
 {
     wb_inode_t *wb_inode = NULL;
@@ -1097,10 +1097,10 @@ wb_fulfill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
      * </comment> */
     wb_set_invalidate(wb_inode);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         wb_fulfill_err(head, op_errno);
-    } else if (op_ret < head->total_size) {
-        wb_fulfill_short_write(head, op_ret);
+    } else if (GET_RET(op_ret) < head->total_size) {
+        wb_fulfill_short_write(head, GET_RET(op_ret));
     } else {
         wb_head_done(head);
     }
@@ -1520,7 +1520,7 @@ __wb_handle_failed_conflict(wb_request_t *req, wb_request_t *conflict,
              * 3. So, skip the request for now.
              * 4. Otherwise, resume (unwind) it with error.
              */
-            req->op_ret = -1;
+            req->op_ret = gf_error;
             req->op_errno = conflict->op_errno;
             if ((req->stub->fop == GF_FOP_TRUNCATE) ||
                 (req->stub->fop == GF_FOP_FTRUNCATE)) {
@@ -1643,10 +1643,10 @@ __wb_pick_winds(wb_inode_t *wb_inode, list_head_t *tasks,
                          req->unique, gf_fop_list[req->fop], req->gen, req_gfid,
                          conflict->unique, gf_fop_list[conflict->fop],
                          conflict->gen, conflict_gfid,
-                         (conflict->op_ret == 1) ? "yes" : "no",
+                         (GET_RET(conflict->op_ret) == 1) ? "yes" : "no",
                          strerror(conflict->op_errno));
 
-            if (conflict->op_ret == -1) {
+            if (IS_ERROR(conflict->op_ret)) {
                 /* There is a conflicting liability which failed
                  * to sync in previous attempts, resume the req
                  * and fail, unless its an fsync/flush.
@@ -1738,7 +1738,7 @@ wb_do_winds(wb_inode_t *wb_inode, list_head_t *tasks)
     {
         list_del_init(&req->winds);
 
-        if (req->op_ret == -1) {
+        if (IS_ERROR(req->op_ret)) {
             call_unwind_error_keep_stub(req->stub, req->op_ret, req->op_errno);
         } else {
             call_resume_keep_stub(req->stub);
@@ -1805,9 +1805,9 @@ wb_set_inode_size(wb_inode_t *wb_inode, struct iatt *postbuf)
 }
 
 int
-wb_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct iatt *prebuf, struct iatt *postbuf,
-              dict_t *xdata)
+wb_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
+              struct iatt *postbuf, dict_t *xdata)
 {
     wb_request_t *req = NULL;
     wb_inode_t *wb_inode;
@@ -1899,7 +1899,7 @@ wb_writev(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iovec *vector,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(writev, frame, -1, op_errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(writev, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -1940,7 +1940,8 @@ wb_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(readv, frame, -1, ENOMEM, NULL, 0, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(readv, frame, gf_error, ENOMEM, NULL, 0, NULL, NULL,
+                        NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -1954,7 +1955,7 @@ noqueue:
 
 int
 wb_flush_bg_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     STACK_DESTROY(frame->root);
     return 0;
@@ -1967,13 +1968,13 @@ wb_flush_helper(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     wb_inode_t *wb_inode = NULL;
     call_frame_t *bg_frame = NULL;
     int32_t op_errno = 0;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
 
     conf = this->private;
 
     wb_inode = wb_inode_ctx_get(this, fd->inode);
     if (!wb_inode) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto unwind;
     }
@@ -1988,7 +1989,7 @@ wb_flush_helper(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 flushbehind:
     bg_frame = copy_frame(frame);
     if (!bg_frame) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -2024,7 +2025,7 @@ wb_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(flush, frame, -1, ENOMEM, NULL);
+    STACK_UNWIND_STRICT(flush, frame, gf_error, ENOMEM, NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -2070,7 +2071,7 @@ wb_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t datasync,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(fsync, frame, -1, op_errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(fsync, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -2112,7 +2113,7 @@ wb_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(stat, frame, -1, ENOMEM, NULL, NULL);
+    STACK_UNWIND_STRICT(stat, frame, gf_error, ENOMEM, NULL, NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -2154,7 +2155,7 @@ wb_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(fstat, frame, -1, ENOMEM, NULL, NULL);
+    STACK_UNWIND_STRICT(fstat, frame, gf_error, ENOMEM, NULL, NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -2168,12 +2169,12 @@ noqueue:
 
 int32_t
 wb_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                 struct iatt *postbuf, dict_t *xdata)
 {
     GF_ASSERT(frame->local);
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         wb_set_inode_size(frame->local, postbuf);
 
     frame->local = NULL;
@@ -2217,7 +2218,7 @@ wb_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(truncate, frame, -1, ENOMEM, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(truncate, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -2227,12 +2228,12 @@ unwind:
 
 int32_t
 wb_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     GF_ASSERT(frame->local);
 
-    if (op_ret == 0)
+    if (IS_SUCCESS(op_ret))
         wb_set_inode_size(frame->local, postbuf);
 
     frame->local = NULL;
@@ -2285,7 +2286,7 @@ wb_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 unwind:
     frame->local = NULL;
 
-    STACK_UNWIND_STRICT(ftruncate, frame, -1, op_errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(ftruncate, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -2323,7 +2324,7 @@ wb_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc, struct iatt *stbuf,
 
     return 0;
 unwind:
-    STACK_UNWIND_STRICT(setattr, frame, -1, ENOMEM, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(setattr, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -2367,7 +2368,7 @@ wb_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd, struct iatt *stbuf,
 
     return 0;
 unwind:
-    STACK_UNWIND_STRICT(fsetattr, frame, -1, ENOMEM, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(fsetattr, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -2397,8 +2398,8 @@ wb_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(create, frame, -1, ENOMEM, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(create, frame, gf_error, ENOMEM, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 
@@ -2420,16 +2421,16 @@ wb_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(open, frame, -1, ENOMEM, NULL, NULL);
+    STACK_UNWIND_STRICT(open, frame, gf_error, ENOMEM, NULL, NULL);
     return 0;
 }
 
 int32_t
-wb_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, inode_t *inode, struct iatt *buf, dict_t *xdata,
-              struct iatt *postparent)
+wb_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, inode_t *inode,
+              struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
-    if (op_ret == 0) {
+    if (IS_SUCCESS(op_ret)) {
         wb_inode_t *wb_inode = wb_inode_ctx_get(this, inode);
         if (wb_inode)
             wb_set_inode_size(wb_inode, buf);
@@ -2473,7 +2474,8 @@ unwind:
     if (stub)
         call_stub_destroy(stub);
 
-    STACK_UNWIND_STRICT(lookup, frame, -1, ENOMEM, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(lookup, frame, gf_error, ENOMEM, NULL, NULL, NULL,
+                        NULL);
     return 0;
 
 noqueue:
@@ -2535,7 +2537,7 @@ unlock:
 
 int32_t
 wb_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                 dict_t *xdata)
 {
     wb_inode_t *wb_inode = NULL;
@@ -2546,7 +2548,7 @@ wb_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     fd = frame->local;
     frame->local = NULL;
 
-    if (op_ret <= 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     list_for_each_entry(entry, &entries->list, list)
@@ -2630,7 +2632,8 @@ wb_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(link, frame, -1, ENOMEM, NULL, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(link, frame, gf_error, ENOMEM, NULL, NULL, NULL, NULL,
+                        NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -2677,7 +2680,7 @@ wb_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t keep_size,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(fallocate, frame, -1, ENOMEM, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(fallocate, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -2723,7 +2726,7 @@ wb_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(discard, frame, -1, ENOMEM, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(discard, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -2768,7 +2771,7 @@ wb_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     return 0;
 
 unwind:
-    STACK_UNWIND_STRICT(zerofill, frame, -1, ENOMEM, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(zerofill, frame, gf_error, ENOMEM, NULL, NULL, NULL);
 
     if (stub)
         call_stub_destroy(stub);
@@ -2805,8 +2808,8 @@ unwind:
     if (stub)
         call_stub_destroy(stub);
 
-    STACK_UNWIND_STRICT(rename, frame, -1, ENOMEM, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(rename, frame, gf_error, ENOMEM, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
 
     return 0;
 
@@ -2904,7 +2907,7 @@ __wb_dump_requests(struct list_head *head, char *prefix)
 
         gf_proc_dump_write("generation-number", "%" PRIu64, req->gen);
 
-        gf_proc_dump_write("req->op_ret", "%d", req->op_ret);
+        gf_proc_dump_write("req->op_ret", "%d", GET_RET(req->op_ret));
         gf_proc_dump_write("req->op_errno", "%d", req->op_errno);
         gf_proc_dump_write("sync-attempts", "%d", req->wind_count);
 

--- a/xlators/playground/rot-13/src/rot-13.c
+++ b/xlators/playground/rot-13/src/rot-13.c
@@ -46,7 +46,7 @@ rot13_iovec(struct iovec *vector, int count)
 
 int32_t
 rot13_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                 int32_t count, struct iatt *stbuf, struct iobref *iobref,
                 dict_t *xdata)
 {
@@ -71,7 +71,7 @@ rot13_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
 int32_t
 rot13_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, prebuf, postbuf,

--- a/xlators/protocol/client/src/client-handshake.c
+++ b/xlators/protocol/client/src/client-handshake.c
@@ -30,7 +30,7 @@ extern rpc_clnt_prog_t clnt_pmap_prog;
 int32_t
 client3_getspec(call_frame_t *frame, xlator_t *this, void *data)
 {
-    CLIENT_STACK_UNWIND(getspec, frame, -1, ENOSYS, NULL);
+    CLIENT_STACK_UNWIND(getspec, frame, gf_error, ENOSYS, NULL);
     return 0;
 }
 
@@ -697,7 +697,7 @@ client_setvolume_cbk(struct rpc_req *req, struct iovec *iov, int count,
         0,
     };
     int ret = 0;
-    int32_t op_ret = 0;
+    int op_ret = 0;
     int32_t op_errno = 0;
     gf_boolean_t auth_fail = _gf_false;
     glusterfs_ctx_t *ctx = NULL;

--- a/xlators/protocol/client/src/client-rpc-fops.c
+++ b/xlators/protocol/client/src/client-rpc-fops.c
@@ -92,7 +92,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(symlink, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(symlink, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), inode, &stbuf,
                         &preparent, &postparent, xdata);
 
@@ -161,9 +163,10 @@ out:
                 "path=%s", local->loc.path, NULL);
     }
 
-    CLIENT_STACK_UNWIND(mknod, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(mknod, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        inode, &stbuf, &preparent, &postparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -229,9 +232,10 @@ out:
                 "Path=%s", local->loc.path, NULL);
     }
 
-    CLIENT_STACK_UNWIND(mkdir, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(mkdir, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        inode, &stbuf, &preparent, &postparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -367,8 +371,10 @@ out:
                 loc_gfid_utoa(&local->loc), NULL);
     }
 
-    CLIENT_STACK_UNWIND(open, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), fd, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(open, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        fd, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -425,8 +431,10 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(stat, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &iatt, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(stat, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &iatt, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -484,7 +492,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(readlink, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readlink, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), rsp.path, &iatt,
                         xdata);
 
@@ -551,9 +561,10 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(unlink, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &preparent,
-                        &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(unlink, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &preparent, &postparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -608,9 +619,10 @@ out:
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
-    CLIENT_STACK_UNWIND(rmdir, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &preparent,
-                        &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(rmdir, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &preparent, &postparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -663,7 +675,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(truncate, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(truncate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -715,8 +729,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(statfs, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &statfs, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(statfs, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &statfs, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -776,9 +792,10 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(writev, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
-                        xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(writev, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &prestat, &poststat, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -836,8 +853,10 @@ out:
                 fop_log_level(GF_FOP_FLUSH, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(flush, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(flush, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -893,9 +912,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fsync, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
-                        xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsync, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &prestat, &poststat, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -955,7 +975,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(setxattr, frame, rsp.op_ret, op_errno, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(setxattr, frame, fin_ret, op_errno, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -1025,7 +1047,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(getxattr, frame, rsp.op_ret, op_errno, dict, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(getxattr, frame, fin_ret, op_errno, dict, xdata);
 
     /* don't use GF_FREE, this memory was allocated by libc */
     free(rsp.dict.dict_val);
@@ -1091,7 +1115,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(fgetxattr, frame, rsp.op_ret, op_errno, dict, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fgetxattr, frame, fin_ret, op_errno, dict, xdata);
 
     free(rsp.dict.dict_val);
 
@@ -1155,7 +1181,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(removexattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(removexattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1203,7 +1231,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fremovexattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fremovexattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1251,7 +1281,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fsyncdir, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsyncdir, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1299,8 +1331,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(access, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(access, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -1353,7 +1387,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(ftruncate, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(ftruncate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -1405,8 +1441,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fstat, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &stat, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fstat, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &stat, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -1453,7 +1491,9 @@ out:
                 fop_log_level(GF_FOP_INODELK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(inodelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(inodelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1505,7 +1545,9 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(finodelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(finodelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1554,7 +1596,9 @@ out:
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(entrylk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(entrylk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1603,7 +1647,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(fentrylk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fentrylk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -1662,7 +1708,9 @@ out:
                 loc_gfid_utoa(&local->loc), NULL);
     }
 
-    CLIENT_STACK_UNWIND(xattrop, frame, rsp.op_ret, gf_error_to_errno(op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(xattrop, frame, fin_ret, gf_error_to_errno(op_errno),
                         dict, xdata);
 
     free(rsp.dict.dict_val);
@@ -1728,8 +1776,10 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(fxattrop, frame, rsp.op_ret,
-                        gf_error_to_errno(op_errno), dict, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fxattrop, frame, fin_ret, gf_error_to_errno(op_errno),
+                        dict, xdata);
 
     free(rsp.dict.dict_val);
 
@@ -1791,7 +1841,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(fsetxattr, frame, rsp.op_ret, op_errno, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsetxattr, frame, fin_ret, op_errno, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -1843,7 +1895,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fsetattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsetattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -1903,7 +1957,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fallocate, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fallocate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -1958,7 +2014,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(discard, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(discard, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -2012,7 +2070,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(zerofill, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(zerofill, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -2060,7 +2120,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(ipc, frame, rsp.op_ret, gf_error_to_errno(rsp.op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(ipc, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
                         xdata);
 
     free(rsp.xdata.xdata_val);
@@ -2108,8 +2170,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(seek, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), rsp.offset, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(seek, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        rsp.offset, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -2163,7 +2227,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(setattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(setattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -2241,9 +2307,10 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, "Path=%s", local->loc.path, NULL);
     }
 
-    CLIENT_STACK_UNWIND(create, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), fd, inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(create, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        fd, inode, &stbuf, &preparent, &postparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -2291,7 +2358,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(rchecksum, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(rchecksum, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), rsp.weak_checksum,
                         (uint8_t *)rsp.strong_checksum.strong_checksum_val,
                         xdata);
@@ -2354,8 +2423,10 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(lease, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &lease, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(lease, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &lease, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -2425,7 +2496,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(lk, frame, rsp.op_ret, gf_error_to_errno(rsp.op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(lk, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
                         &lock, xdata);
 
     free(rsp.xdata.xdata_val);
@@ -2481,7 +2554,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, "remote_fd=%d", local->cmd, NULL);
     }
-    CLIENT_STACK_UNWIND(readdir, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readdir, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
     if (rsp.op_ret != -1) {
@@ -2540,7 +2615,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(readdirp, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readdirp, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
     if (rsp.op_ret != -1) {
@@ -2610,9 +2687,11 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(rename, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &stbuf, &preoldparent,
-                        &postoldparent, &prenewparent, &postnewparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(rename, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &stbuf, &preoldparent, &postoldparent, &prenewparent,
+                        &postnewparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -2677,9 +2756,10 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(link, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(link, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        inode, &stbuf, &preparent, &postparent, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -2744,7 +2824,9 @@ out:
                 "Path=%s", local->loc.path, "gfid=%s",
                 loc_gfid_utoa(&local->loc), NULL);
     }
-    CLIENT_STACK_UNWIND(opendir, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(opendir, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), fd, xdata);
 
     free(rsp.xdata.xdata_val);
@@ -2843,7 +2925,9 @@ out:
                          "node");
     }
 
-    CLIENT_STACK_UNWIND(lookup, frame, rsp.op_ret, rsp.op_errno, inode, &stbuf,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(lookup, frame, fin_ret, rsp.op_errno, inode, &stbuf,
                         xdata, &postparent);
 
     if (xdata)
@@ -2906,9 +2990,10 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(readv, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), vector, rspcount,
-                        &stat, iobref, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readv, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        vector, rspcount, &stat, iobref, xdata);
 
     free(rsp.xdata.xdata_val);
 
@@ -2986,7 +3071,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(getactivelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(getactivelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &locklist, xdata);
 
     free(rsp.xdata.xdata_val);
@@ -3039,7 +3126,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(setactivelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(setactivelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     free(rsp.xdata.xdata_val);
@@ -3228,7 +3317,8 @@ client3_3_lookup(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3273,7 +3363,7 @@ client3_3_stat(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(stat, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(stat, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3315,7 +3405,7 @@ client3_3_truncate(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(truncate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(truncate, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -3357,7 +3447,7 @@ client3_3_ftruncate(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(ftruncate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(ftruncate, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -3399,7 +3489,7 @@ client3_3_access(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(access, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(access, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -3487,7 +3577,7 @@ unwind:
         iobref_unref(rsp_iobref);
     }
 
-    CLIENT_STACK_UNWIND(readlink, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(readlink, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -3528,7 +3618,7 @@ client3_3_unlink(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(unlink, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(unlink, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -3569,7 +3659,7 @@ client3_3_rmdir(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(rmdir, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(rmdir, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -3629,8 +3719,8 @@ client3_3_symlink(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 unwind:
 
-    CLIENT_STACK_UNWIND(symlink, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(symlink, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3673,8 +3763,8 @@ client3_3_rename(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    CLIENT_STACK_UNWIND(rename, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3731,7 +3821,7 @@ client3_3_link(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    CLIENT_STACK_UNWIND(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                         NULL);
     GF_FREE(req.xdata.xdata_val);
 
@@ -3784,8 +3874,8 @@ client3_3_mknod(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(mknod, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3850,8 +3940,8 @@ client3_3_mkdir(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3908,8 +3998,8 @@ client3_3_create(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(create, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    CLIENT_STACK_UNWIND(create, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -3968,7 +4058,7 @@ client3_3_open(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(open, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(open, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -4067,7 +4157,8 @@ unwind:
     if (rsp_iobref)
         iobref_unref(rsp_iobref);
 
-    CLIENT_STACK_UNWIND(readv, frame, -1, op_errno, NULL, 0, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(readv, frame, gf_error, op_errno, NULL, 0, NULL, NULL,
+                        NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4128,7 +4219,7 @@ client3_3_writev(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(writev, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(writev, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4189,7 +4280,7 @@ client3_3_flush(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(flush, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(flush, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4231,7 +4322,7 @@ client3_3_fsync(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(fsync, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(fsync, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4275,7 +4366,7 @@ client3_3_fstat(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(fstat, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(fstat, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4329,7 +4420,7 @@ client3_3_opendir(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(opendir, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(opendir, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -4372,7 +4463,7 @@ client3_3_fsyncdir(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(fsyncdir, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fsyncdir, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4415,7 +4506,7 @@ client3_3_statfs(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(statfs, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(statfs, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -4458,7 +4549,7 @@ client3_3_setxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(setxattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(setxattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.dict.dict_val);
 
     GF_FREE(req.xdata.xdata_val);
@@ -4504,7 +4595,7 @@ client3_3_fsetxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fsetxattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fsetxattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.dict.dict_val);
 
     GF_FREE(req.xdata.xdata_val);
@@ -4592,7 +4683,7 @@ client3_3_fgetxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fgetxattr, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(fgetxattr, frame, gf_error, op_errno, NULL, NULL);
 
     if (rsp_iobref)
         iobref_unref(rsp_iobref);
@@ -4614,7 +4705,7 @@ client3_3_getxattr(call_frame_t *frame, xlator_t *this, void *data)
     };
     dict_t *dict = NULL;
     int ret = 0;
-    int32_t op_ret = -1;
+    int op_ret = -1;
     int op_errno = ESTALE;
     int count = 0;
     clnt_local_t *local = NULL;
@@ -4720,7 +4811,9 @@ unwind:
     if (rsp_iobref)
         iobref_unref(rsp_iobref);
 
-    CLIENT_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, NULL);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, op_ret);
+    CLIENT_STACK_UNWIND(getxattr, frame, fin_ret, op_errno, dict, NULL);
 
     if (dict) {
         dict_unref(dict);
@@ -4819,7 +4912,7 @@ client3_3_xattrop(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(xattrop, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(xattrop, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.dict.dict_val);
 
@@ -4913,7 +5006,7 @@ client3_3_fxattrop(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fxattrop, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(fxattrop, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.dict.dict_val);
 
@@ -4961,7 +5054,7 @@ client3_3_removexattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(removexattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(removexattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5004,7 +5097,7 @@ client3_3_fremovexattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fremovexattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fremovexattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5046,7 +5139,7 @@ client3_3_lease(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(lease, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(lease, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5116,7 +5209,7 @@ client3_3_lk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(lk, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(lk, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5158,7 +5251,7 @@ client3_3_inodelk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(inodelk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(inodelk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5206,7 +5299,7 @@ client3_3_finodelk(call_frame_t *frame, xlator_t *this, void *data)
     GF_FREE(req.xdata.xdata_val);
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(finodelk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(finodelk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5251,7 +5344,7 @@ client3_3_entrylk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(entrylk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(entrylk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5294,7 +5387,7 @@ client3_3_fentrylk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fentrylk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fentrylk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5334,7 +5427,7 @@ client3_3_rchecksum(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(rchecksum, frame, -1, op_errno, 0, NULL, NULL);
+    CLIENT_STACK_UNWIND(rchecksum, frame, gf_error, op_errno, 0, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5439,7 +5532,7 @@ unwind:
     if (rsp_iobref)
         iobref_unref(rsp_iobref);
 
-    CLIENT_STACK_UNWIND(readdir, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(readdir, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5543,7 +5636,7 @@ unwind:
 
     GF_FREE(req.dict.dict_val);
 
-    CLIENT_STACK_UNWIND(readdirp, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(readdirp, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
@@ -5585,7 +5678,7 @@ client3_3_setattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(setattr, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(setattr, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5626,7 +5719,7 @@ client3_3_fsetattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fsetattr, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(fsetattr, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5667,7 +5760,7 @@ client3_3_fallocate(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fallocate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(fallocate, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5707,7 +5800,7 @@ client3_3_discard(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(discard, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(discard, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5749,7 +5842,7 @@ client3_3_zerofill(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(zerofill, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(zerofill, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5791,7 +5884,7 @@ client3_3_ipc(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(ipc, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(ipc, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5835,7 +5928,7 @@ client3_3_seek(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(ipc, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(ipc, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.xdata_val);
 
     return 0;
@@ -5885,7 +5978,7 @@ client3_3_getactivelk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(getactivelk, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(getactivelk, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 
@@ -5945,7 +6038,7 @@ client3_3_setactivelk(call_frame_t *frame, xlator_t *this, void *data)
 
 unwind:
 
-    CLIENT_STACK_UNWIND(setactivelk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(setactivelk, frame, gf_error, op_errno, NULL);
 
     GF_FREE(req.xdata.xdata_val);
 

--- a/xlators/protocol/client/src/client-rpc-fops_v2.c
+++ b/xlators/protocol/client/src/client-rpc-fops_v2.c
@@ -81,7 +81,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(symlink, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(symlink, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), inode, &stbuf,
                         &preparent, &postparent, xdata);
 
@@ -148,9 +150,10 @@ out:
                 "path=%s", local->loc.path, NULL);
     }
 
-    CLIENT_STACK_UNWIND(mknod, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(mknod, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        inode, &stbuf, &preparent, &postparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -214,9 +217,10 @@ out:
                 "path=%s", local->loc.path, NULL);
     }
 
-    CLIENT_STACK_UNWIND(mkdir, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(mkdir, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        inode, &stbuf, &preparent, &postparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -279,8 +283,10 @@ out:
                 loc_gfid_utoa(&local->loc), NULL);
     }
 
-    CLIENT_STACK_UNWIND(open, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), fd, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(open, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        fd, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -335,8 +341,10 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(stat, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &iatt, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(stat, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &iatt, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -392,7 +400,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(readlink, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readlink, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), rsp.path, &iatt,
                         xdata);
 
@@ -457,9 +467,10 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(unlink, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &preparent,
-                        &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(unlink, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &preparent, &postparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -512,9 +523,10 @@ out:
                     PC_MSG_REMOTE_OP_FAILED, NULL);
         }
     }
-    CLIENT_STACK_UNWIND(rmdir, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &preparent,
-                        &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(rmdir, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &preparent, &postparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -565,7 +577,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(truncate, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(truncate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -617,8 +631,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(statfs, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &statfs, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(statfs, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &statfs, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -676,9 +692,10 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(writev, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
-                        xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(writev, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &prestat, &poststat, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -733,8 +750,10 @@ out:
                 fop_log_level(GF_FOP_FLUSH, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(flush, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(flush, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -788,9 +807,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fsync, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
-                        xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsync, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &prestat, &poststat, xdata);
     if (xdata)
         dict_unref(xdata);
 
@@ -844,7 +864,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(setxattr, frame, rsp.op_ret, op_errno, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(setxattr, frame, fin_ret, op_errno, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -918,7 +940,9 @@ out:
         rsp.op_ret = 0;
     }
 
-    CLIENT_STACK_UNWIND(getxattr, frame, rsp.op_ret, op_errno, dict, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(getxattr, frame, fin_ret, op_errno, dict, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -985,7 +1009,9 @@ out:
         rsp.op_ret = 0;
     }
 
-    CLIENT_STACK_UNWIND(fgetxattr, frame, rsp.op_ret, op_errno, dict, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fgetxattr, frame, fin_ret, op_errno, dict, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -1045,7 +1071,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(removexattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(removexattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1091,7 +1119,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fremovexattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fremovexattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1137,7 +1167,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fsyncdir, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsyncdir, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1183,8 +1215,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(access, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(access, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -1235,7 +1269,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(ftruncate, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(ftruncate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -1285,8 +1321,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fstat, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &stat, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fstat, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &stat, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -1331,7 +1369,9 @@ out:
                 fop_log_level(GF_FOP_INODELK, gf_error_to_errno(rsp.op_errno)),
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(inodelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(inodelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1381,7 +1421,9 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(finodelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(finodelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1428,7 +1470,9 @@ out:
                 gf_error_to_errno(rsp.op_errno), PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(entrylk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(entrylk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1475,7 +1519,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(fentrylk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fentrylk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -1538,7 +1584,9 @@ out:
         rsp.op_ret = 0;
     }
 
-    CLIENT_STACK_UNWIND(xattrop, frame, rsp.op_ret, gf_error_to_errno(op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(xattrop, frame, fin_ret, gf_error_to_errno(op_errno),
                         dict, xdata);
 
     if (xdata)
@@ -1607,8 +1655,10 @@ out:
             client_attempt_reopen(local->fd, this);
     }
 
-    CLIENT_STACK_UNWIND(fxattrop, frame, rsp.op_ret,
-                        gf_error_to_errno(op_errno), dict, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fxattrop, frame, fin_ret, gf_error_to_errno(op_errno),
+                        dict, xdata);
     if (xdata)
         dict_unref(xdata);
 
@@ -1665,7 +1715,9 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(fsetxattr, frame, rsp.op_ret, op_errno, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsetxattr, frame, fin_ret, op_errno, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -1718,7 +1770,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fallocate, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fallocate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -1771,7 +1825,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(discard, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(discard, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
     if (xdata)
@@ -1822,7 +1878,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(zerofill, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(zerofill, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -1868,7 +1926,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(ipc, frame, rsp.op_ret, gf_error_to_errno(rsp.op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(ipc, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
                         xdata);
 
     if (xdata)
@@ -1913,8 +1973,10 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(seek, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), rsp.offset, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(seek, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        rsp.offset, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -1966,7 +2028,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(setattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(setattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -2020,7 +2084,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(fsetattr, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(fsetattr, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prestat, &poststat,
                         xdata);
 
@@ -2097,9 +2163,10 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, "path=%s", local->loc.path, NULL);
     }
 
-    CLIENT_STACK_UNWIND(create, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), fd, inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(create, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        fd, inode, &stbuf, &preparent, &postparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -2151,8 +2218,10 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(lease, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &lease, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(lease, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &lease, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -2220,7 +2289,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(lk, frame, rsp.op_ret, gf_error_to_errno(rsp.op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(lk, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
                         &lock, xdata);
 
     free(rsp.flock.lk_owner.lk_owner_val);
@@ -2274,7 +2345,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, "remote_fd=%d", local->cmd, NULL);
     }
-    CLIENT_STACK_UNWIND(readdir, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readdir, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
     if (rsp.op_ret != -1) {
@@ -2331,7 +2404,9 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(readdirp, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readdirp, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &entries, xdata);
 
     if (rsp.op_ret != -1) {
@@ -2399,9 +2474,11 @@ out:
         gf_smsg(this->name, GF_LOG_WARNING, gf_error_to_errno(rsp.op_errno),
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
-    CLIENT_STACK_UNWIND(rename, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), &stbuf, &preoldparent,
-                        &postoldparent, &prenewparent, &postnewparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(rename, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        &stbuf, &preoldparent, &postoldparent, &prenewparent,
+                        &postnewparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -2465,9 +2542,10 @@ out:
         }
     }
 
-    CLIENT_STACK_UNWIND(link, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), inode, &stbuf,
-                        &preparent, &postparent, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(link, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        inode, &stbuf, &preparent, &postparent, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -2532,7 +2610,9 @@ out:
                 "path=%s", local->loc.path, "gfid=%s",
                 loc_gfid_utoa(&local->loc), NULL);
     }
-    CLIENT_STACK_UNWIND(opendir, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(opendir, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), fd, xdata);
 
     if (xdata)
@@ -2629,7 +2709,9 @@ out:
                          "node");
     }
 
-    CLIENT_STACK_UNWIND(lookup, frame, rsp.op_ret, rsp.op_errno, inode, &stbuf,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(lookup, frame, fin_ret, rsp.op_errno, inode, &stbuf,
                         xdata, &postparent);
 
     if (xdata)
@@ -2690,9 +2772,10 @@ out:
         if (local->attempt_reopen)
             client_attempt_reopen(local->fd, this);
     }
-    CLIENT_STACK_UNWIND(readv, frame, rsp.op_ret,
-                        gf_error_to_errno(rsp.op_errno), vector, rspcount,
-                        &stat, iobref, xdata);
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(readv, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
+                        vector, rspcount, &stat, iobref, xdata);
 
     if (xdata)
         dict_unref(xdata);
@@ -2767,7 +2850,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(getactivelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(getactivelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &locklist, xdata);
     if (xdata)
         dict_unref(xdata);
@@ -2815,7 +2900,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(setactivelk, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(setactivelk, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), xdata);
 
     if (xdata)
@@ -2880,7 +2967,9 @@ out:
         if (local->attempt_reopen_out)
             client_attempt_reopen(local->fd_out, this);
     }
-    CLIENT_STACK_UNWIND(copy_file_range, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(copy_file_range, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &stbuf, &prestat,
                         &poststat, xdata);
 
@@ -3069,7 +3158,8 @@ client4_0_lookup(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(lookup, frame, -1, op_errno, NULL, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(lookup, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3114,7 +3204,7 @@ client4_0_stat(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(stat, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(stat, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3157,7 +3247,7 @@ client4_0_truncate(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(truncate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(truncate, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3200,7 +3290,7 @@ client4_0_ftruncate(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(ftruncate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(ftruncate, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3242,7 +3332,7 @@ client4_0_access(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(access, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(access, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3296,7 +3386,7 @@ client4_0_readlink(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 unwind:
 
-    CLIENT_STACK_UNWIND(readlink, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(readlink, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3337,7 +3427,7 @@ client4_0_unlink(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(unlink, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(unlink, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3378,7 +3468,7 @@ client4_0_rmdir(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(rmdir, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(rmdir, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3438,8 +3528,8 @@ client4_0_symlink(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 unwind:
 
-    CLIENT_STACK_UNWIND(symlink, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(symlink, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3482,8 +3572,8 @@ client4_0_rename(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(rename, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    CLIENT_STACK_UNWIND(rename, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3541,7 +3631,7 @@ client4_0_link(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    CLIENT_STACK_UNWIND(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                         NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3594,8 +3684,8 @@ client4_0_mknod(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(mknod, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(mknod, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3660,8 +3750,8 @@ client4_0_mkdir(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(mkdir, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(mkdir, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3718,8 +3808,8 @@ client4_0_create(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(create, frame, -1, op_errno, NULL, NULL, NULL, NULL,
-                        NULL, NULL);
+    CLIENT_STACK_UNWIND(create, frame, gf_error, op_errno, NULL, NULL, NULL,
+                        NULL, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3778,7 +3868,7 @@ client4_0_open(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(open, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(open, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -3872,7 +3962,8 @@ unwind:
     if (rsp_iobuf)
         iobuf_unref(rsp_iobuf);
 
-    CLIENT_STACK_UNWIND(readv, frame, -1, op_errno, NULL, 0, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(readv, frame, gf_error, op_errno, NULL, 0, NULL, NULL,
+                        NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3934,7 +4025,7 @@ client4_0_writev(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(writev, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(writev, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -3994,7 +4085,7 @@ client4_0_flush(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(flush, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(flush, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4036,7 +4127,7 @@ client4_0_fsync(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(fsync, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(fsync, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4080,7 +4171,7 @@ client4_0_fstat(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(fstat, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(fstat, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4134,7 +4225,7 @@ client4_0_opendir(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(opendir, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(opendir, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -4178,7 +4269,7 @@ client4_0_fsyncdir(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(fsyncdir, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fsyncdir, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4221,7 +4312,7 @@ client4_0_statfs(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(statfs, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(statfs, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4264,7 +4355,7 @@ client4_0_setxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(setxattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(setxattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.dict.pairs.pairs_val);
 
     GF_FREE(req.xdata.pairs.pairs_val);
@@ -4309,7 +4400,7 @@ client4_0_fsetxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fsetxattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fsetxattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.dict.pairs.pairs_val);
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -4360,7 +4451,7 @@ client4_0_fgetxattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fgetxattr, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(fgetxattr, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -4379,9 +4470,10 @@ client4_0_getxattr(call_frame_t *frame, xlator_t *this, void *data)
     };
     dict_t *dict = NULL;
     int ret = 0;
-    int32_t op_ret = -1;
+    int op_ret = -1;
     int op_errno = ESTALE;
     clnt_local_t *local = NULL;
+    gf_return_t fin_ret;
 
     if (!frame || !this || !data) {
         op_errno = 0;
@@ -4445,8 +4537,11 @@ client4_0_getxattr(call_frame_t *frame, xlator_t *this, void *data)
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
+
 unwind:
-    CLIENT_STACK_UNWIND(getxattr, frame, op_ret, op_errno, dict, NULL);
+
+    SET_RET(fin_ret, op_ret);
+    CLIENT_STACK_UNWIND(getxattr, frame, fin_ret, op_errno, dict, NULL);
 
     if (dict) {
         dict_unref(dict);
@@ -4508,7 +4603,7 @@ client4_0_xattrop(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(xattrop, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(xattrop, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.dict.pairs.pairs_val);
     GF_FREE(req.xdata.pairs.pairs_val);
@@ -4559,7 +4654,7 @@ client4_0_fxattrop(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fxattrop, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(fxattrop, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.dict.pairs.pairs_val);
     GF_FREE(req.xdata.pairs.pairs_val);
@@ -4603,7 +4698,7 @@ client4_0_removexattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(removexattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(removexattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4646,7 +4741,7 @@ client4_0_fremovexattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fremovexattr, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fremovexattr, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4688,7 +4783,7 @@ client4_0_lease(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(lease, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(lease, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4758,7 +4853,7 @@ client4_0_lk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(lk, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(lk, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4800,7 +4895,7 @@ client4_0_inodelk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(inodelk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(inodelk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4848,7 +4943,7 @@ client4_0_finodelk(call_frame_t *frame, xlator_t *this, void *data)
     GF_FREE(req.xdata.pairs.pairs_val);
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(finodelk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(finodelk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4893,7 +4988,7 @@ client4_0_entrylk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(entrylk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(entrylk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -4936,7 +5031,7 @@ client4_0_fentrylk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fentrylk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(fentrylk, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5042,7 +5137,7 @@ unwind:
     if (rsp_iobref)
         iobref_unref(rsp_iobref);
 
-    CLIENT_STACK_UNWIND(readdir, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(readdir, frame, gf_error, op_errno, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5147,7 +5242,7 @@ unwind:
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
-    CLIENT_STACK_UNWIND(readdirp, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(readdirp, frame, gf_error, op_errno, NULL, NULL);
     return 0;
 }
 
@@ -5189,7 +5284,7 @@ client4_0_setattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(setattr, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(setattr, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5230,7 +5325,7 @@ client4_0_fallocate(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fallocate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(fallocate, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5270,7 +5365,7 @@ client4_0_discard(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(discard, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(discard, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5312,7 +5407,7 @@ client4_0_zerofill(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(zerofill, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(zerofill, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5354,7 +5449,7 @@ client4_0_ipc(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(ipc, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(ipc, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5398,7 +5493,7 @@ client4_0_seek(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(ipc, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(ipc, frame, gf_error, op_errno, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5447,7 +5542,7 @@ client4_0_getactivelk(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(getactivelk, frame, -1, op_errno, NULL, NULL);
+    CLIENT_STACK_UNWIND(getactivelk, frame, gf_error, op_errno, NULL, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -5505,7 +5600,7 @@ client4_0_setactivelk(call_frame_t *frame, xlator_t *this, void *data)
 
 unwind:
 
-    CLIENT_STACK_UNWIND(setactivelk, frame, -1, op_errno, NULL);
+    CLIENT_STACK_UNWIND(setactivelk, frame, gf_error, op_errno, NULL);
 
     GF_FREE(req.xdata.pairs.pairs_val);
 
@@ -5552,7 +5647,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(rchecksum, frame, rsp.op_ret,
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(rchecksum, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), rsp.weak_checksum,
                         (uint8_t *)rsp.strong_checksum.strong_checksum_val,
                         xdata);
@@ -5580,6 +5677,7 @@ client4_namelink_cbk(struct rpc_req *req, struct iovec *iov, int count,
     struct iatt postbuf = {
         0,
     };
+    gf_return_t fin_ret;
     dict_t *xdata = NULL;
     call_frame_t *frame = NULL;
     gfx_common_2iatt_rsp rsp = {
@@ -5608,7 +5706,9 @@ client4_namelink_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    CLIENT_STACK_UNWIND(namelink, frame, rsp.op_ret,
+
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(namelink, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), &prebuf, &postbuf,
                         xdata);
     if (xdata)
@@ -5626,6 +5726,7 @@ client4_icreate_cbk(struct rpc_req *req, struct iovec *iov, int count,
     struct iatt stbuf = {
         0,
     };
+    gf_return_t fin_ret;
     dict_t *xdata = NULL;
     call_frame_t *frame = NULL;
     gfx_common_iatt_rsp rsp = {
@@ -5655,7 +5756,9 @@ client4_icreate_cbk(struct rpc_req *req, struct iovec *iov, int count,
 
     xdr_to_dict(&rsp.xdata, &xdata);
 out:
-    CLIENT_STACK_UNWIND(icreate, frame, rsp.op_ret,
+
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(icreate, frame, fin_ret,
                         gf_error_to_errno(rsp.op_errno), inode, &stbuf, xdata);
     if (xdata)
         dict_unref(xdata);
@@ -5718,7 +5821,9 @@ out:
                 PC_MSG_REMOTE_OP_FAILED, NULL);
     }
 
-    CLIENT_STACK_UNWIND(put, frame, rsp.op_ret, gf_error_to_errno(rsp.op_errno),
+    gf_return_t fin_ret;
+    SET_RET(fin_ret, rsp.op_ret);
+    CLIENT_STACK_UNWIND(put, frame, fin_ret, gf_error_to_errno(rsp.op_errno),
                         inode, &stbuf, &preparent, &postparent, xdata);
 
     if (xdata)
@@ -5771,7 +5876,7 @@ client4_0_namelink(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(namelink, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(namelink, frame, gf_error, op_errno, NULL, NULL, NULL);
     return 0;
 }
 
@@ -5822,7 +5927,7 @@ client4_0_icreate(call_frame_t *frame, xlator_t *this, void *data)
 free_reqdata:
     GF_FREE(req.xdata.pairs.pairs_val);
 unwind:
-    CLIENT_STACK_UNWIND(icreate, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(icreate, frame, gf_error, op_errno, NULL, NULL, NULL);
     return 0;
 }
 
@@ -5886,7 +5991,8 @@ client4_0_put(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(put, frame, -1, op_errno, NULL, NULL, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(put, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
+                        NULL);
     return 0;
 }
 
@@ -5956,8 +6062,8 @@ client4_0_copy_file_range(call_frame_t *frame, xlator_t *this, void *data)
     return 0;
 
 unwind:
-    CLIENT_STACK_UNWIND(copy_file_range, frame, -1, op_errno, NULL, NULL, NULL,
-                        NULL);
+    CLIENT_STACK_UNWIND(copy_file_range, frame, gf_error, op_errno, NULL, NULL,
+                        NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -5997,7 +6103,7 @@ client4_0_fsetattr(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(fsetattr, frame, -1, op_errno, NULL, NULL, NULL);
+    CLIENT_STACK_UNWIND(fsetattr, frame, gf_error, op_errno, NULL, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;
@@ -6042,7 +6148,7 @@ client4_0_rchecksum(call_frame_t *frame, xlator_t *this, void *data)
 
     return 0;
 unwind:
-    CLIENT_STACK_UNWIND(rchecksum, frame, -1, op_errno, 0, NULL, NULL);
+    CLIENT_STACK_UNWIND(rchecksum, frame, gf_error, op_errno, 0, NULL, NULL);
     GF_FREE(req.xdata.pairs.pairs_val);
 
     return 0;

--- a/xlators/protocol/client/src/client.c
+++ b/xlators/protocol/client/src/client.c
@@ -379,7 +379,7 @@ client_lookup(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 out:
     /* think of avoiding a missing frame */
     if (ret)
-        STACK_UNWIND_STRICT(lookup, frame, -1, ENOTCONN, NULL, NULL, NULL,
+        STACK_UNWIND_STRICT(lookup, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
                             NULL);
 
     return 0;
@@ -407,7 +407,7 @@ client_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(stat, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(stat, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -436,7 +436,8 @@ client_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(truncate, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(truncate, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -465,7 +466,8 @@ client_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(ftruncate, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(ftruncate, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -494,7 +496,7 @@ client_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t mask,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(access, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(access, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -523,7 +525,8 @@ client_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(readlink, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(readlink, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -554,8 +557,8 @@ client_mknod(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(mknod, frame, -1, ENOTCONN, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(mknod, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
+                            NULL, NULL);
 
     return 0;
 }
@@ -585,8 +588,8 @@ client_mkdir(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(mkdir, frame, -1, ENOTCONN, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(mkdir, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
+                            NULL, NULL);
 
     return 0;
 }
@@ -615,7 +618,8 @@ client_unlink(call_frame_t *frame, xlator_t *this, loc_t *loc, int xflag,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(unlink, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(unlink, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -645,7 +649,7 @@ client_rmdir(call_frame_t *frame, xlator_t *this, loc_t *loc, int flags,
 out:
     /* think of avoiding a missing frame */
     if (ret)
-        STACK_UNWIND_STRICT(rmdir, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(rmdir, frame, gf_error, ENOTCONN, NULL, NULL, NULL);
 
     return 0;
 }
@@ -675,8 +679,8 @@ client_symlink(call_frame_t *frame, xlator_t *this, const char *linkpath,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(symlink, frame, -1, ENOTCONN, NULL, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(symlink, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL, NULL, NULL);
 
     return 0;
 }
@@ -705,8 +709,8 @@ client_rename(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(rename, frame, -1, ENOTCONN, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(rename, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
 
     return 0;
 }
@@ -735,8 +739,8 @@ client_link(call_frame_t *frame, xlator_t *this, loc_t *oldloc, loc_t *newloc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(link, frame, -1, ENOTCONN, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(link, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
+                            NULL, NULL);
 
     return 0;
 }
@@ -769,8 +773,8 @@ client_create(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(create, frame, -1, ENOTCONN, NULL, NULL, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(create, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
+                            NULL, NULL, NULL);
 
     return 0;
 }
@@ -801,7 +805,7 @@ client_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(open, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(open, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -834,8 +838,8 @@ client_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(readv, frame, -1, ENOTCONN, NULL, 0, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(readv, frame, gf_error, ENOTCONN, NULL, 0, NULL,
+                            NULL, NULL);
 
     return 0;
 }
@@ -871,7 +875,8 @@ client_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(writev, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(writev, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -898,7 +903,7 @@ client_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(flush, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(flush, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -927,7 +932,7 @@ client_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fsync, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(fsync, frame, gf_error, ENOTCONN, NULL, NULL, NULL);
 
     return 0;
 }
@@ -954,7 +959,7 @@ client_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fstat, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(fstat, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -983,7 +988,7 @@ client_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(opendir, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(opendir, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1012,7 +1017,7 @@ client_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t flags,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fsyncdir, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(fsyncdir, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1039,7 +1044,7 @@ client_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(statfs, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(statfs, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1073,8 +1078,8 @@ client_copy_file_range(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(copy_file_range, frame, -1, ENOTCONN, NULL, NULL,
-                            NULL, NULL);
+        STACK_UNWIND_STRICT(copy_file_range, frame, gf_error, ENOTCONN, NULL,
+                            NULL, NULL, NULL);
 
     return 0;
 }
@@ -1198,6 +1203,7 @@ client_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
     int op_ret = -1;
     int op_errno = ENOTCONN;
     int need_unwind = 0;
+    gf_return_t fin_ret;
     clnt_conf_t *conf = NULL;
     rpc_clnt_procedure_t *proc = NULL;
     clnt_args_t args = {
@@ -1247,8 +1253,10 @@ client_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
         }
     }
 out:
-    if (need_unwind)
-        STACK_UNWIND_STRICT(setxattr, frame, op_ret, op_errno, NULL);
+    if (need_unwind) {
+        SET_RET(fin_ret, op_ret);
+        STACK_UNWIND_STRICT(setxattr, frame, fin_ret, op_errno, NULL);
+    }
 
     return 0;
 }
@@ -1278,7 +1286,7 @@ client_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fsetxattr, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(fsetxattr, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1307,7 +1315,7 @@ client_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fgetxattr, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(fgetxattr, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1336,7 +1344,7 @@ client_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(getxattr, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(getxattr, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1366,7 +1374,7 @@ client_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(xattrop, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(xattrop, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1396,7 +1404,7 @@ client_fxattrop(call_frame_t *frame, xlator_t *this, fd_t *fd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fxattrop, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(fxattrop, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1425,7 +1433,7 @@ client_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(removexattr, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(removexattr, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1454,7 +1462,7 @@ client_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fremovexattr, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(fremovexattr, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1483,7 +1491,7 @@ client_lease(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(lk, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(lk, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1513,7 +1521,7 @@ client_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(lk, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(lk, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1544,7 +1552,7 @@ client_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(inodelk, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(inodelk, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1575,7 +1583,7 @@ client_finodelk(call_frame_t *frame, xlator_t *this, const char *volume,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(finodelk, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(finodelk, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1608,7 +1616,7 @@ client_entrylk(call_frame_t *frame, xlator_t *this, const char *volume,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(entrylk, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(entrylk, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1641,7 +1649,7 @@ client_fentrylk(call_frame_t *frame, xlator_t *this, const char *volume,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fentrylk, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(fentrylk, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1671,7 +1679,8 @@ client_rchecksum(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(rchecksum, frame, -1, ENOTCONN, 0, NULL, NULL);
+        STACK_UNWIND_STRICT(rchecksum, frame, gf_error, ENOTCONN, 0, NULL,
+                            NULL);
 
     return 0;
 }
@@ -1704,7 +1713,7 @@ client_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(readdir, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(readdir, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1737,7 +1746,7 @@ client_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(readdirp, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(readdirp, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -1767,7 +1776,8 @@ client_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(setattr, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(setattr, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -1797,7 +1807,8 @@ client_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fsetattr, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(fsetattr, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -1828,7 +1839,8 @@ client_fallocate(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t mode,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(fallocate, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(fallocate, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -1858,7 +1870,8 @@ client_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(discard, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(discard, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -1888,7 +1901,8 @@ client_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(zerofill, frame, -1, ENOTCONN, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(zerofill, frame, gf_error, ENOTCONN, NULL, NULL,
+                            NULL);
 
     return 0;
 }
@@ -1915,7 +1929,7 @@ client_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(ipc, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(ipc, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -1945,7 +1959,7 @@ client_seek(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(seek, frame, -1, ENOTCONN, 0, NULL);
+        STACK_UNWIND_STRICT(seek, frame, gf_error, ENOTCONN, 0, NULL);
 
     return 0;
 }
@@ -1973,7 +1987,7 @@ client_getactivelk(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(getactivelk, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(getactivelk, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -2002,7 +2016,7 @@ client_setactivelk(call_frame_t *frame, xlator_t *this, loc_t *loc,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(setactivelk, frame, -1, ENOTCONN, NULL);
+        STACK_UNWIND_STRICT(setactivelk, frame, gf_error, ENOTCONN, NULL);
 
     return 0;
 }
@@ -2032,7 +2046,7 @@ client_getspec(call_frame_t *frame, xlator_t *this, const char *key,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(getspec, frame, -1, EINVAL, NULL);
+        STACK_UNWIND_STRICT(getspec, frame, gf_error, EINVAL, NULL);
 
     return 0;
 }
@@ -2056,7 +2070,7 @@ client_compound(call_frame_t *frame, xlator_t *this, void *data, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(compound, frame, -1, ENOTCONN, NULL, NULL);
+        STACK_UNWIND_STRICT(compound, frame, gf_error, ENOTCONN, NULL, NULL);
 
     return 0;
 }
@@ -2083,7 +2097,8 @@ client_namelink(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(namelink, frame, -1, EINVAL, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(namelink, frame, gf_error, EINVAL, NULL, NULL,
+                            NULL);
     return 0;
 }
 
@@ -2111,7 +2126,7 @@ client_icreate(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(icreate, frame, -1, EINVAL, NULL, NULL, NULL);
+        STACK_UNWIND_STRICT(icreate, frame, gf_error, EINVAL, NULL, NULL, NULL);
     return 0;
 }
 
@@ -2150,8 +2165,8 @@ client_put(call_frame_t *frame, xlator_t *this, loc_t *loc, mode_t mode,
     }
 out:
     if (ret)
-        STACK_UNWIND_STRICT(put, frame, -1, ENOTCONN, NULL, NULL, NULL, NULL,
-                            NULL);
+        STACK_UNWIND_STRICT(put, frame, gf_error, ENOTCONN, NULL, NULL, NULL,
+                            NULL, NULL);
 
     return 0;
 }
@@ -2633,7 +2648,7 @@ init(xlator_t *this)
 
     this->private = conf;
 
-    /* If it returns -1, then its a failure, if it returns +1 we need
+    /* If it returns gf_error, then its a failure, if it returns +1 we need
        have to understand that 'this' is subvolume of a xlator which,
        will set the remote host and remote subvolume in a setxattr
        call.

--- a/xlators/protocol/server/src/server-common.c
+++ b/xlators/protocol/server/src/server-common.c
@@ -353,10 +353,10 @@ server_post_open(call_frame_t *frame, xlator_t *this, gfs3_open_rsp *rsp,
 }
 
 void
-server_post_readv(gfs3_read_rsp *rsp, struct iatt *stbuf, int op_ret)
+server_post_readv(gfs3_read_rsp *rsp, struct iatt *stbuf, gf_return_t op_ret)
 {
     gf_stat_from_iatt(&rsp->stat, stbuf);
-    rsp->size = op_ret;
+    rsp->size = GET_RET(op_ret);
 }
 
 int
@@ -716,10 +716,10 @@ server4_post_open(call_frame_t *frame, xlator_t *this, gfx_open_rsp *rsp,
 }
 
 void
-server4_post_readv(gfx_read_rsp *rsp, struct iatt *stbuf, int op_ret)
+server4_post_readv(gfx_read_rsp *rsp, struct iatt *stbuf, gf_return_t op_ret)
 {
     gfx_stat_from_iattx(&rsp->stat, stbuf);
-    rsp->size = op_ret;
+    rsp->size = GET_RET(op_ret);
 }
 
 int

--- a/xlators/protocol/server/src/server-common.h
+++ b/xlators/protocol/server/src/server-common.h
@@ -107,7 +107,7 @@ int
 server_post_open(call_frame_t *frame, xlator_t *this, gfs3_open_rsp *rsp,
                  fd_t *fd);
 void
-server_post_readv(gfs3_read_rsp *rsp, struct iatt *stbuf, int op_ret);
+server_post_readv(gfs3_read_rsp *rsp, struct iatt *stbuf, gf_return_t op_ret);
 
 int
 server_post_opendir(call_frame_t *frame, xlator_t *this, gfs3_opendir_rsp *rsp,
@@ -160,7 +160,7 @@ int
 server4_post_open(call_frame_t *frame, xlator_t *this, gfx_open_rsp *rsp,
                   fd_t *fd);
 void
-server4_post_readv(gfx_read_rsp *rsp, struct iatt *stbuf, int op_ret);
+server4_post_readv(gfx_read_rsp *rsp, struct iatt *stbuf, gf_return_t op_ret);
 
 int
 server4_post_create(call_frame_t *frame, gfx_create_rsp *rsp,

--- a/xlators/protocol/server/src/server-handshake.c
+++ b/xlators/protocol/server/src/server-handshake.c
@@ -238,7 +238,7 @@ server_setvolume(rpcsvc_request_t *req)
     char *msg = NULL;
     xlator_t *this = NULL;
     int32_t ret = -1;
-    int32_t op_ret = -1;
+    int op_ret = -1;
     int32_t op_errno = EINVAL;
     uint32_t opversion = 0;
     rpc_transport_t *xprt = NULL;

--- a/xlators/protocol/server/src/server-helpers.c
+++ b/xlators/protocol/server/src/server-helpers.c
@@ -224,7 +224,7 @@ free_state(server_state_t *state)
 
 static int
 server_connection_cleanup_flush_cbk(call_frame_t *frame, void *cookie,
-                                    xlator_t *this, int32_t op_ret,
+                                    xlator_t *this, gf_return_t op_ret,
                                     int32_t op_errno, dict_t *xdata)
 {
     int32_t ret = -1;
@@ -783,7 +783,7 @@ server_resolve_is_empty(server_resolve_t *resolve)
 }
 
 void
-server_print_reply(call_frame_t *frame, int op_ret, int op_errno)
+server_print_reply(call_frame_t *frame, gf_return_t op_ret, int op_errno)
 {
     server_conf_t *conf = NULL;
     server_state_t *state = NULL;

--- a/xlators/protocol/server/src/server-resolve.c
+++ b/xlators/protocol/server/src/server-resolve.c
@@ -41,7 +41,7 @@ resolve_loc_touchup(call_frame_t *frame)
 
 int
 resolve_gfid_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, inode_t *inode,
+                       gf_return_t op_ret, int op_errno, inode_t *inode,
                        struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     server_state_t *state = NULL;
@@ -53,7 +53,7 @@ resolve_gfid_entry_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     resolve = state->resolve_now;
     resolve_loc = &resolve->resolve_loc;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ENOENT) {
             gf_msg_debug(this->name, 0, "%s/%s: failed to resolve (%s)",
                          uuid_utoa(resolve_loc->pargfid), resolve_loc->name,
@@ -102,9 +102,9 @@ out:
 }
 
 int
-resolve_gfid_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
-                 int op_errno, inode_t *inode, struct iatt *buf, dict_t *xdata,
-                 struct iatt *postparent)
+resolve_gfid_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+                 gf_return_t op_ret, int op_errno, inode_t *inode,
+                 struct iatt *buf, dict_t *xdata, struct iatt *postparent)
 {
     server_state_t *state = NULL;
     server_resolve_t *resolve = NULL;
@@ -116,7 +116,7 @@ resolve_gfid_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int op_ret,
     resolve = state->resolve_now;
     resolve_loc = &resolve->resolve_loc;
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         if (op_errno == ENOENT) {
             gf_msg_debug(this->name, GF_LOG_DEBUG, "%s: failed to resolve (%s)",
                          uuid_utoa(resolve_loc->gfid), strerror(op_errno));
@@ -240,7 +240,7 @@ resolve_continue(call_frame_t *frame)
     this = frame->this;
     resolve = state->resolve_now;
 
-    resolve->op_ret = 0;
+    resolve->op_ret = gf_success;
     resolve->op_errno = 0;
 
     if (resolve->fd_no != -1) {
@@ -288,7 +288,7 @@ resolve_entry_simple(call_frame_t *frame)
     if (!parent) {
         /* simple resolution is indecisive. need to perform
            deep resolution */
-        resolve->op_ret = -1;
+        resolve->op_ret = gf_error;
         resolve->op_errno = ESTALE;
         ret = 1;
         goto out;
@@ -299,7 +299,7 @@ resolve_entry_simple(call_frame_t *frame)
         gf_msg(this->name, GF_LOG_ERROR, EPERM, PS_MSG_GFID_RESOLVE_FAILED,
                "%s: parent type not directory (%d)", uuid_utoa(parent->gfid),
                parent->ia_type);
-        resolve->op_ret = -1;
+        resolve->op_ret = gf_error;
         resolve->op_errno = EPERM;
         ret = 1;
         goto out;
@@ -314,7 +314,7 @@ resolve_entry_simple(call_frame_t *frame)
            resolving outside the parent's tree, which is not allowed */
         gf_msg(this->name, GF_LOG_ERROR, EPERM, PS_MSG_GFID_RESOLVE_FAILED,
                "%s: basename sent by client not allowed", resolve->bname);
-        resolve->op_ret = -1;
+        resolve->op_ret = gf_error;
         resolve->op_errno = EPERM;
         ret = 1;
         goto out;
@@ -333,7 +333,7 @@ resolve_entry_simple(call_frame_t *frame)
                 ret = 1;
                 break;
             default:
-                resolve->op_ret = -1;
+                resolve->op_ret = gf_error;
                 resolve->op_errno = ENOENT;
                 ret = 1;
                 break;
@@ -349,7 +349,7 @@ resolve_entry_simple(call_frame_t *frame)
                      "Performing lookup on backend to rule out any "
                      "possible stale dentries in inode table",
                      inode, uuid_utoa(inode->gfid), resolve->path);
-        resolve->op_ret = -1;
+        resolve->op_ret = gf_error;
         resolve->op_errno = EEXIST;
         ret = 1;
         goto out;
@@ -409,7 +409,7 @@ resolve_inode_simple(call_frame_t *frame)
     inode = inode_find(state->itable, resolve->gfid);
 
     if (!inode) {
-        resolve->op_ret = -1;
+        resolve->op_ret = gf_error;
         resolve->op_errno = ESTALE;
         ret = 1;
         goto out;
@@ -467,7 +467,7 @@ resolve_anonfd_simple(call_frame_t *frame)
     inode = inode_find(state->itable, resolve->gfid);
 
     if (!inode) {
-        resolve->op_ret = -1;
+        resolve->op_ret = gf_error;
         resolve->op_errno = ENOENT;
         ret = 1;
         goto out;
@@ -540,7 +540,7 @@ server_resolve_fd(call_frame_t *frame)
     if (serv_ctx == NULL) {
         gf_msg("", GF_LOG_INFO, ENOMEM, PS_MSG_NO_MEMORY,
                "server_ctx_get() failed");
-        resolve->op_ret = -1;
+        resolve->op_ret = gf_error;
         resolve->op_errno = ENOMEM;
         return 0;
     }
@@ -566,7 +566,7 @@ server_resolve_fd(call_frame_t *frame)
             gf_msg("", GF_LOG_INFO, EBADF, PS_MSG_FD_NOT_FOUND,
                    "fd not "
                    "found in context");
-            resolve->op_ret = -1;
+            resolve->op_ret = gf_error;
             resolve->op_errno = EBADF;
         }
     } else {
@@ -575,7 +575,7 @@ server_resolve_fd(call_frame_t *frame)
             gf_msg("", GF_LOG_INFO, EBADF, PS_MSG_FD_NOT_FOUND,
                    "fd not "
                    "found in context");
-            resolve->op_ret = -1;
+            resolve->op_ret = gf_error;
             resolve->op_errno = EBADF;
         }
     }
@@ -609,7 +609,7 @@ server_resolve(call_frame_t *frame)
                    "no resolution type for %s (%s)", resolve->path,
                    gf_fop_list[frame->root->op]);
 
-        resolve->op_ret = -1;
+        resolve->op_ret = gf_error;
         resolve->op_errno = EINVAL;
 
         server_resolve_all(frame);

--- a/xlators/protocol/server/src/server-rpc-fops.c
+++ b/xlators/protocol/server/src/server-rpc-fops.c
@@ -57,7 +57,7 @@ set_resolve_gfid(client_t *client, uuid_t resolve_gfid, char *on_wire_gfid)
 /* Callback function section */
 int
 server_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct statvfs *buf,
+                  gf_return_t op_ret, int32_t op_errno, struct statvfs *buf,
                   dict_t *xdata)
 {
     gfs3_statfs_rsp rsp = {
@@ -68,7 +68,7 @@ server_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_WARNING, op_errno, PS_MSG_STATFS,
                "%" PRId64 ": STATFS, client: %s, error-xlator: %s",
                frame->root->unique, STACK_CLIENT_NAME(frame->root),
@@ -79,7 +79,7 @@ server_statfs_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_statfs(&rsp, buf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -93,7 +93,7 @@ out:
 
 int
 server_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, inode_t *inode,
+                  gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                   struct iatt *stbuf, dict_t *xdata, struct iatt *postparent)
 {
     rpcsvc_request_t *req = NULL;
@@ -107,7 +107,7 @@ server_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (state->is_revalidate == 1 && op_ret == -1) {
+    if (state->is_revalidate == 1 && IS_ERROR(op_ret)) {
         state->is_revalidate = 2;
         loc_copy(&fresh_loc, &state->loc);
         inode_unref(fresh_loc.inode);
@@ -126,7 +126,7 @@ server_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         if (state->is_revalidate && op_errno == ENOENT) {
             if (!__is_root_gfid(state->resolve.gfid)) {
                 inode_unlink(state->loc.inode, state->loc.parent,
@@ -155,10 +155,10 @@ server_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_lookup(&rsp, frame, state, inode, stbuf, postparent);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         if (state->resolve.bname) {
             gf_msg(this->name, fop_log_level(GF_FOP_LOOKUP, op_errno), op_errno,
                    PS_MSG_LOOKUP_INFO,
@@ -193,7 +193,7 @@ out:
 
 int
 server_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct gf_lease *lease,
+                 gf_return_t op_ret, int32_t op_errno, struct gf_lease *lease,
                  dict_t *xdata)
 {
     gfs3_lease_rsp rsp = {
@@ -205,7 +205,7 @@ server_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_LEASE, op_errno), op_errno,
                PS_MSG_LK_INFO,
@@ -218,7 +218,7 @@ server_lease_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_lease(&rsp, lease);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -231,8 +231,9 @@ out:
 }
 
 int
-server_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
-              int32_t op_errno, struct gf_flock *lock, dict_t *xdata)
+server_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
+              gf_return_t op_ret, int32_t op_errno, struct gf_flock *lock,
+              dict_t *xdata)
 {
     gfs3_lk_rsp rsp = {
         0,
@@ -243,7 +244,7 @@ server_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_LK, op_errno), op_errno,
                PS_MSG_LK_INFO,
@@ -258,7 +259,7 @@ server_lk_cbk(call_frame_t *frame, void *cookie, xlator_t *this, int32_t op_ret,
 
     server_post_lk(this, &rsp, lock);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -272,7 +273,7 @@ out:
 
 int
 server_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -285,7 +286,7 @@ server_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_INODELK, op_errno), op_errno,
                PS_MSG_INODELK_INFO,
                "%" PRId64
@@ -298,7 +299,7 @@ server_inodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -312,7 +313,7 @@ out:
 
 int
 server_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -325,7 +326,7 @@ server_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_FINODELK, op_errno), op_errno,
                PS_MSG_INODELK_INFO,
                "%" PRId64 ": FINODELK %" PRId64
@@ -338,7 +339,7 @@ server_finodelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -352,7 +353,7 @@ out:
 
 int
 server_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -365,7 +366,7 @@ server_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_ENTRYLK, op_errno), op_errno,
                PS_MSG_ENTRYLK_INFO,
                "%" PRId64
@@ -378,7 +379,7 @@ server_entrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -392,7 +393,7 @@ out:
 
 int
 server_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -405,7 +406,7 @@ server_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_FENTRYLK, op_errno), op_errno,
                PS_MSG_ENTRYLK_INFO,
                "%" PRId64 ": FENTRYLK %" PRId64
@@ -418,7 +419,7 @@ server_fentrylk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -432,7 +433,7 @@ out:
 
 int
 server_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                  gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -443,7 +444,7 @@ server_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_ACCESS_INFO,
                "%" PRId64
@@ -456,7 +457,7 @@ server_access_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -470,7 +471,7 @@ out:
 
 int
 server_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
     gfs3_rmdir_rsp rsp = {
@@ -484,7 +485,7 @@ server_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_DIR_INFO,
                "%" PRId64
                ": RMDIR %s (%s/%s), client: %s, "
@@ -498,7 +499,7 @@ server_rmdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_rmdir(state, &rsp, preparent, postparent);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -512,7 +513,7 @@ out:
 
 int
 server_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *stbuf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -527,7 +528,7 @@ server_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_MKDIR, op_errno), op_errno,
                PS_MSG_DIR_INFO,
                "%" PRId64
@@ -541,7 +542,7 @@ server_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_mkdir(state, &rsp, inode, stbuf, preparent, postparent, xdata);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -555,7 +556,7 @@ out:
 
 int
 server_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, inode_t *inode,
+                 gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                  struct iatt *stbuf, struct iatt *preparent,
                  struct iatt *postparent, dict_t *xdata)
 {
@@ -570,7 +571,7 @@ server_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_MKNOD, op_errno), op_errno,
                PS_MSG_MKNOD_INFO,
                "%" PRId64
@@ -584,7 +585,7 @@ server_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_mknod(state, &rsp, stbuf, preparent, postparent, inode);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -598,7 +599,7 @@ out:
 
 int
 server_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -609,7 +610,7 @@ server_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FSYNCDIR, op_errno), op_errno,
                PS_MSG_DIR_INFO,
@@ -623,7 +624,7 @@ server_fsyncdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -637,7 +638,7 @@ out:
 
 int
 server_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                   gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                    dict_t *xdata)
 {
     gfs3_readdir_rsp rsp = {
@@ -650,7 +651,7 @@ server_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_READDIR, op_errno), op_errno,
                PS_MSG_DIR_INFO,
@@ -664,17 +665,17 @@ server_readdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* (op_ret == 0) is valid, and means EOF */
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         ret = server_post_readdir(&rsp, entries);
         if (ret == -1) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto out;
         }
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -690,8 +691,10 @@ out:
 
 int
 server_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                   gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                   dict_t *xdata)
 {
+    int ret;
     server_state_t *state = NULL;
     rpcsvc_request_t *req = NULL;
     gfs3_opendir_rsp rsp = {
@@ -702,7 +705,7 @@ server_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_OPENDIR, op_errno), op_errno,
                PS_MSG_DIR_INFO,
@@ -715,13 +718,15 @@ server_opendir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    op_ret = server_post_opendir(frame, this, &rsp, fd);
-    if (op_ret)
+    ret = server_post_opendir(frame, this, &rsp, fd);
+    if (ret < 0) {
+        op_ret = gf_error;
         goto out;
+    }
 out:
-    if (op_ret)
+    if (IS_ERROR(op_ret))
         rsp.fd = fd_no;
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -735,7 +740,7 @@ out:
 
 int
 server_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -746,14 +751,14 @@ server_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (gf_replace_old_iatt_in_dict(xdata)) {
         op_errno = errno;
-        op_ret = -1;
+        op_ret = gf_error;
         goto out;
     }
 
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (ENODATA == op_errno || ENOATTR == op_errno)
             loglevel = GF_LOG_DEBUG;
@@ -771,7 +776,7 @@ server_removexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -785,7 +790,7 @@ out:
 
 int
 server_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                        int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                        gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -795,14 +800,14 @@ server_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (gf_replace_old_iatt_in_dict(xdata)) {
         op_errno = errno;
-        op_ret = -1;
+        op_ret = gf_error;
         goto out;
     }
 
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FREMOVEXATTR, op_errno),
                op_errno, PS_MSG_REMOVEXATTR_INFO,
@@ -816,7 +821,7 @@ server_fremovexattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -830,7 +835,7 @@ out:
 
 int
 server_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata)
 {
     gfs3_getxattr_rsp rsp = {
@@ -842,7 +847,7 @@ server_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_GETXATTR, op_errno), op_errno,
                PS_MSG_GETXATTR_INFO,
@@ -859,7 +864,7 @@ server_getxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                rsp.dict.dict_len, op_errno, out);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -875,7 +880,7 @@ out:
 
 int
 server_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *dict,
+                     gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                      dict_t *xdata)
 {
     gfs3_fgetxattr_rsp rsp = {
@@ -887,7 +892,7 @@ server_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FGETXATTR, op_errno), op_errno,
                PS_MSG_GETXATTR_INFO,
@@ -905,7 +910,7 @@ server_fgetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
 out:
 
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -940,7 +945,7 @@ _gf_server_log_setxattr_failure(dict_t *d, char *k, data_t *v, void *tmp)
 
 int
 server_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                    gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -950,14 +955,14 @@ server_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (gf_replace_old_iatt_in_dict(xdata)) {
         op_errno = errno;
-        op_ret = -1;
+        op_ret = gf_error;
         goto out;
     }
 
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (op_errno != ENOTSUP)
             dict_foreach(state->dict, _gf_server_log_setxattr_failure, frame);
@@ -975,7 +980,7 @@ server_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1010,7 +1015,7 @@ _gf_server_log_fsetxattr_failure(dict_t *d, char *k, data_t *v, void *tmp)
 
 int
 server_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -1020,14 +1025,14 @@ server_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (gf_replace_old_iatt_in_dict(xdata)) {
         op_errno = errno;
-        op_ret = -1;
+        op_ret = gf_error;
         goto out;
     }
 
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         if (op_errno != ENOTSUP) {
             dict_foreach(state->dict, _gf_server_log_fsetxattr_failure, frame);
@@ -1045,7 +1050,7 @@ server_fsetxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1059,7 +1064,7 @@ out:
 
 int
 server_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                   struct iatt *preoldparent, struct iatt *postoldparent,
                   struct iatt *prenewparent, struct iatt *postnewparent,
                   dict_t *xdata)
@@ -1081,7 +1086,7 @@ server_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret == -1) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(state->resolve.pargfid, oldpar_str);
         uuid_utoa_r(state->resolve2.pargfid, newpar_str);
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_RENAME_INFO,
@@ -1098,7 +1103,7 @@ server_rename_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_rename(frame, state, &rsp, stbuf, preoldparent, postoldparent,
                        prenewparent, postnewparent);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1112,7 +1117,7 @@ out:
 
 int
 server_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
     gfs3_unlink_rsp rsp = {
@@ -1123,7 +1128,7 @@ server_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     if (gf_replace_old_iatt_in_dict(xdata)) {
         op_errno = errno;
-        op_ret = -1;
+        op_ret = gf_error;
         goto out;
     }
 
@@ -1132,7 +1137,7 @@ server_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_UNLINK, op_errno), op_errno,
                PS_MSG_LINK_INFO,
                "%" PRId64
@@ -1154,7 +1159,7 @@ server_unlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_unlink(state, &rsp, preparent, postparent);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1168,7 +1173,7 @@ out:
 
 int
 server_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, inode_t *inode,
+                   gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                    struct iatt *stbuf, struct iatt *preparent,
                    struct iatt *postparent, dict_t *xdata)
 {
@@ -1183,7 +1188,7 @@ server_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_LINK_INFO,
                "%" PRId64
                ": SYMLINK %s (%s/%s), client: %s, "
@@ -1198,7 +1203,7 @@ server_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                         xdata);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1212,7 +1217,7 @@ out:
 
 int
 server_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, inode_t *inode,
+                gf_return_t op_ret, int32_t op_errno, inode_t *inode,
                 struct iatt *stbuf, struct iatt *preparent,
                 struct iatt *postparent, dict_t *xdata)
 {
@@ -1233,7 +1238,7 @@ server_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         uuid_utoa_r(state->resolve.gfid, gfid_str);
         uuid_utoa_r(state->resolve2.pargfid, newpar_str);
 
@@ -1250,7 +1255,7 @@ server_link_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_link(state, &rsp, inode, stbuf, preparent, postparent, xdata);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1264,7 +1269,7 @@ out:
 
 int
 server_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                     struct iatt *postbuf, dict_t *xdata)
 {
     gfs3_truncate_rsp rsp = {
@@ -1276,7 +1281,7 @@ server_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_TRUNCATE_INFO,
                "%" PRId64
@@ -1291,7 +1296,7 @@ server_truncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_truncate(&rsp, prebuf, postbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1305,7 +1310,7 @@ out:
 
 int
 server_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                  dict_t *xdata)
 {
     gfs3_fstat_rsp rsp = {
@@ -1318,7 +1323,7 @@ server_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                rsp.xdata.xdata_len, op_errno, out);
 
     state = CALL_STATE(frame);
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_FSTAT, op_errno), op_errno,
                PS_MSG_STAT_INFO,
                "%" PRId64 ": FSTAT %" PRId64
@@ -1333,7 +1338,7 @@ server_fstat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_fstat(state, &rsp, stbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1347,7 +1352,7 @@ out:
 
 int
 server_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                      struct iatt *postbuf, dict_t *xdata)
 {
     gfs3_ftruncate_rsp rsp = {0};
@@ -1357,7 +1362,7 @@ server_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FTRUNCATE, op_errno), op_errno,
                PS_MSG_TRUNCATE_INFO,
@@ -1373,7 +1378,7 @@ server_ftruncate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_ftruncate(&rsp, prebuf, postbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1387,7 +1392,7 @@ out:
 
 int
 server_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                 gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -1398,7 +1403,7 @@ server_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FLUSH, op_errno), op_errno,
                PS_MSG_FLUSH_INFO,
@@ -1412,7 +1417,7 @@ server_flush_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1426,7 +1431,7 @@ out:
 
 int
 server_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                 gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                  struct iatt *postbuf, dict_t *xdata)
 {
     gfs3_fsync_rsp rsp = {
@@ -1438,7 +1443,7 @@ server_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FSYNC, op_errno), op_errno,
                PS_MSG_SYNC_INFO,
@@ -1454,7 +1459,7 @@ server_fsync_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_fsync(&rsp, prebuf, postbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1468,7 +1473,7 @@ out:
 
 int
 server_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, struct iatt *prebuf,
+                  gf_return_t op_ret, int32_t op_errno, struct iatt *prebuf,
                   struct iatt *postbuf, dict_t *xdata)
 {
     gfs3_write_rsp rsp = {
@@ -1480,7 +1485,7 @@ server_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_WRITE, op_errno), op_errno,
                PS_MSG_WRITE_INFO,
@@ -1496,7 +1501,7 @@ server_writev_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_writev(&rsp, prebuf, postbuf);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1510,7 +1515,7 @@ out:
 
 int
 server_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                 int32_t op_ret, int32_t op_errno, struct iovec *vector,
+                 gf_return_t op_ret, int32_t op_errno, struct iovec *vector,
                  int32_t count, struct iatt *stbuf, struct iobref *iobref,
                  dict_t *xdata)
 {
@@ -1533,7 +1538,7 @@ server_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_READ, op_errno), op_errno,
                PS_MSG_READ_INFO,
@@ -1549,7 +1554,7 @@ server_readv_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_readv(&rsp, stbuf, op_ret);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1563,8 +1568,9 @@ out:
 
 int
 server_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, uint32_t weak_checksum,
-                     uint8_t *strong_checksum, dict_t *xdata)
+                     gf_return_t op_ret, int32_t op_errno,
+                     uint32_t weak_checksum, uint8_t *strong_checksum,
+                     dict_t *xdata)
 {
     gfs3_rchecksum_rsp rsp = {
         0,
@@ -1575,7 +1581,7 @@ server_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_RCHECKSUM, op_errno), op_errno,
                PS_MSG_CHKSUM_INFO,
@@ -1590,7 +1596,7 @@ server_rchecksum_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_rchecksum(&rsp, weak_checksum, strong_checksum);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1604,8 +1610,9 @@ out:
 
 int
 server_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, fd_t *fd, dict_t *xdata)
 {
+    int ret;
     server_state_t *state = NULL;
     rpcsvc_request_t *req = NULL;
     gfs3_open_rsp rsp = {
@@ -1615,7 +1622,7 @@ server_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_OPEN, op_errno), op_errno,
                PS_MSG_OPEN_INFO,
@@ -1626,11 +1633,13 @@ server_open_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
         goto out;
     }
 
-    op_ret = server_post_open(frame, this, &rsp, fd);
-    if (op_ret)
+    ret = server_post_open(frame, this, &rsp, fd);
+    if (ret < 0) {
+        op_ret = gf_error;
         goto out;
+    }
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1643,10 +1652,11 @@ out:
 
 int
 server_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                  int32_t op_ret, int32_t op_errno, fd_t *fd, inode_t *inode,
-                  struct iatt *stbuf, struct iatt *preparent,
+                  gf_return_t op_ret, int32_t op_errno, fd_t *fd,
+                  inode_t *inode, struct iatt *stbuf, struct iatt *preparent,
                   struct iatt *postparent, dict_t *xdata)
 {
+    int ret;
     server_state_t *state = NULL;
     rpcsvc_request_t *req = NULL;
     uint64_t fd_no = 0;
@@ -1659,7 +1669,7 @@ server_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     state = CALL_STATE(frame);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_CREATE_INFO,
                "%" PRId64
                ": CREATE %s (%s/%s), client: %s, "
@@ -1678,18 +1688,18 @@ server_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                  frame->root->unique, state->loc.name,
                  uuid_utoa(stbuf->ia_gfid));
 
-    op_ret = server_post_create(frame, &rsp, state, this, fd, inode, stbuf,
-                                preparent, postparent);
-    if (op_ret) {
-        op_errno = -op_ret;
-        op_ret = -1;
+    ret = server_post_create(frame, &rsp, state, this, fd, inode, stbuf,
+                             preparent, postparent);
+    if (ret < 0) {
+        op_errno = -ret;
+        op_ret = gf_error;
         goto out;
     }
 
 out:
-    if (op_ret)
+    if (IS_ERROR(op_ret))
         rsp.fd = fd_no;
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1703,7 +1713,7 @@ out:
 
 int
 server_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, const char *buf,
+                    gf_return_t op_ret, int32_t op_errno, const char *buf,
                     struct iatt *stbuf, dict_t *xdata)
 {
     gfs3_readlink_rsp rsp = {
@@ -1715,7 +1725,7 @@ server_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_LINK_INFO,
                "%" PRId64
@@ -1729,7 +1739,7 @@ server_readlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_readlink(&rsp, stbuf, buf);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
     if (!rsp.path)
         rsp.path = "";
@@ -1745,7 +1755,7 @@ out:
 
 int
 server_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, struct iatt *stbuf,
+                gf_return_t op_ret, int32_t op_errno, struct iatt *stbuf,
                 dict_t *xdata)
 {
     gfs3_stat_rsp rsp = {
@@ -1758,7 +1768,7 @@ server_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                rsp.xdata.xdata_len, op_errno, out);
 
     state = CALL_STATE(frame);
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_STAT, op_errno), op_errno,
                PS_MSG_STAT_INFO,
                "%" PRId64 ": STAT %s (%s), client: %s, error-xlator: %s",
@@ -1770,7 +1780,7 @@ server_stat_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_stat(state, &rsp, stbuf);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1784,7 +1794,7 @@ out:
 
 int
 server_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                    struct iatt *statpost, dict_t *xdata)
 {
     gfs3_setattr_rsp rsp = {
@@ -1796,7 +1806,7 @@ server_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_SETATTR_INFO,
                "%" PRId64
@@ -1811,7 +1821,7 @@ server_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_setattr(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1825,7 +1835,7 @@ out:
 
 int
 server_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata)
 {
     gfs3_fsetattr_rsp rsp = {
@@ -1837,7 +1847,7 @@ server_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FSETATTR, op_errno), op_errno,
                PS_MSG_SETATTR_INFO,
@@ -1853,7 +1863,7 @@ server_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_fsetattr(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1867,7 +1877,7 @@ out:
 
 int
 server_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, dict_t *dict,
+                   gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                    dict_t *xdata)
 {
     gfs3_xattrop_rsp rsp = {
@@ -1879,7 +1889,7 @@ server_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_XATTROP, op_errno), op_errno,
                PS_MSG_XATTROP_INFO,
@@ -1896,7 +1906,7 @@ server_xattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                rsp.dict.dict_len, op_errno, out);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1912,7 +1922,7 @@ out:
 
 int
 server_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, dict_t *dict,
+                    gf_return_t op_ret, int32_t op_errno, dict_t *dict,
                     dict_t *xdata)
 {
     gfs3_xattrop_rsp rsp = {
@@ -1924,7 +1934,7 @@ server_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FXATTROP, op_errno), op_errno,
                PS_MSG_XATTROP_INFO,
@@ -1941,7 +1951,7 @@ server_fxattrop_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
                                rsp.dict.dict_len, op_errno, out);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -1957,7 +1967,7 @@ out:
 
 int
 server_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, gf_dirent_t *entries,
+                    gf_return_t op_ret, int32_t op_errno, gf_dirent_t *entries,
                     dict_t *xdata)
 {
     gfs3_readdirp_rsp rsp = {
@@ -1972,7 +1982,7 @@ server_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_READDIRP, op_errno), op_errno,
                PS_MSG_DIR_INFO,
@@ -1986,10 +1996,10 @@ server_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* (op_ret == 0) is valid, and means EOF */
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         ret = server_post_readdirp(&rsp, entries);
         if (ret == -1) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto out;
         }
@@ -1998,7 +2008,7 @@ server_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     gf_link_inodes_from_dirent(this, state->fd->inode, entries);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -2014,7 +2024,7 @@ out:
 
 int
 server_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                     gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                      struct iatt *statpost, dict_t *xdata)
 {
     gfs3_fallocate_rsp rsp = {
@@ -2026,7 +2036,7 @@ server_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_FALLOCATE, op_errno), op_errno,
                PS_MSG_ALLOC_INFO,
@@ -2042,7 +2052,7 @@ server_fallocate_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_fallocate(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -2056,7 +2066,7 @@ out:
 
 int
 server_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                   int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                   gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                    struct iatt *statpost, dict_t *xdata)
 {
     gfs3_discard_rsp rsp = {
@@ -2068,7 +2078,7 @@ server_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, fop_log_level(GF_FOP_DISCARD, op_errno), op_errno,
                PS_MSG_DISCARD_INFO,
@@ -2084,7 +2094,7 @@ server_discard_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_discard(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -2098,7 +2108,7 @@ out:
 
 int
 server_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int32_t op_ret, int32_t op_errno, struct iatt *statpre,
+                    gf_return_t op_ret, int32_t op_errno, struct iatt *statpre,
                     struct iatt *statpost, dict_t *xdata)
 {
     gfs3_zerofill_rsp rsp = {
@@ -2113,7 +2123,7 @@ server_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, (&rsp.xdata.xdata_val),
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_ZEROFILL, op_errno), op_errno,
                PS_MSG_ZEROFILL_INFO,
                "%" PRId64 ": ZEROFILL%" PRId64
@@ -2128,7 +2138,7 @@ server_zerofill_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     server_post_zerofill(&rsp, statpre, statpost);
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     server_submit_reply(frame, req, &rsp, NULL, 0, NULL,
@@ -2141,7 +2151,7 @@ out:
 
 int
 server_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-               int32_t op_ret, int32_t op_errno, dict_t *xdata)
+               gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gf_common_rsp rsp = {
         0,
@@ -2155,7 +2165,7 @@ server_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, (&rsp.xdata.xdata_val),
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, GF_LOG_INFO, op_errno, PS_MSG_SERVER_IPC_INFO,
                "%" PRId64 ": IPC%" PRId64
                " (%s), client: %s, "
@@ -2167,7 +2177,7 @@ server_ipc_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     server_submit_reply(frame, req, &rsp, NULL, 0, NULL,
@@ -2180,7 +2190,8 @@ out:
 
 int
 server_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                int32_t op_ret, int32_t op_errno, off_t offset, dict_t *xdata)
+                gf_return_t op_ret, int32_t op_errno, off_t offset,
+                dict_t *xdata)
 {
     struct gfs3_seek_rsp rsp = {
         0,
@@ -2194,7 +2205,7 @@ server_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, (&rsp.xdata.xdata_val),
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret) {
+    if (IS_ERROR(op_ret)) {
         gf_msg(this->name, fop_log_level(GF_FOP_SEEK, op_errno), op_errno,
                PS_MSG_SEEK_INFO,
                "%" PRId64 ": SEEK%" PRId64
@@ -2208,7 +2219,7 @@ server_seek_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
     server_post_seek(&rsp, offset);
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     server_submit_reply(frame, req, &rsp, NULL, 0, NULL,
@@ -2221,7 +2232,7 @@ out:
 
 static int
 server_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int32_t op_errno, dict_t *xdata)
 {
     gfs3_setactivelk_rsp rsp = {
         0,
@@ -2234,7 +2245,7 @@ server_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
         gf_msg(this->name, GF_LOG_INFO, op_errno, 0,
                "%" PRId64
@@ -2247,7 +2258,7 @@ server_setactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -2266,12 +2277,12 @@ int
 server_rchecksum_resume(call_frame_t *frame, xlator_t *bound_xl)
 {
     server_state_t *state = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = EINVAL;
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0) {
+    if (IS_ERROR(state->resolve.op_ret)) {
         op_ret = state->resolve.op_ret;
         op_errno = state->resolve.op_errno;
         goto err;
@@ -2295,7 +2306,7 @@ server_lease_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_lease_cbk, bound_xl, bound_xl->fops->lease,
@@ -2316,7 +2327,7 @@ server_lk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_lk_cbk, bound_xl, bound_xl->fops->lk, state->fd,
@@ -2334,18 +2345,18 @@ int
 server_rename_resume(call_frame_t *frame, xlator_t *bound_xl)
 {
     server_state_t *state = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = 0;
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0) {
+    if (IS_ERROR(state->resolve.op_ret)) {
         op_ret = state->resolve.op_ret;
         op_errno = state->resolve.op_errno;
         goto err;
     }
 
-    if (state->resolve2.op_ret != 0) {
+    if (IS_ERROR(state->resolve2.op_ret)) {
         op_ret = state->resolve2.op_ret;
         op_errno = state->resolve2.op_errno;
         goto err;
@@ -2364,18 +2375,18 @@ int
 server_link_resume(call_frame_t *frame, xlator_t *bound_xl)
 {
     server_state_t *state = NULL;
-    int op_ret = 0;
+    gf_return_t op_ret = gf_success;
     int op_errno = 0;
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0) {
+    if (IS_ERROR(state->resolve.op_ret)) {
         op_ret = state->resolve.op_ret;
         op_errno = state->resolve.op_errno;
         goto err;
     }
 
-    if (state->resolve2.op_ret != 0) {
+    if (IS_ERROR(state->resolve2.op_ret)) {
         op_ret = state->resolve2.op_ret;
         op_errno = state->resolve2.op_errno;
         goto err;
@@ -2400,7 +2411,7 @@ server_symlink_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -2422,7 +2433,7 @@ server_access_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_access_cbk, bound_xl, bound_xl->fops->access,
@@ -2442,7 +2453,7 @@ server_fentrylk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->xdata)
@@ -2471,7 +2482,7 @@ server_entrylk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->xdata)
@@ -2501,7 +2512,7 @@ server_finodelk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->xdata)
@@ -2533,7 +2544,7 @@ server_inodelk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->xdata)
@@ -2560,7 +2571,7 @@ server_rmdir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_rmdir_cbk, bound_xl, bound_xl->fops->rmdir,
@@ -2580,7 +2591,7 @@ server_mkdir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -2602,7 +2613,7 @@ server_mknod_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -2625,7 +2636,7 @@ server_fsyncdir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fsyncdir_cbk, bound_xl, bound_xl->fops->fsyncdir,
@@ -2645,7 +2656,7 @@ server_readdir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     GF_ASSERT(state->fd);
@@ -2667,7 +2678,7 @@ server_readdirp_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_readdirp_cbk, bound_xl, bound_xl->fops->readdirp,
@@ -2687,7 +2698,7 @@ server_opendir_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->fd = fd_create(state->loc.inode, frame->root->pid);
@@ -2713,7 +2724,7 @@ server_statfs_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_statfs_cbk, bound_xl, bound_xl->fops->statfs,
@@ -2733,7 +2744,7 @@ server_removexattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_removexattr_cbk, bound_xl,
@@ -2753,7 +2764,7 @@ server_fremovexattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fremovexattr_cbk, bound_xl,
@@ -2773,7 +2784,7 @@ server_fgetxattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fgetxattr_cbk, bound_xl, bound_xl->fops->fgetxattr,
@@ -2792,7 +2803,7 @@ server_xattrop_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_xattrop_cbk, bound_xl, bound_xl->fops->xattrop,
@@ -2811,7 +2822,7 @@ server_fxattrop_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fxattrop_cbk, bound_xl, bound_xl->fops->fxattrop,
@@ -2830,7 +2841,7 @@ server_fsetxattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_setxattr_cbk, bound_xl, bound_xl->fops->fsetxattr,
@@ -2850,7 +2861,7 @@ server_unlink_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_unlink_cbk, bound_xl, bound_xl->fops->unlink,
@@ -2869,7 +2880,7 @@ server_truncate_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_truncate_cbk, bound_xl, bound_xl->fops->truncate,
@@ -2888,7 +2899,7 @@ server_fstat_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fstat_cbk, bound_xl, bound_xl->fops->fstat,
@@ -2907,7 +2918,7 @@ server_setxattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_setxattr_cbk, bound_xl, bound_xl->fops->setxattr,
@@ -2927,7 +2938,7 @@ server_getxattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_getxattr_cbk, bound_xl, bound_xl->fops->getxattr,
@@ -2946,7 +2957,7 @@ server_ftruncate_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_ftruncate_cbk, bound_xl, bound_xl->fops->ftruncate,
@@ -2966,7 +2977,7 @@ server_flush_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_flush_cbk, bound_xl, bound_xl->fops->flush,
@@ -2986,7 +2997,7 @@ server_fsync_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fsync_cbk, bound_xl, bound_xl->fops->fsync,
@@ -3006,7 +3017,7 @@ server_writev_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_writev_cbk, bound_xl, bound_xl->fops->writev,
@@ -3027,7 +3038,7 @@ server_readv_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_readv_cbk, bound_xl, bound_xl->fops->readv,
@@ -3048,7 +3059,7 @@ server_create_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->loc.inode = inode_new(state->itable);
@@ -3058,7 +3069,7 @@ server_create_resume(call_frame_t *frame, xlator_t *bound_xl)
         gf_msg("server", GF_LOG_ERROR, 0, PS_MSG_FD_CREATE_FAILED,
                "fd creation for the inode %s failed",
                state->loc.inode ? uuid_utoa(state->loc.inode->gfid) : NULL);
-        state->resolve.op_ret = -1;
+        state->resolve.op_ret = gf_error;
         state->resolve.op_errno = ENOMEM;
         goto err;
     }
@@ -3083,7 +3094,7 @@ server_open_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     state->fd = fd_create(state->loc.inode, frame->root->pid);
@@ -3106,7 +3117,7 @@ server_readlink_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_readlink_cbk, bound_xl, bound_xl->fops->readlink,
@@ -3125,7 +3136,7 @@ server_fsetattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fsetattr_cbk, bound_xl, bound_xl->fops->fsetattr,
@@ -3145,7 +3156,7 @@ server_setattr_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_setattr_cbk, bound_xl, bound_xl->fops->setattr,
@@ -3165,7 +3176,7 @@ server_stat_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_stat_cbk, bound_xl, bound_xl->fops->stat,
@@ -3184,7 +3195,7 @@ server_lookup_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     if (!state->loc.inode)
@@ -3210,7 +3221,7 @@ server_fallocate_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_fallocate_cbk, bound_xl, bound_xl->fops->fallocate,
@@ -3231,7 +3242,7 @@ server_discard_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_discard_cbk, bound_xl, bound_xl->fops->discard,
@@ -3251,7 +3262,7 @@ server_zerofill_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_zerofill_cbk, bound_xl, bound_xl->fops->zerofill,
@@ -3271,7 +3282,7 @@ server_seek_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_seek_cbk, bound_xl, bound_xl->fops->seek,
@@ -3286,7 +3297,7 @@ err:
 
 static int
 server_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int32_t op_ret, int32_t op_errno,
+                       gf_return_t op_ret, int32_t op_errno,
                        lock_migration_info_t *locklist, dict_t *xdata)
 {
     gfs3_getactivelk_rsp rsp = {
@@ -3301,7 +3312,7 @@ server_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     GF_PROTOCOL_DICT_SERIALIZE(this, xdata, &rsp.xdata.xdata_val,
                                rsp.xdata.xdata_len, op_errno, out);
 
-    if (op_ret < 0) {
+    if (IS_ERROR(op_ret)) {
         state = CALL_STATE(frame);
 
         gf_msg(this->name, GF_LOG_INFO, op_errno, 0,
@@ -3316,17 +3327,17 @@ server_getactivelk_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     }
 
     /* (op_ret == 0) means there are no locks on the file*/
-    if (op_ret > 0) {
+    if (IS_SUCCESS(op_ret)) {
         ret = serialize_rsp_locklist(locklist, &rsp);
         if (ret == -1) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto out;
         }
     }
 
 out:
-    rsp.op_ret = op_ret;
+    rsp.op_ret = GET_RET(op_ret);
     rsp.op_errno = gf_errno_to_error(op_errno);
 
     req = frame->local;
@@ -3348,7 +3359,7 @@ server_getactivelk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_getactivelk_cbk, bound_xl,
@@ -3367,7 +3378,7 @@ server_setactivelk_resume(call_frame_t *frame, xlator_t *bound_xl)
 
     state = CALL_STATE(frame);
 
-    if (state->resolve.op_ret != 0)
+    if (IS_ERROR(state->resolve.op_ret))
         goto err;
 
     STACK_WIND(frame, server_setactivelk_cbk, bound_xl,
@@ -5824,8 +5835,8 @@ out:
     free(args.bname);
     free(args.xdata.xdata_val);
 
-    server_lookup_cbk(frame, NULL, frame->this, -1, EINVAL, NULL, NULL, NULL,
-                      NULL);
+    server_lookup_cbk(frame, NULL, frame->this, gf_error, EINVAL, NULL, NULL,
+                      NULL, NULL);
     ret = 0;
 
 err:

--- a/xlators/protocol/server/src/server.h
+++ b/xlators/protocol/server/src/server.h
@@ -104,7 +104,7 @@ typedef struct {
     u_char pargfid[16];
     char *path;
     char *bname;
-    int op_ret;
+    gf_return_t op_ret;
     int op_errno;
     loc_t resolve_loc;
 } server_resolve_t;

--- a/xlators/storage/posix/src/posix-aio.c
+++ b/xlators/storage/posix/src/posix-aio.c
@@ -76,7 +76,7 @@ posix_aio_readv_complete(struct posix_aio_cb *paiocb, int res, int res2)
         0,
     };
     int _fd = -1;
-    int op_ret = -1;
+    gf_return_t op_ret;
     int op_errno = 0;
     struct iovec iov;
     struct iobref *iobref = NULL;
@@ -94,7 +94,7 @@ posix_aio_readv_complete(struct posix_aio_cb *paiocb, int res, int res2)
     offset = paiocb->offset;
 
     if (res < 0) {
-        op_ret = -1;
+        ret = -1;
         op_errno = -res;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_READV_FAILED,
                "readv(async) failed fd=%d,size=%lu,offset=%llu (%d)", _fd,
@@ -105,19 +105,18 @@ posix_aio_readv_complete(struct posix_aio_cb *paiocb, int res, int res2)
 
     ret = posix_fdstat(this, fd->inode, _fd, &postbuf);
     if (ret != 0) {
-        op_ret = -1;
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_FSTAT_FAILED,
                "fstat failed on fd=%d", _fd);
         goto out;
     }
 
-    op_ret = res;
+    ret = res;
     op_errno = 0;
 
     iobref = iobref_new();
     if (!iobref) {
-        op_ret = -1;
+        ret = -1;
         op_errno = ENOMEM;
         goto out;
     }
@@ -125,15 +124,16 @@ posix_aio_readv_complete(struct posix_aio_cb *paiocb, int res, int res2)
     iobref_add(iobref, iobuf);
 
     iov.iov_base = iobuf_ptr(iobuf);
-    iov.iov_len = op_ret;
+    iov.iov_len = ret;
 
     /* Hack to notify higher layers of EOF. */
     if (!postbuf.ia_size || (offset + iov.iov_len) >= postbuf.ia_size)
         op_errno = ENOENT;
 
-    GF_ATOMIC_ADD(priv->read_value, op_ret);
+    GF_ATOMIC_ADD(priv->read_value, ret);
 
 out:
+    SET_RET(op_ret, ret);
     STACK_UNWIND_STRICT(readv, frame, op_ret, op_errno, &iov, 1, &postbuf,
                         iobref, NULL);
     if (iobuf)
@@ -229,7 +229,7 @@ posix_aio_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(readv, frame, -1, op_errno, 0, 0, 0, 0, 0);
+    STACK_UNWIND_STRICT(readv, frame, gf_error, op_errno, 0, 0, 0, 0, 0);
     if (iobuf)
         iobuf_unref(iobuf);
 
@@ -254,14 +254,14 @@ posix_aio_writev_complete(struct posix_aio_cb *paiocb, int res, int res2)
         0,
     };
     int _fd = -1;
-    int op_ret = -1;
+    gf_return_t op_ret;
     int op_errno = 0;
     int ret = 0;
     struct posix_private *priv = NULL;
     fd_t *fd = NULL;
 
     if (!paiocb) {
-        op_ret = -1;
+        ret = -1;
         op_errno = EINVAL;
         goto out;
     }
@@ -274,7 +274,7 @@ posix_aio_writev_complete(struct posix_aio_cb *paiocb, int res, int res2)
     _fd = paiocb->_fd;
 
     if (res < 0) {
-        op_ret = -1;
+        ret = -1;
         op_errno = -res;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_WRITEV_FAILED,
                "writev(async) failed fd=%d,offset=%llu (%d)", _fd,
@@ -285,19 +285,19 @@ posix_aio_writev_complete(struct posix_aio_cb *paiocb, int res, int res2)
 
     ret = posix_fdstat(this, fd->inode, _fd, &postbuf);
     if (ret != 0) {
-        op_ret = -1;
         op_errno = errno;
         gf_msg(this->name, GF_LOG_ERROR, op_errno, P_MSG_FSTAT_FAILED,
                "fstat failed on fd=%d", _fd);
         goto out;
     }
 
-    op_ret = res;
+    ret = res;
     op_errno = 0;
 
-    GF_ATOMIC_ADD(priv->write_value, op_ret);
+    GF_ATOMIC_ADD(priv->write_value, ret);
 
 out:
+    SET_RET(op_ret, ret);
     STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, &prebuf, &postbuf,
                         NULL);
 
@@ -389,7 +389,7 @@ posix_aio_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
 
     return 0;
 err:
-    STACK_UNWIND_STRICT(writev, frame, -1, op_errno, 0, 0, 0);
+    STACK_UNWIND_STRICT(writev, frame, gf_error, op_errno, 0, 0, 0);
 
     if (paiocb) {
         if (paiocb->iobref)

--- a/xlators/storage/posix/src/posix-inode-fd-ops.c
+++ b/xlators/storage/posix/src/posix-inode-fd-ops.c
@@ -163,7 +163,8 @@ posix_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     struct iatt buf = {
         0,
     };
-    int32_t op_ret = -1;
+    int op_ret = -1;
+    gf_return_t fin_ret;
     int32_t op_errno = 0;
     struct posix_private *priv = NULL;
     char *real_path = NULL;
@@ -212,7 +213,9 @@ posix_stat(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 
 out:
     SET_TO_OLD_FS_ID();
-    STACK_UNWIND_STRICT(stat, frame, op_ret, op_errno, &buf, xattr_rsp);
+
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(stat, frame, fin_ret, op_errno, &buf, xattr_rsp);
     if (xattr_rsp)
         dict_unref(xattr_rsp);
 
@@ -356,7 +359,8 @@ int
 posix_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
               struct iatt *stbuf, int32_t valid, dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     char *real_path = 0;
     struct iatt statpre = {
@@ -465,7 +469,8 @@ posix_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
 out:
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(setattr, frame, op_ret, op_errno, &statpre, &statpost,
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(setattr, frame, fin_ret, op_errno, &statpre, &statpost,
                         xattr_rsp);
     if (xattr_rsp)
         dict_unref(xattr_rsp);
@@ -569,7 +574,8 @@ int
 posix_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
                struct iatt *stbuf, int32_t valid, dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     struct iatt statpre = {
         0,
@@ -679,7 +685,8 @@ posix_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
 out:
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(fsetattr, frame, op_ret, op_errno, &statpre, &statpost,
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(fsetattr, frame, fin_ret, op_errno, &statpre, &statpost,
                         xattr_rsp);
     if (xattr_rsp)
         dict_unref(xattr_rsp);
@@ -847,7 +854,7 @@ _posix_do_zerofill(int fd, off_t offset, off_t len, int o_direct)
     off_t num_vect = 0;
     off_t num_loop = 1;
     off_t idx = 0;
-    int32_t op_ret = -1;
+    int op_ret = -1;
     int32_t vect_size = VECTOR_SIZE;
     off_t remain = 0;
     off_t extra = 0;
@@ -1072,11 +1079,13 @@ posix_glfallocate(call_frame_t *frame, xlator_t *this, fd_t *fd,
     if (ret < 0)
         goto err;
 
-    STACK_UNWIND_STRICT(fallocate, frame, 0, 0, &statpre, &statpost, rsp_xdata);
+    STACK_UNWIND_STRICT(fallocate, frame, gf_success, 0, &statpre, &statpost,
+                        rsp_xdata);
     return 0;
 
 err:
-    STACK_UNWIND_STRICT(fallocate, frame, -1, -ret, NULL, NULL, rsp_xdata);
+    STACK_UNWIND_STRICT(fallocate, frame, gf_error, -ret, NULL, NULL,
+                        rsp_xdata);
     return 0;
 }
 
@@ -1103,12 +1112,13 @@ posix_discard(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     if (ret < 0)
         goto err;
 
-    STACK_UNWIND_STRICT(discard, frame, 0, 0, &statpre, &statpost, rsp_xdata);
+    STACK_UNWIND_STRICT(discard, frame, gf_success, 0, &statpre, &statpost,
+                        rsp_xdata);
     return 0;
 
 err:
 #endif /* FALLOC_FL_KEEP_SIZE */
-    STACK_UNWIND_STRICT(discard, frame, -1, -ret, NULL, NULL, rsp_xdata);
+    STACK_UNWIND_STRICT(discard, frame, gf_error, -ret, NULL, NULL, rsp_xdata);
     return 0;
 }
 
@@ -1124,6 +1134,7 @@ posix_zerofill(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
         0,
     };
     struct posix_private *priv = NULL;
+    gf_return_t fin_ret;
     int op_ret = -1;
     int op_errno = EINVAL;
     dict_t *rsp_xdata = NULL;
@@ -1149,7 +1160,8 @@ overwrite:
         goto unwind;
     }
 
-    STACK_UNWIND_STRICT(zerofill, frame, 0, 0, &statpre, &statpost, rsp_xdata);
+    STACK_UNWIND_STRICT(zerofill, frame, gf_success, 0, &statpre, &statpost,
+                        rsp_xdata);
     return 0;
 
 out:
@@ -1178,7 +1190,8 @@ out:
     }
 
 unwind:
-    STACK_UNWIND_STRICT(zerofill, frame, op_ret, op_errno, NULL, NULL,
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(zerofill, frame, fin_ret, op_errno, NULL, NULL,
                         rsp_xdata);
     return 0;
 }
@@ -1193,7 +1206,7 @@ posix_ipc(call_frame_t *frame, xlator_t *this, int32_t op, dict_t *xdata)
      */
     gf_msg(this->name, GF_LOG_ERROR, 0, P_MSG_IPC_NOT_HANDLE,
            "GF_LOG_IPC(%d) not handled", op);
-    STACK_UNWIND_STRICT(ipc, frame, -1, EOPNOTSUPP, NULL);
+    STACK_UNWIND_STRICT(ipc, frame, gf_error, EOPNOTSUPP, NULL);
     return 0;
 }
 
@@ -1270,10 +1283,10 @@ posix_seek(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 out:
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(seek, frame, (ret == -1 ? -1 : 0), err,
+    STACK_UNWIND_STRICT(seek, frame, (ret == -1 ? gf_error : gf_success), err,
                         (ret == -1 ? -1 : ret), rsp_xdata);
 #else
-    STACK_UNWIND_STRICT(seek, frame, -1, EINVAL, 0, NULL);
+    STACK_UNWIND_STRICT(seek, frame, gf_error, EINVAL, 0, NULL);
 #endif
     return 0;
 }
@@ -1283,7 +1296,8 @@ posix_opendir(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
               dict_t *xdata)
 {
     char *real_path = NULL;
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = EINVAL;
     DIR *dir = NULL;
     struct posix_fd *pfd = NULL;
@@ -1357,7 +1371,8 @@ out:
     }
 
     SET_TO_OLD_FS_ID();
-    STACK_UNWIND_STRICT(opendir, frame, op_ret, op_errno, fd, NULL);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(opendir, frame, fin_ret, op_errno, fd, NULL);
     return 0;
 }
 
@@ -1410,7 +1425,8 @@ posix_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
                dict_t *xdata)
 {
     char *dest = NULL;
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = EINVAL;
     char *real_path = NULL;
     struct iatt stbuf = {
@@ -1447,7 +1463,8 @@ posix_readlink(call_frame_t *frame, xlator_t *this, loc_t *loc, size_t size,
 out:
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(readlink, frame, op_ret, op_errno, dest, &stbuf, NULL);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(readlink, frame, fin_ret, op_errno, dest, &stbuf, NULL);
 
     return 0;
 }
@@ -1456,7 +1473,8 @@ int32_t
 posix_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
                dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     char *real_path = 0;
     struct posix_private *priv = NULL;
@@ -1526,7 +1544,8 @@ posix_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t offset,
 out:
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(truncate, frame, op_ret, op_errno, &prebuf, &postbuf,
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(truncate, frame, fin_ret, op_errno, &prebuf, &postbuf,
                         NULL);
 
     return 0;
@@ -1536,7 +1555,8 @@ int32_t
 posix_open(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t flags,
            fd_t *fd, dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     char *real_path = NULL;
     int32_t _fd = -1;
@@ -1643,7 +1663,8 @@ out:
 
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(open, frame, op_ret, op_errno, fd, rsp_xdata);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(open, frame, fin_ret, op_errno, fd, rsp_xdata);
 
     return 0;
 }
@@ -1652,7 +1673,8 @@ int
 posix_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
             off_t offset, uint32_t flags, dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     int _fd = -1;
     struct posix_private *priv = NULL;
@@ -1773,8 +1795,9 @@ posix_readv(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
 
 out:
 
-    STACK_UNWIND_STRICT(readv, frame, op_ret, op_errno, &vec, 1, &stbuf, iobref,
-                        rsp_xdata);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(readv, frame, fin_ret, op_errno, &vec, 1, &stbuf,
+                        iobref, rsp_xdata);
 
     if (iobref)
         iobref_unref(iobref);
@@ -1787,7 +1810,7 @@ out:
 int32_t
 __posix_pwritev(int fd, struct iovec *vector, int count, off_t offset)
 {
-    int32_t op_ret = 0;
+    int op_ret = 0;
     int idx = 0;
     int retval = 0;
     off_t internal_off = 0;
@@ -1815,7 +1838,7 @@ int32_t
 __posix_writev(int fd, struct iovec *vector, int count, off_t startoff,
                int odirect)
 {
-    int32_t op_ret = 0;
+    int op_ret = 0;
     int idx = 0;
     int max_buf_size = 0;
     int retval = 0;
@@ -1925,7 +1948,8 @@ posix_writev(call_frame_t *frame, xlator_t *this, fd_t *fd,
              struct iovec *vector, int32_t count, off_t offset, uint32_t flags,
              struct iobref *iobref, dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     int _fd = -1;
     struct posix_private *priv = NULL;
@@ -2136,7 +2160,8 @@ out:
     }
 
 unwind:
-    STACK_UNWIND_STRICT(writev, frame, op_ret, op_errno, &preop, &postop,
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(writev, frame, fin_ret, op_errno, &preop, &postop,
                         rsp_xdata);
 
     if (rsp_xdata)
@@ -2149,7 +2174,8 @@ posix_copy_file_range(call_frame_t *frame, xlator_t *this, fd_t *fd_in,
                       off64_t off_in, fd_t *fd_out, off64_t off_out, size_t len,
                       uint32_t flags, dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     int _fd_in = -1;
     int _fd_out = -1;
@@ -2400,7 +2426,8 @@ out:
         locked = _gf_false;
     }
 
-    STACK_UNWIND_STRICT(copy_file_range, frame, op_ret, op_errno, &stbuf,
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(copy_file_range, frame, fin_ret, op_errno, &stbuf,
                         &preop_dst, &postop_dst, rsp_xdata);
 
     if (rsp_xdata)
@@ -2412,7 +2439,8 @@ int32_t
 posix_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
 {
     char *real_path = NULL;
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     struct statvfs buf = {
         0,
@@ -2488,14 +2516,16 @@ posix_statfs(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *xdata)
     op_ret = 0;
 
 out:
-    STACK_UNWIND_STRICT(statfs, frame, op_ret, op_errno, &buf, NULL);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(statfs, frame, fin_ret, op_errno, &buf, NULL);
     return 0;
 }
 
 int32_t
 posix_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     int ret = -1;
     struct posix_fd *pfd = NULL;
@@ -2514,7 +2544,8 @@ posix_flush(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
     op_ret = 0;
 
 out:
-    STACK_UNWIND_STRICT(flush, frame, op_ret, op_errno, NULL);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(flush, frame, fin_ret, op_errno, NULL);
 
     return 0;
 }
@@ -2559,7 +2590,7 @@ posix_batch_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
 
     stub = fop_fsync_stub(frame, default_fsync, fd, datasync, xdata);
     if (!stub) {
-        STACK_UNWIND_STRICT(fsync, frame, -1, ENOMEM, 0, 0, 0);
+        STACK_UNWIND_STRICT(fsync, frame, gf_error, ENOMEM, 0, 0, 0);
         return 0;
     }
 
@@ -2578,7 +2609,8 @@ int32_t
 posix_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t datasync,
             dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     int _fd = -1;
     struct posix_fd *pfd = NULL;
@@ -2664,7 +2696,8 @@ posix_fsync(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t datasync,
 out:
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(fsync, frame, op_ret, op_errno, &preop, &postop, NULL);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(fsync, frame, fin_ret, op_errno, &preop, &postop, NULL);
 
     return 0;
 }
@@ -2703,7 +2736,8 @@ int32_t
 posix_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
                int flags, dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     char *real_path = NULL;
     char *acl_xattr = NULL;
@@ -3076,7 +3110,8 @@ posix_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc, dict_t *dict,
 out:
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(setxattr, frame, op_ret, op_errno, xattr);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(setxattr, frame, fin_ret, op_errno, xattr);
 
     if (xattr)
         dict_unref(xattr);
@@ -3511,7 +3546,8 @@ posix_getxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                const char *name, dict_t *xdata)
 {
     struct posix_private *priv = NULL;
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     char *value = NULL;
     char *real_path = NULL;
@@ -4017,7 +4053,8 @@ done:
 out:
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(getxattr, frame, op_ret, op_errno, dict, xattr_rsp);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(getxattr, frame, fin_ret, op_errno, dict, xattr_rsp);
 
     if (xattr_rsp)
         dict_unref(xattr_rsp);
@@ -4033,7 +4070,8 @@ int32_t
 posix_fgetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, const char *name,
                 dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = EINVAL;
     struct posix_fd *pfd = NULL;
     int _fd = -1;
@@ -4319,7 +4357,8 @@ done:
 out:
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(fgetxattr, frame, op_ret, op_errno, dict, xattr_rsp);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(fgetxattr, frame, fin_ret, op_errno, dict, xattr_rsp);
 
     if (xattr_rsp)
         dict_unref(xattr_rsp);
@@ -4345,7 +4384,8 @@ int32_t
 posix_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
                 int flags, dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     struct posix_fd *pfd = NULL;
     int _fd = -1;
@@ -4440,7 +4480,8 @@ posix_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *dict,
 out:
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(fsetxattr, frame, op_ret, op_errno, xattr);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(fsetxattr, frame, fin_ret, op_errno, xattr);
 
     if (xattr)
         dict_unref(xattr);
@@ -4451,7 +4492,7 @@ out:
 int
 _posix_remove_xattr(dict_t *dict, char *key, data_t *value, void *data)
 {
-    int32_t op_ret = 0;
+    int op_ret = 0;
     xlator_t *this = NULL;
     posix_xattr_filler_t *filler = NULL;
 
@@ -4651,6 +4692,7 @@ int32_t
 posix_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                   const char *name, dict_t *xdata)
 {
+    gf_return_t fin_ret;
     int op_ret = -1;
     int op_errno = EINVAL;
     dict_t *xdata_rsp = NULL;
@@ -4660,7 +4702,8 @@ posix_removexattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
     op_ret = posix_common_removexattr(frame, loc, NULL, name, xdata, &op_errno,
                                       &xdata_rsp);
 out:
-    STACK_UNWIND_STRICT(removexattr, frame, op_ret, op_errno, xdata_rsp);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(removexattr, frame, fin_ret, op_errno, xdata_rsp);
 
     if (xdata_rsp)
         dict_unref(xdata_rsp);
@@ -4672,7 +4715,8 @@ int32_t
 posix_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
                    const char *name, dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = EINVAL;
     dict_t *xdata_rsp = NULL;
 
@@ -4681,7 +4725,8 @@ posix_fremovexattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
     op_ret = posix_common_removexattr(frame, NULL, fd, name, xdata, &op_errno,
                                       &xdata_rsp);
 out:
-    STACK_UNWIND_STRICT(fremovexattr, frame, op_ret, op_errno, xdata_rsp);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(fremovexattr, frame, fin_ret, op_errno, xdata_rsp);
 
     if (xdata_rsp)
         dict_unref(xdata_rsp);
@@ -4693,7 +4738,8 @@ int32_t
 posix_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
                dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     int ret = -1;
     struct posix_fd *pfd = NULL;
@@ -4712,7 +4758,8 @@ posix_fsyncdir(call_frame_t *frame, xlator_t *this, fd_t *fd, int datasync,
     op_ret = 0;
 
 out:
-    STACK_UNWIND_STRICT(fsyncdir, frame, op_ret, op_errno, NULL);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(fsyncdir, frame, fin_ret, op_errno, NULL);
 
     return 0;
 }
@@ -5042,6 +5089,7 @@ do_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
            gf_xattrop_flags_t optype, dict_t *xattr, dict_t *xdata)
 {
     int op_ret = 0;
+    gf_return_t fin_ret;
     int op_errno = 0;
     int _fd = -1;
     char *real_path = NULL;
@@ -5127,7 +5175,9 @@ do_xattrop(call_frame_t *frame, xlator_t *this, loc_t *loc, fd_t *fd,
     posix_set_mode_in_dict(xdata, xdata_rsp, &stbuf);
 out:
 
-    STACK_UNWIND_STRICT(xattrop, frame, op_ret, op_errno, xattr_rsp, xdata_rsp);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(xattrop, frame, fin_ret, op_errno, xattr_rsp,
+                        xdata_rsp);
 
     if (xattr_rsp)
         dict_unref(xattr_rsp);
@@ -5157,7 +5207,8 @@ int
 posix_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t mask,
              dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     char *real_path = NULL;
 
@@ -5187,7 +5238,8 @@ posix_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int32_t mask,
 out:
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(access, frame, op_ret, op_errno, NULL);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(access, frame, fin_ret, op_errno, NULL);
     return 0;
 }
 
@@ -5195,7 +5247,8 @@ int32_t
 posix_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
                 dict_t *xdata)
 {
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     int _fd = -1;
     struct iatt preop = {
@@ -5272,7 +5325,8 @@ posix_ftruncate(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
 out:
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(ftruncate, frame, op_ret, op_errno, &preop, &postop,
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(ftruncate, frame, fin_ret, op_errno, &preop, &postop,
                         NULL);
 
     return 0;
@@ -5282,7 +5336,8 @@ int32_t
 posix_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 {
     int _fd = -1;
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     struct iatt buf = {
         0,
@@ -5340,7 +5395,8 @@ posix_fstat(call_frame_t *frame, xlator_t *this, fd_t *fd, dict_t *xdata)
 out:
     SET_TO_OLD_FS_ID();
 
-    STACK_UNWIND_STRICT(fstat, frame, op_ret, op_errno, &buf, xattr_rsp);
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(fstat, frame, fin_ret, op_errno, &buf, xattr_rsp);
     if (xattr_rsp)
         dict_unref(xattr_rsp);
     return 0;
@@ -5358,7 +5414,7 @@ posix_lease(call_frame_t *frame, xlator_t *this, loc_t *loc,
            "\"features/leases\" translator is not loaded. You need"
            "to use it for proper functioning of your application");
 
-    STACK_UNWIND_STRICT(lease, frame, -1, ENOSYS, &nullease, NULL);
+    STACK_UNWIND_STRICT(lease, frame, gf_error, ENOSYS, &nullease, NULL);
     return 0;
 }
 
@@ -5377,7 +5433,7 @@ posix_lk(call_frame_t *frame, xlator_t *this, fd_t *fd, int32_t cmd,
                         "not loaded. You need to use it for proper "
                         "functioning of your application.");
 
-    STACK_UNWIND_STRICT(lk, frame, -1, ENOSYS, &nullock, NULL);
+    STACK_UNWIND_STRICT(lk, frame, gf_error, ENOSYS, &nullock, NULL);
     return 0;
 }
 
@@ -5390,7 +5446,7 @@ posix_inodelk(call_frame_t *frame, xlator_t *this, const char *volume,
                         "not loaded. You need to use it for proper "
                         "functioning of your application.");
 
-    STACK_UNWIND_STRICT(inodelk, frame, -1, ENOSYS, NULL);
+    STACK_UNWIND_STRICT(inodelk, frame, gf_error, ENOSYS, NULL);
     return 0;
 }
 
@@ -5403,7 +5459,7 @@ posix_finodelk(call_frame_t *frame, xlator_t *this, const char *volume,
                         "not loaded. You need to use it for proper "
                         "functioning of your application.");
 
-    STACK_UNWIND_STRICT(finodelk, frame, -1, ENOSYS, NULL);
+    STACK_UNWIND_STRICT(finodelk, frame, gf_error, ENOSYS, NULL);
     return 0;
 }
 
@@ -5417,7 +5473,7 @@ posix_entrylk(call_frame_t *frame, xlator_t *this, const char *volume,
                         "not loaded. You need to use it for proper "
                         "functioning of your application.");
 
-    STACK_UNWIND_STRICT(entrylk, frame, -1, ENOSYS, NULL);
+    STACK_UNWIND_STRICT(entrylk, frame, gf_error, ENOSYS, NULL);
     return 0;
 }
 
@@ -5431,7 +5487,7 @@ posix_fentrylk(call_frame_t *frame, xlator_t *this, const char *volume,
                         "not loaded. You need to use it for proper "
                         "functioning of your application.");
 
-    STACK_UNWIND_STRICT(fentrylk, frame, -1, ENOSYS, NULL);
+    STACK_UNWIND_STRICT(fentrylk, frame, gf_error, ENOSYS, NULL);
     return 0;
 }
 
@@ -5713,7 +5769,8 @@ posix_do_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     DIR *dir = NULL;
     int ret = -1;
     int count = 0;
-    int32_t op_ret = -1;
+    gf_return_t fin_ret;
+    int op_ret = -1;
     int32_t op_errno = 0;
     gf_dirent_t entries;
     int32_t skip_dirs = 0;
@@ -5773,10 +5830,12 @@ posix_do_readdir(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
     posix_readdirp_fill(this, fd, &entries, dict);
 
 out:
+
+    SET_RET(fin_ret, op_ret);
     if (whichop == GF_FOP_READDIR)
-        STACK_UNWIND_STRICT(readdir, frame, op_ret, op_errno, &entries, NULL);
+        STACK_UNWIND_STRICT(readdir, frame, fin_ret, op_errno, &entries, NULL);
     else
-        STACK_UNWIND_STRICT(readdirp, frame, op_ret, op_errno, &entries, NULL);
+        STACK_UNWIND_STRICT(readdirp, frame, fin_ret, op_errno, &entries, NULL);
 
     gf_dirent_free(&entries);
 
@@ -5795,8 +5854,9 @@ int32_t
 posix_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
                off_t off, dict_t *dict)
 {
+    gf_return_t fin_ret;
     gf_dirent_t entries;
-    int32_t op_ret = -1, op_errno = 0;
+    int op_ret = -1, op_errno = 0;
     gf_dirent_t *entry = NULL;
 
     if ((dict != NULL) && (dict_get(dict, GET_ANCESTRY_DENTRY_KEY))) {
@@ -5810,7 +5870,8 @@ posix_readdirp(call_frame_t *frame, xlator_t *this, fd_t *fd, size_t size,
             list_for_each_entry(entry, &entries.list, list) { op_ret++; }
         }
 
-        STACK_UNWIND_STRICT(readdirp, frame, op_ret, op_errno, &entries, NULL);
+        SET_RET(fin_ret, op_ret);
+        STACK_UNWIND_STRICT(readdirp, frame, fin_ret, op_errno, &entries, NULL);
 
         gf_dirent_free(&entries);
         return 0;
@@ -5828,6 +5889,7 @@ posix_rchecksum(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     char *buf = NULL;
     int _fd = -1;
     struct posix_fd *pfd = NULL;
+    gf_return_t fin_ret;
     int op_ret = -1;
     int op_errno = 0;
     int ret = 0;
@@ -5947,7 +6009,8 @@ posix_rchecksum(call_frame_t *frame, xlator_t *this, fd_t *fd, off_t offset,
     posix_set_ctime(frame, this, NULL, _fd, fd->inode, NULL);
 
 out:
-    STACK_UNWIND_STRICT(rchecksum, frame, op_ret, op_errno, weak_checksum,
+    SET_RET(fin_ret, op_ret);
+    STACK_UNWIND_STRICT(rchecksum, frame, fin_ret, op_errno, weak_checksum,
                         checksum, rsp_xdata);
     if (rsp_xdata)
         dict_unref(rsp_xdata);

--- a/xlators/system/posix-acl/src/posix-acl.c
+++ b/xlators/system/posix-acl/src/posix-acl.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 
 #include <glusterfs/defaults.h>
+#include <glusterfs/globals.h>
 
 #include "posix-acl.h"
 #include "posix-acl-xattr.h"
@@ -939,8 +940,8 @@ out:
 
 int
 posix_acl_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, inode_t *inode, struct iatt *buf,
-                     dict_t *xattr, struct iatt *postparent)
+                     gf_return_t op_ret, int op_errno, inode_t *inode,
+                     struct iatt *buf, dict_t *xattr, struct iatt *postparent)
 {
     struct posix_acl *acl_access = NULL;
     struct posix_acl *acl_default = NULL;
@@ -951,12 +952,12 @@ posix_acl_lookup_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     int ret = 0;
     dict_t *my_xattr = NULL;
 
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     ctx = posix_acl_ctx_new(inode, this);
     if (!ctx) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = ENOMEM;
         goto unwind;
     }
@@ -1051,8 +1052,11 @@ green:
     STACK_WIND(frame, posix_acl_lookup_cbk, FIRST_CHILD(this),
                FIRST_CHILD(this)->fops->lookup, loc, my_xattr);
     return 0;
+
 red:
-    STACK_UNWIND_STRICT(lookup, frame, -1, EACCES, NULL, NULL, NULL, NULL);
+
+    STACK_UNWIND_STRICT(lookup, frame, gf_error, EACCES, NULL, NULL, NULL,
+                        NULL);
 
     return 0;
 }
@@ -1061,7 +1065,7 @@ int
 posix_acl_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int mask,
                  dict_t *xdata)
 {
-    int op_ret = 0;
+    gf_return_t op_ret = {0};
     int op_errno = 0;
     int perm = 0;
     int mode = 0;
@@ -1079,7 +1083,7 @@ posix_acl_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int mask,
         goto unwind;
     }
     if (!perm) {
-        op_ret = -1;
+        op_ret = gf_error;
         op_errno = EINVAL;
         goto unwind;
     }
@@ -1087,10 +1091,10 @@ posix_acl_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int mask,
     if (is_fuse_call) {
         mode = acl_permits(frame, loc->inode, perm);
         if (mode) {
-            op_ret = 0;
+            op_ret = gf_success;
             op_errno = 0;
         } else {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = EACCES;
         }
     } else {
@@ -1111,10 +1115,12 @@ posix_acl_access(call_frame_t *frame, xlator_t *this, loc_t *loc, int mask,
     }
 
 unwind:
-    if (is_fuse_call)
+    if (is_fuse_call) {
         STACK_UNWIND_STRICT(access, frame, op_ret, op_errno, NULL);
-    else
-        STACK_UNWIND_STRICT(access, frame, 0, mode, NULL);
+    } else {
+        op_ret = gf_success;
+        STACK_UNWIND_STRICT(access, frame, op_ret, mode, NULL);
+    }
     return 0;
 }
 
@@ -1137,7 +1143,7 @@ posix_acl_truncate(call_frame_t *frame, xlator_t *this, loc_t *loc, off_t off,
     }
 
     /* fail by default */
-    STACK_UNWIND_STRICT(truncate, frame, -1, EACCES, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(truncate, frame, gf_error, EACCES, NULL, NULL, NULL);
     return 0;
 
 green:
@@ -1183,7 +1189,7 @@ green:
                FIRST_CHILD(this)->fops->open, loc, flags, fd, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(open, frame, -1, EACCES, NULL, NULL);
+    STACK_UNWIND_STRICT(open, frame, gf_error, EACCES, NULL, NULL);
     return 0;
 }
 
@@ -1204,7 +1210,8 @@ green:
                FIRST_CHILD(this)->fops->readv, fd, size, offset, flags, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(readv, frame, -1, EACCES, NULL, 0, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(readv, frame, gf_error, EACCES, NULL, 0, NULL, NULL,
+                        NULL);
     return 0;
 }
 
@@ -1227,7 +1234,7 @@ green:
                flags, iobref, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(writev, frame, -1, EACCES, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(writev, frame, gf_error, EACCES, NULL, NULL, NULL);
     return 0;
 }
 
@@ -1248,7 +1255,7 @@ green:
                FIRST_CHILD(this)->fops->ftruncate, fd, offset, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(ftruncate, frame, -1, EACCES, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(ftruncate, frame, gf_error, EACCES, NULL, NULL, NULL);
     return 0;
 }
 
@@ -1265,17 +1272,17 @@ green:
                FIRST_CHILD(this)->fops->opendir, loc, fd, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(opendir, frame, -1, EACCES, NULL, NULL);
+    STACK_UNWIND_STRICT(opendir, frame, gf_error, EACCES, NULL, NULL);
     return 0;
 }
 
 int
 posix_acl_mkdir_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, inode_t *inode, struct iatt *buf,
-                    struct iatt *preparent, struct iatt *postparent,
-                    dict_t *xdata)
+                    gf_return_t op_ret, int op_errno, inode_t *inode,
+                    struct iatt *buf, struct iatt *preparent,
+                    struct iatt *postparent, dict_t *xdata)
 {
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     posix_acl_ctx_update(inode, this, buf, GF_FOP_MKDIR);
@@ -1304,17 +1311,18 @@ green:
                FIRST_CHILD(this)->fops->mkdir, loc, newmode, umask, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(mkdir, frame, -1, EACCES, NULL, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(mkdir, frame, gf_error, EACCES, NULL, NULL, NULL, NULL,
+                        NULL);
     return 0;
 }
 
 int
 posix_acl_mknod_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                    int op_ret, int op_errno, inode_t *inode, struct iatt *buf,
-                    struct iatt *preparent, struct iatt *postparent,
-                    dict_t *xdata)
+                    gf_return_t op_ret, int op_errno, inode_t *inode,
+                    struct iatt *buf, struct iatt *preparent,
+                    struct iatt *postparent, dict_t *xdata)
 {
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     posix_acl_ctx_update(inode, this, buf, GF_FOP_MKNOD);
@@ -1344,17 +1352,18 @@ green:
                xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(mknod, frame, -1, EACCES, NULL, NULL, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(mknod, frame, gf_error, EACCES, NULL, NULL, NULL, NULL,
+                        NULL);
     return 0;
 }
 
 int
 posix_acl_create_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                     int op_ret, int op_errno, fd_t *fd, inode_t *inode,
+                     gf_return_t op_ret, int op_errno, fd_t *fd, inode_t *inode,
                      struct iatt *buf, struct iatt *preparent,
                      struct iatt *postparent, dict_t *xdata)
 {
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     posix_acl_ctx_update(inode, this, buf, GF_FOP_CREATE);
@@ -1384,18 +1393,18 @@ green:
                xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(create, frame, -1, EACCES, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(create, frame, gf_error, EACCES, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 
 int
 posix_acl_symlink_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, inode_t *inode,
+                      gf_return_t op_ret, int op_errno, inode_t *inode,
                       struct iatt *buf, struct iatt *preparent,
                       struct iatt *postparent, dict_t *xdata)
 {
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     posix_acl_ctx_update(inode, this, buf, GF_FOP_SYMLINK);
@@ -1419,8 +1428,8 @@ green:
                FIRST_CHILD(this)->fops->symlink, linkname, loc, umask, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(symlink, frame, -1, EACCES, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(symlink, frame, gf_error, EACCES, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 
@@ -1440,7 +1449,7 @@ green:
                FIRST_CHILD(this)->fops->unlink, loc, xflag, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(unlink, frame, -1, EACCES, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(unlink, frame, gf_error, EACCES, NULL, NULL, NULL);
     return 0;
 }
 
@@ -1460,7 +1469,7 @@ green:
                FIRST_CHILD(this)->fops->rmdir, loc, flags, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(rmdir, frame, -1, EACCES, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(rmdir, frame, gf_error, EACCES, NULL, NULL, NULL);
     return 0;
 }
 
@@ -1486,8 +1495,8 @@ posix_acl_rename(call_frame_t *frame, xlator_t *this, loc_t *old, loc_t *new,
                FIRST_CHILD(this)->fops->rename, old, new, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(rename, frame, -1, EACCES, NULL, NULL, NULL, NULL, NULL,
-                        NULL);
+    STACK_UNWIND_STRICT(rename, frame, gf_error, EACCES, NULL, NULL, NULL, NULL,
+                        NULL, NULL);
     return 0;
 }
 
@@ -1518,7 +1527,7 @@ posix_acl_link(call_frame_t *frame, xlator_t *this, loc_t *old, loc_t *new,
                FIRST_CHILD(this)->fops->link, old, new, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(link, frame, -1, op_errno, NULL, NULL, NULL, NULL,
+    STACK_UNWIND_STRICT(link, frame, gf_error, op_errno, NULL, NULL, NULL, NULL,
                         NULL);
 
     return 0;
@@ -1537,14 +1546,14 @@ green:
                FIRST_CHILD(this)->fops->readdir, fd, size, offset, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(readdir, frame, -1, EACCES, NULL, NULL);
+    STACK_UNWIND_STRICT(readdir, frame, gf_error, EACCES, NULL, NULL);
 
     return 0;
 }
 
 int
 posix_acl_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, gf_dirent_t *entries,
+                       gf_return_t op_ret, int op_errno, gf_dirent_t *entries,
                        dict_t *xdata)
 {
     gf_dirent_t *entry = NULL;
@@ -1554,7 +1563,7 @@ posix_acl_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     data_t *data = NULL;
     int ret = 0;
 
-    if (op_ret <= 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     list_for_each_entry(entry, &entries->list, list)
@@ -1565,7 +1574,7 @@ posix_acl_readdirp_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
 
         ctx = posix_acl_ctx_new(entry->inode, this);
         if (!ctx) {
-            op_ret = -1;
+            op_ret = gf_error;
             op_errno = ENOMEM;
             goto unwind;
         }
@@ -1652,7 +1661,7 @@ green:
         dict_unref(alloc_dict);
     return 0;
 red:
-    STACK_UNWIND_STRICT(readdirp, frame, -1, EACCES, NULL, NULL);
+    STACK_UNWIND_STRICT(readdirp, frame, gf_error, EACCES, NULL, NULL);
 
     return 0;
 }
@@ -1718,7 +1727,7 @@ setattr_scrutiny(call_frame_t *frame, inode_t *inode, struct iatt *buf,
 
 int
 posix_acl_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                      int op_ret, int op_errno, struct iatt *prebuf,
+                      gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                       struct iatt *postbuf, dict_t *xdata)
 {
     inode_t *inode = NULL;
@@ -1726,7 +1735,7 @@ posix_acl_setattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     inode = frame->local;
     frame->local = NULL;
 
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     posix_acl_ctx_update(inode, this, postbuf, GF_FOP_SETATTR);
@@ -1754,14 +1763,14 @@ posix_acl_setattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                FIRST_CHILD(this)->fops->setattr, loc, buf, valid, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(setattr, frame, -1, op_errno, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(setattr, frame, gf_error, op_errno, NULL, NULL, NULL);
 
     return 0;
 }
 
 int
 posix_acl_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, struct iatt *prebuf,
+                       gf_return_t op_ret, int op_errno, struct iatt *prebuf,
                        struct iatt *postbuf, dict_t *xdata)
 {
     inode_t *inode = NULL;
@@ -1769,7 +1778,7 @@ posix_acl_fsetattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
     inode = frame->local;
     frame->local = NULL;
 
-    if (op_ret != 0)
+    if (IS_ERROR(op_ret))
         goto unwind;
 
     posix_acl_ctx_update(inode, this, postbuf, GF_FOP_FSETATTR);
@@ -1797,7 +1806,7 @@ posix_acl_fsetattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
                FIRST_CHILD(this)->fops->fsetattr, fd, buf, valid, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(fsetattr, frame, -1, EACCES, NULL, NULL, NULL);
+    STACK_UNWIND_STRICT(fsetattr, frame, gf_error, EACCES, NULL, NULL, NULL);
 
     return 0;
 }
@@ -1946,7 +1955,7 @@ out:
 }
 int
 posix_acl_setxattr_cbk(call_frame_t *frame, void *cookie, xlator_t *this,
-                       int op_ret, int op_errno, dict_t *xdata)
+                       gf_return_t op_ret, int op_errno, dict_t *xdata)
 {
     /*
      * Update the context of posix_acl_translator, if any of
@@ -1983,7 +1992,7 @@ posix_acl_setxattr(call_frame_t *frame, xlator_t *this, loc_t *loc,
                       xattr, flags, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(setxattr, frame, -1, op_errno, NULL);
+    STACK_UNWIND_STRICT(setxattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
@@ -2007,7 +2016,7 @@ posix_acl_fsetxattr(call_frame_t *frame, xlator_t *this, fd_t *fd,
                FIRST_CHILD(this)->fops->fsetxattr, fd, xattr, flags, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(fsetxattr, frame, -1, op_errno, NULL);
+    STACK_UNWIND_STRICT(fsetxattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }
@@ -2030,7 +2039,7 @@ green:
     return 0;
 
 red:
-    STACK_UNWIND_STRICT(getxattr, frame, -1, EACCES, NULL, NULL);
+    STACK_UNWIND_STRICT(getxattr, frame, gf_error, EACCES, NULL, NULL);
 
     return 0;
 }
@@ -2051,7 +2060,7 @@ green:
                FIRST_CHILD(this)->fops->fgetxattr, fd, name, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(fgetxattr, frame, -1, EACCES, NULL, NULL);
+    STACK_UNWIND_STRICT(fgetxattr, frame, gf_error, EACCES, NULL, NULL);
 
     return 0;
 }
@@ -2088,7 +2097,7 @@ green:
                FIRST_CHILD(this)->fops->removexattr, loc, name, xdata);
     return 0;
 red:
-    STACK_UNWIND_STRICT(removexattr, frame, -1, op_errno, NULL);
+    STACK_UNWIND_STRICT(removexattr, frame, gf_error, op_errno, NULL);
 
     return 0;
 }


### PR DESCRIPTION
* return signature of all 'fops' callback changed to `gf_return_t`.

* provide IS_ERROR()/IS_SUCCESS() macros to check only this type of argument.

* provide 2 global variables `gf_success` and `gf_error` introduced, which
  can used instead of -1 and 0 return used largely today.

Change-Id: Ib91216afaa89d7e4509757b50dd8a7d60a6bf0a9
Updates: #280
Signed-off-by: Amar Tumballi <amar@kadalu.io>

